### PR TITLE
Checking for return codes alleviates the ability to emit -1 values fo…

### DIFF
--- a/src/report.c
+++ b/src/report.c
@@ -2439,7 +2439,7 @@ doEvent()
 void
 doPayload()
 {
-    bool lsbin = TRUE;
+    bool lsbin = FALSE;
     bool filebin = TRUE;
     uint64_t data;
 

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -674,19 +674,24 @@ reportPeriodicStuff(void)
 
     // We report CPU time for this period.
     cpu = doGetProcCPU();
-    doProcMetric(PROC_CPU, cpu - cpuState);
-    cpuState = cpu;
+    if (cpu != -1) {
+        doProcMetric(PROC_CPU, cpu - cpuState);
+        cpuState = cpu;
+    }
 
     mem = osGetProcMemory(g_proc.pid);
-    doProcMetric(PROC_MEM, mem);
+    if (mem != -1) doProcMetric(PROC_MEM, mem);
 
     nthread = osGetNumThreads(g_proc.pid);
-    doProcMetric(PROC_THREAD, nthread);
+    if (nthread != -1) doProcMetric(PROC_THREAD, nthread);
 
     nfds = osGetNumFds(g_proc.pid);
-    doProcMetric(PROC_FD, nfds);
+    if (nfds != -1) doProcMetric(PROC_FD, nfds);
 
     children = osGetNumChildProcs(g_proc.pid);
+    if (children < 0) {
+        children = 0;
+    }
     doProcMetric(PROC_CHILD, children);
 
     // report totals (not by file descriptor/socket descriptor)


### PR DESCRIPTION
…r system/proc metrics.

closes #15 