### PR TITLE
Docs messaging & cleanup

### DIFF
--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -41,7 +41,11 @@ Flags:
 Use "scope [command] --help" for more information about a command.
 ```
 
-As noted just above, to see a specific command's help or its required parameters, enter `./scope <command> -h` or `./scope help <command> [flags]`.
+As noted just above, to see a specific command's help or its required parameters, enter: 
+`./scope <command> -h` 
+
+…or: 
+`./scope help <command> [flags]`.
 
 ### dash
 ---
@@ -65,7 +69,7 @@ Displays an interactive dashboard with an overview of what's happening with the 
 
 ### events
 ---
-Outputs events for a session. You can obtain detailed information about each event by inputting the Event ID as a positional parameter. (By default, the Event ID appears in blue in []'s at the left.) You can provide filters to narrow down by name (e.g., `http`, `net`, `fs`, or `console`) or by field (e.g., `fs.open`, `stdout`, or `net.conn.open`). You can use JavaScript expressions to further refine the query and express logic.
+Outputs events for a session. You can obtain detailed information about each event by inputting the Event ID as a positional parameter. (By default, the Event ID appears in blue, in `[]`'s at the left.) You can provide filters to narrow down by name (e.g., `http`, `net`, `fs`, or `console`), or by field (e.g., `fs.open`, `stdout`, or `net.conn.open`). You can use JavaScript expressions to further refine the query, and to express logic.
 
 #### Usage
 
@@ -101,7 +105,7 @@ scope events -n 1000 -e 'sourcetype!="console" && source.indexOf("cribl.log") ==
 
 ### extract
 ---
-Outputs `ldscope`, `libscope.so`, `scope.yml`, and `scope_protocol.yml` to the provided directory. These files can configured to instrument any application, and to output the data to any existing tool using simple TCP protocols. Libscope can easily be used with any dynamic or static application, regardless of the runtime.
+Outputs `ldscope`, `libscope.so`, `scope.yml`, and `scope_protocol.yml` to the provided directory. You can configure these files to instrument any application, and to output the data to any existing tool via simple TCP protocols. The `libscope` component can easily be used with any dynamic or static application, regardless of the runtime.
 
 #### Usage
   `scope extract (<dir>) [flags]`
@@ -250,7 +254,7 @@ scope version --summary
 ### --verbose
 ----
 
-This flag sets the verbosity level. `0` is least verbose, `4` is the default, and `9` is most verbose. For descriptions of individual levels, see [Appendix: Default Configuration](/docs/config-files).
+This flag sets the verbosity level. `0` is least verbose, `4` is the default, and `9` is most verbose. For descriptions of individual levels, see [Config Files](/docs/config-files).
 
 #### Usage
 

--- a/website/src/pages/docs/community.md
+++ b/website/src/pages/docs/community.md
@@ -10,4 +10,4 @@ To connect with other AppScope users and developers, [join](https://cribl.io/com
 
 ## How to Contribute
 
-Fork our [repo on GitHub](https://github.com/criblio/appscope.git)(https://github.com/criblio/appscope.git).
+Fork our [repo on GitHub](https://github.com/criblio/appscope.git).

--- a/website/src/pages/docs/how-works.md
+++ b/website/src/pages/docs/how-works.md
@@ -9,30 +9,29 @@ AppScope is a single binary download that consists of three components:
 
 ### The Command Line Interface (CLI)
 
-The AppScope CLI (`scope`) provides a quick and convenient way to explore capabilities and to obtain insight into application behavior. No installation or configuration is required to get started exploring application 
-behavior.
+The AppScope CLI (`scope`) provides a quick and convenient way to explore capabilities, and to obtain insight into application behavior. No installation or configuration is required to get started exploring application behavior.
 
-<span>&#x2605;&#x2605;&#x2605;</span> **WHEN TO USE**: The easiest way to get started with AppScope is to use the CLI. This provides a rich set of capabilities intended to capture data from single applications. Data is captured in the local file system and is managed through the CLI.
+<span>&#x2605;&#x2605;&#x2605;</span> **WHEN TO USE**: The easiest way to get started with AppScope is to use the CLI. This provides a rich set of capabilities intended to capture data from single applications. Data is captured in the local file system, and is managed through the CLI.
 
 
 ### The Loader
 
-Linux, like many other operating systems, provides a loader capable of loading and linking dynamic and static executables as needed. AppScope [provides](/docs/loader-library) a very simple component (`ldscope`) that supports loading static executables. This allows AppScope to interpose functions, and to thereby expose the same data that is exposed from dynamic executables. While the AppScope loader is optional for use with dynamic executables, it is required in order when used to extract details from a static executable.
+Linux, like many other operating systems, provides a loader capable of loading and linking dynamic and static executables as needed. AppScope [provides](/docs/loader-library) a very simple component (`ldscope`) that supports loading static executables. This allows AppScope to interpose functions, and to thereby expose the same data that is exposed from dynamic executables. While the AppScope loader is optional for use with dynamic executables, it is required in order to extract details from a static executable.
 
-<span>&#x2605;&#x2605;&#x2605;</span> **WHEN TO USE**: As you get more interested in obtaining details from  applications, explore using the AppScope library apart from the CLI. This allows for full configurability via the `scope.yml` configuration file available [here](/docs/config-files). You can forward captured data details over UDP, TCP, and local or remote connections, and you can define specific events and metrics for export. You can use the AppScope loader to start applications that include the library.
+<span>&#x2605;&#x2605;&#x2605;</span> **WHEN TO USE**: As you get more interested in obtaining details from  applications, explore using the AppScope library apart from the CLI. This allows for full configurability via the `scope.yml` configuration file, detailed [here](/docs/config-files). You can forward captured data details over UDP, TCP, and local or remote connections, and you can define specific events and metrics for export. You can use the AppScope loader to start applications that include the library.
 
 ### The Library
 
 The AppScope library (`libscope`) is the [core component](/docs/loader-library) that resides in application processes, extracting data as an application executes. You can closely configure the library's behavior using environment variables or a configuration file. 
 
-The library extracts information by interposing functions. When an application calls a function, it actually calls a function of the same name in the `libscope` which extracts details from the function, and the original function call proceeds. This interposition of function calls requires no change to an application: it works with unmodified binaries, and its CPU and memory overhead are minimal.
+The library extracts information by interposing functions. When an application calls a function, it actually calls a function of the same name in `libscope`, which extracts details from the function. Then the original function call proceeds. This interposition of function calls requires no change to an application: it works with unmodified binaries, and its CPU and memory overhead is minimal.
 
-The library is loaded using a number of mechanisms, depending on the type of executable. A dynamic loader can preload the library (where supported) and AppScope is used to load static executables.
+The library is loaded using a number of mechanisms, depending on the type of executable. A dynamic loader can preload the library (where supported), and AppScope is used to load static executables.
 
 Child processes are created with the library present, if the library was present in the parent. In this manner, a single executable is able to start, daemonize, and create any number of children, all of which include interposed functions.
 
 
-<span>&#x2605;&#x2605;&#x2605;</span> **WHEN TO USE**: Similar to the loader above you can use the library independently using the same configuration [file](/docs/config-files) and/or environment variables. Environment variables take precedence over the default configuration, as well as over details in any configuration file. You use an environment variable to load the library independent of any executable. Whether you use this option or the AppScope loader, you get full control of the data source, formats, and transports.
+<span>&#x2605;&#x2605;&#x2605;</span> **WHEN TO USE**: As with the loader above, you can use the library independently, using the same configuration [file](/docs/config-files) and/or environment variables. Environment variables take precedence over the default configuration, as well as over details in any configuration file. You use an environment variable to load the library independent of any executable. Whether you use this option or the AppScope loader, you get full control of the data source, formats, and transports.
 
 
 ## System-Level Design 
@@ -41,4 +40,4 @@ Child processes are created with the library present, if the library was present
 
 
 ### Performance Overhead
-AppScope collects data with around 2% CPU overhead and **minimal** latency penalty. In most cases, the overhead is markedly less than ~2% which is significantly more efficient than legacy and current monitoring systems.
+AppScope collects data with around 2% CPU overhead and **minimal** latency penalty. In most cases, the overhead is markedly less than 2%, which is significantly more efficient than legacy and current monitoring systems.

--- a/website/src/pages/docs/installing.md
+++ b/website/src/pages/docs/installing.md
@@ -5,11 +5,11 @@ title: Installing
 ## Installing
 ---
 
-First, see [Requirements](/docs/requirements) to ensure that you’re completing these steps on a supported system. Getting started is easy.
+First, see [Requirements](/docs/requirements) to ensure that you’re completing these steps on a supported system. Next, getting started is easy.
 
 ### Get AppScope
 
-Directly download the CLI binary from [https://cdn.cribl.io/dl/scope/cli/linux/scope](https://s3-us-west-2.amazonaws.com/io.cribl.cdn/dl/scope/cli/linux/scope). Use this command to both download and make it executable:
+Directly download the CLI binary from [https://cdn.cribl.io/dl/scope/cli/linux/scope](https://s3-us-west-2.amazonaws.com/io.cribl.cdn/dl/scope/cli/linux/scope). Use this command to both download it and make it executable:
 
 
 ```

--- a/website/src/pages/docs/library-using.md
+++ b/website/src/pages/docs/library-using.md
@@ -15,9 +15,9 @@ Start with this basic example:
 LD_PRELOAD=./libscope.so ps -ef
 ```
 
-This executes the command `ps -ef`. But first, the OS' loader loads the AppScope library as part of loading and linking the ps executable.
+This executes the command `ps -ef`. But first, the OS' loader loads the AppScope library, as part of loading and linking the `ps` executable.
 
-Details of the ps application's execution are emitted to the configured transport, in the configured format. For configuration details, see the **Configuring the Library** section below.
+Details of the `ps` application's execution are emitted to the configured transport, in the configured format. For configuration details, see [Configuring the Library](#configuring) below.
 
 ### LD_PRELOAD Environment Variable – Extended Examples
 
@@ -29,7 +29,7 @@ These examples demonstrate using `LD_PRELOAD` with additional variables.
 LD_PRELOAD=./libscope.so SCOPE_METRIC_VERBOSITY=5 ps -ef
 ```
 
-This again executes the `ps` command using the AppScope library. But it also defines the verbosity for metric extraction as level 5. (This verbosity setting overrides any config-file setting, as well as the default value.)
+This again executes the `ps` command using the AppScope library. But it also defines the verbosity for metric extraction as level `5`. (This verbosity setting overrides any config-file setting, as well as the default value.)
 
 #### Example 2:
 
@@ -45,9 +45,9 @@ This again executes the `ps` command using the AppScope library. But it also dir
 LD_PRELOAD=./libscope.so SCOPE_EVENT_DEST=tcp://localhost:9999 ps -ef
 ```
 
-This again executes the `ps` command using the AppScope library. But here, we also specify that events (as opposed to metrics) will be sent over a TCP connection to localhost, using port 9999. (This event destination setting overrides any config-file setting, as well as the default value.)
+This again executes the `ps` command using the AppScope library. But here, we also specify that events (as opposed to metrics) will be sent over a TCP connection to localhost, using port `9999`. (This event destination setting overrides any config-file setting, as well as the default value.)
 
 
-### Configuring the Library
+### <span id="configuring">Configuring the Library</span>
 
-For details on configuring the library, see AppScope online help's CONFIGURATION section. For the default settings in the sample `scope.yml` configuration file, see the [Config Files](/docs/config-files), or see the most-recent file on [GitHub](https://github.com/criblio/appscope/blob/master/conf/scope.yml).
+For details on configuring the library, see AppScope online help's CONFIGURATION section. For the default settings in the sample `scope.yml` configuration file, see [Config Files](/docs/config-files), or inspect the most-recent file on [GitHub](https://github.com/criblio/appscope/blob/master/conf/scope.yml).

--- a/website/src/pages/docs/loader-library.md
+++ b/website/src/pages/docs/loader-library.md
@@ -4,7 +4,7 @@ title: Extracting the Library
 
 ## The Loader, Library and .yml Files
 ---
-As mentioned in [How AppScope Works](/docs/how-works), the single binary contains a **Loader** and a **Library** component that can be used independently of the CLI. In order to use them, they must first be extracted using the `extract` sub-command. This will output `ldscope`, `libscope.so`, `scope.yml` and `scope_protocol.yml` in a directory of choice. These files can be later configured to instrument any application and output the data to any existing tool using simple TCP protocols. 
+As covered in [How AppScope Works](/docs/how-works), the single binary contains **Loader** and **Library** components that can be used independently of the CLI. In order to use these components, you must first extract them using the `extract` sub-command. This will output the `ldscope`, `libscope.so`, `scope.yml`, and `scope_protocol.yml` into a directory that you specify. You can later configure these files to instrument any application, and to output the data to any existing tool via simple TCP protocols. 
 
 
 
@@ -30,4 +30,4 @@ drwxr-xr-x 1 root root    4096 Jan 31 22:32 ../
 
 ### Next Steps
 
-Let's go to [Using the Library](/docs/library-using).
+Let's go on to [Using the Library](/docs/library-using).

--- a/website/src/pages/docs/overview.md
+++ b/website/src/pages/docs/overview.md
@@ -5,11 +5,11 @@ title: Overview
 ## What Is AppScope
 ---
 
-AppScope is an open source instrumentation utility for any Linux command or application, regardless of programming language. It helps users explore, understand, and gain visibility with **NO code modification**. 
+AppScope is an open source, runtime-agnostic instrumentation utility for any Linux command or application. It helps users explore, understand, and gain visibility with **no code modification**. 
 
-It provides fine-grained observability of a proxy/service mesh, without the latency of a sidecar and emits APM-like metric and event data, in open formats, to existing log and metric tools.
+AppScope provides the fine-grained observability of a proxy/service mesh, without the latency of a sidecar. It emits APM-like metric and event data, in open formats, to existing log and metric tools.
 
-It’s like [strace](https://strace.io/) meets [tcpdump](https://www.tcpdump.org/), but with consumable output for events like file access, DNS, and network activity and StatsD-style metrics for applications. It can also look inside encrypted payloads for WAF-like visibility without proxying traffic. 
+It’s like [strace](https://strace.io/) meets [tcpdump](https://www.tcpdump.org/) – but with consumable output for events like file access, DNS, and network activity, and StatsD-style metrics for applications. AppScope can also look inside encrypted payloads, offering WAF-like visibility without proxying traffic. 
 </br>
 </br>
 
@@ -23,6 +23,6 @@ It’s like [strace](https://strace.io/) meets [tcpdump](https://www.tcpdump.org
 - Runtime-agnostic, no dependencies, no code development required, including static executables
 - Capture application metrics: **File, Network, Memory, CPU**
 - Capture application events: console content, stdin/out, logs, errors
-- Capture any and all payloads: DNS, HTTP, and HTTPS
-- Summarize metrics & detect protocols
-- Normalize and forward metrics and events, in real-time to remote systems.
+- Capture any and all payloads: DNS, HTTP, HTTPS
+- Summarize metrics and detect protocols
+- Normalize and forward metrics and events, in real time, to remote systems.

--- a/website/src/pages/docs/requirements.md
+++ b/website/src/pages/docs/requirements.md
@@ -7,7 +7,7 @@ title: Requirements
 
 Requirements for AppScope are as follows:
 
-### Operating Systems (Linux only)
+### Operating Systems (Linux Only)
 
 Supported:
 

--- a/website/src/pages/docs/uninstalling.md
+++ b/website/src/pages/docs/uninstalling.md
@@ -11,7 +11,7 @@ You can uninstall AppScope by simply deleting the binary:
 rm -rf scope
 ```
 
-… and the associated history directory:
+…and the associated history directory:
 
 ```
 cd ~

--- a/website/src/pages/docs/what-do-with-scope.md
+++ b/website/src/pages/docs/what-do-with-scope.md
@@ -7,20 +7,20 @@ title: Cool, but What Can I do with It?
 
 AppScope offers APM-like, black-box instrumentation of any unmodified Linux executable and application. You can use AppScope in single-user troubleshooting, or in a distributed production deployment, with little extra tooling infrastructure. Especially when paired with Cribl LogStream, AppScope can deliver just the data you need to your existing tools.
 
-### Instrument, collect and observe
+### Instrument, Collect and Observe
 
 - Metrics about process and application performance.
-- Logs emitted from an application - with zero configuration - delivered to log files or to the console.
-- Network flow logs, metrics and all DNS requests.
+- Logs emitted from an application – with zero configuration – delivered to log files or to the console.
+- Network flow logs, metrics, and all DNS requests.
 - File open and close operations, with I/O consumption per file.
 - HTTP requests to and from an application, including URI endpoint, HTTP header, and full payload visibility.
 - HTTPS too :)
 
-AppScope works with static or dynamic binaries and can instrument anything running in Linux. The CLI makes it easy to inspect any application without needing a man-in-the-middle proxy. If you're feeling adventurous, you can use the AppScope library independently of the CLI, with even more fine-grained configuration options.
+AppScope works with static or dynamic binaries, and can instrument anything running in Linux. The CLI makes it easy to inspect any application without needing a man-in-the-middle proxy. Once you've gained familiarity, you can use the AppScope library independently of the CLI, with even more fine-grained configuration options.
 
-AppScope collects and forwards StatsD-style metrics about running applications and with HTTP-level visibility, any web server or application can be instantly observable. Its output allow you to use general-purpose tools instead of specialized APM tools and agents.
+AppScope collects and forwards StatsD-style metrics about running applications. With HTTP-level visibility, any web server or application can be instantly observable. AppScope's output allows you to use general-purpose tools instead of specialized APM tools and agents.
 
-### Basic example use cases:
+### Basic Example Use Cases:
 
 - Send HTTP events from Slack to a specified Splunk server.
 - Send metrics from nginx to a specified Datadog server.


### PR DESCRIPTION
- Rephrase "programming language" as "runtime-agnostic," at Dritan's & Ledion's request.
- Minor copy edits – mostly splitting or punctuating long sentences.
- Fix 1 malformed link, & 1 obsolete/mismatched link label.