### PR TITLE
Updating Community Links

### DIFF
--- a/website/src/data/community.yaml
+++ b/website/src/data/community.yaml
@@ -3,6 +3,6 @@
   icon: github
   description: Fork on GitHub...
 - item: Slack
-  link: https://cribl.io/community/
+  link: https://cribl.io/community?utm_source=appscope&utm_medium=footer&utm_campaign=appscope
   icon: slack
   description: Join Us On Slack

--- a/website/src/data/header.yaml
+++ b/website/src/data/header.yaml
@@ -1,21 +1,16 @@
 - name: Overview
   path: /
-  
+
 - name: Docs
   path: /docs/overview
 
 # - name: Resources
 #   path: /resources
-  # child: 
+  # child:
   #   - name: Level 1
   #     path: /resources/level1
   #   - name: Level 2
   #     path: /resources/level2
 
 - name: Community
-  path: https://cribl.io/community
-
-      
-          
-
-   
+  path: https://cribl.io/community?utm_source=appscope&utm_medium=footer&utm_campaign=appscope

--- a/website/src/data/readyGetStarted.yaml
+++ b/website/src/data/readyGetStarted.yaml
@@ -4,7 +4,6 @@
     - icon: github
       url: https://github.com/criblio/appscope
       buttonText: Fork On Github
-    - icon: 
-      url: https://cribl.io/community
+    - icon:
+      url: https://cribl.io/community?utm_source=appscope&utm_medium=footer&utm_campaign=appscope
       buttonText: Join Our Community
-   

--- a/website/src/pages/docs/community.md
+++ b/website/src/pages/docs/community.md
@@ -6,7 +6,7 @@ title: Community
 
 ## Join Our Slack
 
-To connect with other AppScope users and developers, [join](https://cribl.io/community/) our [Community Slack](https://app.slack.com/client/TD0HGJPT5/CPYBPK65V/thread/C01BM8PU30V-1611001888.001100).
+To connect with other AppScope users and developers, [join]( https://cribl.io/community?utm_source=appscope&utm_medium=footer&utm_campaign=appscope) our [Community Slack](https://app.slack.com/client/TD0HGJPT5/CPYBPK65V/thread/C01BM8PU30V-1611001888.001100).
 
 ## How to Contribute
 

--- a/website/src/pages/docs/quick-start-guide.md
+++ b/website/src/pages/docs/quick-start-guide.md
@@ -30,7 +30,7 @@ scope curl https://google.com
 
 To see the monitoring and visualization features AppScope offers, exercise some of its options. E.g.:
 
-- Show last session's captured metrics with `scope metrics`: 
+- Show last session's captured metrics with `scope metrics`:
 
 ```
 NAME         	VALUE	TYPE 	UNIT       	PID	TAGS
@@ -79,7 +79,7 @@ fs.error     	7    	Count	operation  	525	class: stat,file: summary,host: 771f60
 
 
 
-- Display last session's captured events with `scope events`: 
+- Display last session's captured events with `scope events`:
 
 ```
 [j98] Jan 31 21:38:53 ps console stdout 19:40
@@ -104,7 +104,7 @@ fs.error     	7    	Count	operation  	525	class: stat,file: summary,host: 771f60
 [Bh9] Jan 31 21:38:53 ps console stdout /usr/bin/ps -ef
 ```
 
-- Filter out last session's events, for just `http` with `scope events -t http`: 
+- Filter out last session's events, for just `http` with `scope events -t http`:
 
 ```
 [MJ33] Jan 31 19:55:22 cribl http http-resp http.host:localhost:9000 http.method:GET http.scheme:http http.target:/ http.response_content_length:1630
@@ -121,7 +121,7 @@ fs.error     	7    	Count	operation  	525	class: stat,file: summary,host: 771f60
 ```
 
 
-- List this AppScope sessions history with `scope history`: 
+- List this AppScope sessions history with `scope history`:
 
 ```
 Displaying last 20 sessions
@@ -135,4 +135,4 @@ ID	COMMAND	CMDLINE                  	PID	AGE   	DURATION	TOTAL EVENTS
 
 ### Next Steps
 
-For guidance on taking AppScope to the next level, [join](https://cribl.io/community/) our [Community Slack](https://app.slack.com/client/TD0HGJPT5/CPYBPK65V/thread/C01BM8PU30V-1611001888.001100).
+For guidance on taking AppScope to the next level, [join](https://cribl.io/community?utm_source=appscope&utm_medium=footer&utm_campaign=appscope) our [Community Slack](https://app.slack.com/client/TD0HGJPT5/CPYBPK65V/thread/C01BM8PU30V-1611001888.001100).


### PR DESCRIPTION
Adding the UTM to see when community referrals come from Appscope.dev, and removing some of the direct links to Slack since it doesn't work even once you're joined to the community