### PR TITLE
Docs 0.6 updates

### DIFF
--- a/website/src/data/documentationNav.yaml
+++ b/website/src/data/documentationNav.yaml
@@ -51,6 +51,9 @@
     - name: Changelog
       path: /docs/changelog
 
+    - name: Known Issues
+      path: /docs/known-issues
+
 - name: Community
   child: 
     - name: Community

--- a/website/src/data/documentationNav.yaml
+++ b/website/src/data/documentationNav.yaml
@@ -37,6 +37,9 @@
     - name: Examples and Use Cases
       path: /docs/examples-use-cases
 
+    - name: Integrating with LogStream
+      path: /docs/logstream-integration
+
 - name: Reference
   child: 
     - name: CLI Reference

--- a/website/src/pages/docs/changelog.md
+++ b/website/src/pages/docs/changelog.md
@@ -6,7 +6,7 @@ title: Changelog
 
 ## AppScope 0.6
 
-2021-03-16 - Maintenance Pre-Release
+2021-04-01 - Maintenance Pre-Release
 
 This pre-release addresses the following issues:
 

--- a/website/src/pages/docs/changelog.md
+++ b/website/src/pages/docs/changelog.md
@@ -4,6 +4,24 @@ title: Changelog
 
 # Changelog
 
+## AppScope 0.6
+
+2021-03-02 - Maintenance Pre-Release
+
+This pre-release addresses the following issues:
+
+- **Improvement**: [#99](https://github.com/criblio/appscope/issues/99) Enable augmenting HTTP events with HTTP header and payload information
+- **Improvement**: [#38](https://github.com/criblio/appscope/issues/38) Disable (by default) TLS handshake info in payload capture
+- **Improvement**: [#36](https://github.com/criblio/appscope/issues/36) Enable sending running scope instances a signal to reload fresh configuration
+- **Improvement**: [#126](https://github.com/criblio/appscope/issues/126) Add Resolved IP Addresses list to a DNS response event
+- **Improvement**: [#100](https://github.com/criblio/appscope/issues/100) 
+Add `scope run` flags to facilitate sending scope data to third-party systems; also add a `scope k8s` command to facilitate installing a mutating admission webhook in a Kubernetes environment
+- **Improvement**: [#149](https://github.com/criblio/appscope/issues/149) 
+Apply tags set via environment variables to events, to match their application to metrics
+- **Fix**: [#37](https://github.com/criblio/appscope/issues/37) Capture DNS requests' payloads
+- **Fix**: [#2](https://github.com/criblio/appscope/issues/2) Enable scoping of scope
+- **Fix**: [#35](https://github.com/criblio/appscope/issues/35) Improve error messaging and logging when symbols are stripped from Go executables
+
 ## AppScope 0.5.1
 
 2021-02-05 - Maintenance Pre-Release

--- a/website/src/pages/docs/changelog.md
+++ b/website/src/pages/docs/changelog.md
@@ -6,7 +6,7 @@ title: Changelog
 
 ## AppScope 0.6
 
-2021-03-02 - Maintenance Pre-Release
+2021-03-16 - Maintenance Pre-Release
 
 This pre-release addresses the following issues:
 

--- a/website/src/pages/docs/config-files.md
+++ b/website/src/pages/docs/config-files.md
@@ -70,8 +70,8 @@ event:
     # Designed for monitoring log files, but capable of capturing
     # any file writes.
     - type: file
-      name: .*log.*                 # whitelist ex regex describing log file names
-      value: .*                     # whitelist ex regex describing field values
+      name: .*log.*                 # allowlist ex regex describing log file names
+      value: .*                     # allowlist ex regex describing field values
 
     # Creates events from data written to stdout, stderr, or both.
     # May be most useful for capturing debug output from processes
@@ -86,32 +86,32 @@ event:
     # high cardinality.
 #    - type: metric
 #      name: .*                      # (net.*)|(.*err.*)
-#      field: .*                     # whitelist regex describing field names
+#      field: .*                     # allowlist regex describing field names
 #      value: .*
 
     # Enable extraction of HTTP headers
     - type: http
       name: .*                      # (http-resp)|(http-metrics)
-      field: .*                     # whitelist regex describing field names
+      field: .*                     # allowlist regex describing field names
       value: .*
       headers:                      # (?i)X-myHeader.*
 
     # Creates events describing network connectivity
     - type: net
       name: .*                      #
-      field: .*                     # whitelist regex describing field names
+      field: .*                     # allowlist regex describing field names
       value: .*
 
     # Creates events describing file connectivity
     - type: fs
       name: .*                      #
-      field: .*                     # whitelist regex describing field names
+      field: .*                     # allowlist regex describing field names
       value: .*
 
     # Creates events describing dns activity
     - type: dns
       name: .*                      #
-      field: .*                     # whitelist regex describing field names
+      field: .*                     # allowlist regex describing field names
       value: .*
 
 payload:

--- a/website/src/pages/docs/config-files.md
+++ b/website/src/pages/docs/config-files.md
@@ -69,16 +69,16 @@ event:
     # Creates events from data written to files.
     # Designed for monitoring log files, but capable of capturing
     # any file writes.
-#    - type: file
-#      name: .*log.*                 # whitelist ex regex describing log file names
-#      value: .*                     # whitelist ex regex describing field values
+    - type: file
+      name: .*log.*                 # whitelist ex regex describing log file names
+      value: .*                     # whitelist ex regex describing field values
 
     # Creates events from data written to stdout, stderr, or both.
     # May be most useful for capturing debug output from processes
     # running in containerized environments.
-#    - type: console
-#      name: stdout                  # (stdout|stderr)
-#      value: .*
+    - type: console
+      name: stdout                  # (stdout|stderr)
+      value: .*
 
     # Creates events from libscope's metric (statsd) data.  May be
     # most useful for data which could overwhelm metric aggregation
@@ -90,28 +90,29 @@ event:
 #      value: .*
 
     # Enable extraction of HTTP headers
-#    - type: http
-#      name: .*                      # (http-resp)|(http-metrics)
-#      field: .*                     # whitelist regex describing field names
-#      value: .*
+    - type: http
+      name: .*                      # (http-resp)|(http-metrics)
+      field: .*                     # whitelist regex describing field names
+      value: .*
+      headers:                      # (?i)X-myHeader.*
 
     # Creates events describing network connectivity
-#    - type: net
-#      name: .*                      #
-#      field: .*                     # whitelist regex describing field names
-#      value: .*
+    - type: net
+      name: .*                      #
+      field: .*                     # whitelist regex describing field names
+      value: .*
 
     # Creates events describing file connectivity
-#    - type: fs
-#      name: .*                      #
-#      field: .*                     # whitelist regex describing field names
-#      value: .*
+    - type: fs
+      name: .*                      #
+      field: .*                     # whitelist regex describing field names
+      value: .*
 
     # Creates events describing dns activity
-#    - type: dns
-#      name: .*                      #
-#      field: .*                     # whitelist regex describing field names
-#      value: .*
+    - type: dns
+      name: .*                      #
+      field: .*                     # whitelist regex describing field names
+      value: .*
 
 payload:
   enable: false                     # true, false
@@ -123,7 +124,7 @@ libscope:
   commanddir : '/tmp'
   #  commanddir supports changes to configuration settings of running
   #  processes.  At every summary period the library looks in commanddir
-  #  to see if a file named scope.<pid> exists.  (where pid is the process ID
+  #  to see if a file named scope.<pid> exists.  (Where pid is the process ID
   #  of the process running with scope.)  If it exists, it processes every
   #  line for environment variable-style commands:
   #      SCOPE_METRIC_VERBOSITY=9
@@ -131,7 +132,7 @@ libscope:
   #  scope.<pid> file when it's complete.
 
   log:
-    level: error                    # debug, info, warning, error, none
+    level: warning                    # debug, info, warning, error, none
     transport:
       type: file
       path: '/tmp/scope.log'

--- a/website/src/pages/docs/examples-use-cases.md
+++ b/website/src/pages/docs/examples-use-cases.md
@@ -90,3 +90,7 @@ transport:
     host: ddog
     port: 5000
 ```
+
+### Next Steps
+
+Explore [Integrating with LogStream](/docs/logstream-integration).

--- a/website/src/pages/docs/installing.md
+++ b/website/src/pages/docs/installing.md
@@ -33,10 +33,6 @@ The container provides the AppScope binary on Ubuntu 20.04.
 
 ### Explore the CLI
 
-Run `scope --help` or `scope -h` to view CLI options. Also see the complete [CLI Reference](/docs/cli-reference).
-
-
-
-### Next Steps
-
-Get into the CLI with the [Quick Start Guide](/docs/quick-start-guide).
+- Run `scope --help` or `scope -h` to view CLI options.
+- Try some basic CLI commands in [Using the CLI](/docs/quick-start-guide).
+- See the complete [CLI Reference](/docs/cli-reference).

--- a/website/src/pages/docs/installing.md
+++ b/website/src/pages/docs/installing.md
@@ -5,7 +5,7 @@ title: Installing
 ## Installing
 ---
 
-First, see [Requirements](/docs/requirements) to ensure that you’re completing these steps on a supported system. Next, getting started is easy.
+Getting started is easy. Install AppScope, then explore its CLI.
 
 ### Get AppScope
 
@@ -13,7 +13,9 @@ You can download as a binary to run on your Linux OS, or as a container.
 
 #### Download as Binary
 
-Use this command to download the CLI binary and make it executable:
+First, see [Requirements](/docs/requirements) to ensure that you’re completing these steps on a supported system. 
+
+Next, Use this command to download the CLI binary and make it executable:
 
 ```
 curl -Lo scope https://cdn.cribl.io/dl/scope/\

--- a/website/src/pages/docs/known-issues.md
+++ b/website/src/pages/docs/known-issues.md
@@ -6,7 +6,7 @@ title: Known Issues
 
 ## AppScope 0.6
 
-2021-03-16 - Maintenance Pre-Release
+2021-04-01 - Maintenance Pre-Release
 
 As of this AppScope pre-release, known issues include:
 

--- a/website/src/pages/docs/known-issues.md
+++ b/website/src/pages/docs/known-issues.md
@@ -1,0 +1,23 @@
+---
+title: Known Issues
+---
+
+# Known Issues
+
+## AppScope 0.6
+
+2021-03-16 - Maintenance Pre-Release
+
+As of this pre-release, AppScope has these known issues:
+
+- Java JRE < v.6 is not supported.
+
+- [#38](https://github.com/criblio/appscope/issues/35) Go < v.1.8 is not supported.
+
+- [#38](https://github.com/criblio/appscope/issues/35) Go executables with stripped symbols do not allow function interposition. Executables will run, but will not provide data to AppScope.
+
+- [#143](https://github.com/criblio/appscope/issues/143) Linux distros that use uClibc or MUSL instead of glibc, such as Alpine, are not supported
+
+- [#10](https://github.com/criblio/appscope/issues/10), [#165,](https://github.com/criblio/appscope/issues/165) Scoping the Docker executable is problematic.
+
+- [#119](https://github.com/criblio/appscope/issues/119) HTTP 2 metrics and headers can be viewed only with [Cribl LogStream](https://cribl.io/product/).

--- a/website/src/pages/docs/known-issues.md
+++ b/website/src/pages/docs/known-issues.md
@@ -8,7 +8,7 @@ title: Known Issues
 
 2021-03-16 - Maintenance Pre-Release
 
-As of this pre-release, AppScope has these known issues:
+As of this AppScope pre-release, known issues include:
 
 - Java JRE < v.6 is not supported.
 
@@ -21,3 +21,7 @@ As of this pre-release, AppScope has these known issues:
 - [#10](https://github.com/criblio/appscope/issues/10), [#165,](https://github.com/criblio/appscope/issues/165) Scoping the Docker executable is problematic.
 
 - [#119](https://github.com/criblio/appscope/issues/119) HTTP 2 metrics and headers can be viewed only with [Cribl LogStream](https://cribl.io/product/).
+
+<hr>
+
+See [all issues](https://github.com/criblio/appscope/issues) currently open on GitHub.

--- a/website/src/pages/docs/library-using.md
+++ b/website/src/pages/docs/library-using.md
@@ -50,4 +50,6 @@ This again executes the `ps` command using the AppScope library. But here, we al
 
 ### <span id="configuring">Configuring the Library</span>
 
-For details on configuring the library, see AppScope online help's CONFIGURATION section. For the default settings in the sample `scope.yml` configuration file, see [Config Files](/docs/config-files), or inspect the most-recent file on [GitHub](https://github.com/criblio/appscope/blob/master/conf/scope.yml).
+For a full list of library environment variables, execute: `./libscope.so all`
+
+For the default settings in the sample `scope.yml` configuration file, see [Config Files](/docs/config-files), or inspect the most-recent file on [GitHub](https://github.com/criblio/appscope/blob/master/conf/scope.yml).

--- a/website/src/pages/docs/loader-library.md
+++ b/website/src/pages/docs/loader-library.md
@@ -2,7 +2,7 @@
 title: Extracting the Library
 ---
 
-## The Loader, Library and .yml Files
+## The Loader, Library, and .yml Files
 ---
 As covered in [How AppScope Works](/docs/how-works), the single binary contains **Loader** and **Library** components that can be used independently of the CLI. In order to use these components, you must first extract them using the `extract` sub-command. This will output the `ldscope`, `libscope.so`, `scope.yml`, and `scope_protocol.yml` into a directory that you specify. You can later configure these files to instrument any application, and to output the data to any existing tool via simple TCP protocols. 
 

--- a/website/src/pages/docs/logstream-integration.md
+++ b/website/src/pages/docs/logstream-integration.md
@@ -1,0 +1,32 @@
+---
+title: Integrating with LogStream
+---
+
+## Integrating with LogStream
+---
+
+AppScope will connect to LogStream. A single configuration element is used to define a LogStream connection. The environment variable SCOPE_LOGSTREAM defines a LogStream connection:
+SCOPE_LOGSTREAM=hostname:port
+SCOPE_LOGSTREAM=ip:port
+SCOPE_LOGSTREAM=tcp://ip:port
+
+Default port is 10090
+
+A host name or IPv4 address is supplied along with a port number. If no port number is supplied, the default port 10090 will be used. Optionally, the syntax “tcp://ip:port” is supported to define an IP address.
+
+When a LogStream connection is established, several configuration parameters are set and will override settings in a configuration file or environment variable. Any override of configuration is logged to the default AppScope log file.  The configuration settings that are not variable and potentially overridden include: 
+Metrics are enabled
+Metrics format is set to ndjson
+Events are enabled
+Transport for events, metrics and payloads utilize the LogStream connection
+
+Configuration elements that are enabled by default when a LogStream connection is defined and can be overridden by a configuration file or environment variables:
+Event watch types are enabled
+File
+Console
+FS
+Net
+HTTP
+DNS
+
+All other configuration elements remain default.

--- a/website/src/pages/docs/logstream-integration.md
+++ b/website/src/pages/docs/logstream-integration.md
@@ -5,28 +5,44 @@ title: Integrating with LogStream
 ## Integrating with LogStream
 ---
 
-AppScope will connect to LogStream. A single configuration element is used to define a LogStream connection. The environment variable SCOPE_LOGSTREAM defines a LogStream connection:
+AppScope can easily connect to Cribl LogStream ([overview](https://cribl.io/product/) | [download](https://cribl.io/download/) | [docs](https://docs.cribl.io/docs/welcome)).
+
+To define a LogStream connection, the only configuration element needed is setting the `SCOPE_LOGSTREAM` environment variable. Here are some example definitions, which we'll unpack below:
+
+```
 SCOPE_LOGSTREAM=hostname:port
 SCOPE_LOGSTREAM=ip:port
 SCOPE_LOGSTREAM=tcp://ip:port
+```
 
-Default port is 10090
+### Requirements
 
-A host name or IPv4 address is supplied along with a port number. If no port number is supplied, the default port 10090 will be used. Optionally, the syntax “tcp://ip:port” is supported to define an IP address.
+You must supply a host name or IPv4 address, along with an optional port number. If you omit the port number, AppScope will attempt to connect on the default port `10090`. 
 
-When a LogStream connection is established, several configuration parameters are set and will override settings in a configuration file or environment variable. Any override of configuration is logged to the default AppScope log file.  The configuration settings that are not variable and potentially overridden include: 
-Metrics are enabled
-Metrics format is set to ndjson
-Events are enabled
-Transport for events, metrics and payloads utilize the LogStream connection
+### Optional TCP Syntax
 
-Configuration elements that are enabled by default when a LogStream connection is defined and can be overridden by a configuration file or environment variables:
-Event watch types are enabled
-File
-Console
-FS
-Net
-HTTP
-DNS
+You can optionally use the syntax `tcp://ip:port` to define an IP address.
 
-All other configuration elements remain default.
+
+### Parameter Overrides
+
+When AppScope establishes a LogStream connection, this sets several AppScope configuration parameters, some of which override settings in any configuration file or environment variable. Any configuration override is logged to AppScope's default log file. 
+
+Configuration settings that are potentially overridden include: 
+
+- Metrics are enabled.
+- Metrics format is set to `ndjson`.
+- Events are enabled.
+- Transport for events, metrics, and payloads use the LogStream connection.
+
+The following configuration elements are enabled by default when a LogStream connection is defined, but these can be overridden by a configuration file or by environment variables:
+
+- Event watch types
+- File
+- Console
+- FS
+- Net
+- HTTP
+- DNS
+
+Other configuration elements are not modified by a LogStream connection.

--- a/website/src/pages/docs/logstream-integration.md
+++ b/website/src/pages/docs/logstream-integration.md
@@ -7,22 +7,15 @@ title: Integrating with LogStream
 
 AppScope can easily connect to Cribl LogStream ([overview](https://cribl.io/product/) | [download](https://cribl.io/download/) | [docs](https://docs.cribl.io/docs/welcome)).
 
-To define a LogStream connection, the only configuration element needed is setting the `SCOPE_LOGSTREAM` environment variable. Here are some example definitions, which we'll unpack below:
+To define a LogStream connection, the only configuration element needed is setting the `SCOPE_CRIBL` environment variable. For example:
 
 ```
-SCOPE_LOGSTREAM=hostname:port
-SCOPE_LOGSTREAM=ip:port
-SCOPE_LOGSTREAM=tcp://ip:port
+SCOPE_CRIBL=tcp://ip:port
 ```
 
 ### Requirements
 
 You must supply a host name or IPv4 address, along with an optional port number. If you omit the port number, AppScope will attempt to connect on the default port `10090`. 
-
-### Optional TCP Syntax
-
-You can optionally use the syntax `tcp://ip:port` to define an IP address.
-
 
 ### Parameter Overrides
 

--- a/website/src/pages/docs/quick-start-guide.md
+++ b/website/src/pages/docs/quick-start-guide.md
@@ -1,8 +1,8 @@
 ---
-title: Quick Start Guide
+title: Using the CLI
 ---
 
-## Quick Start Guide
+## Using the CLI
 ---
 
 ### Explore the CLI
@@ -24,7 +24,6 @@ Let's try another:
 scope curl https://google.com
 >> should see output of curl here <<
 ```
-
 
 ### Let's explore captured data
 
@@ -79,7 +78,7 @@ fs.error     	7    	Count	operation  	525	class: stat,file: summary,host: 771f60
 
 
 
-- Display last session's captured events with `scope events`:
+- Display the last session's captured events with `scope events`:
 
 ```
 [j98] Jan 31 21:38:53 ps console stdout 19:40
@@ -104,7 +103,7 @@ fs.error     	7    	Count	operation  	525	class: stat,file: summary,host: 771f60
 [Bh9] Jan 31 21:38:53 ps console stdout /usr/bin/ps -ef
 ```
 
-- Filter out last session's events, for just `http` with `scope events -t http`:
+- Filter out the last session's events, for just `http` with `scope events -t http`:
 
 ```
 [MJ33] Jan 31 19:55:22 cribl http http-resp http.host:localhost:9000 http.method:GET http.scheme:http http.target:/ http.response_content_length:1630
@@ -121,7 +120,7 @@ fs.error     	7    	Count	operation  	525	class: stat,file: summary,host: 771f60
 ```
 
 
-- List this AppScope sessions history with `scope history`:
+- List this AppScope session's history with `scope history`:
 
 ```
 Displaying last 20 sessions
@@ -135,4 +134,5 @@ ID	COMMAND	CMDLINE                  	PID	AGE   	DURATION	TOTAL EVENTS
 
 ### Next Steps
 
-For guidance on taking AppScope to the next level, [join](https://cribl.io/community?utm_source=appscope&utm_medium=footer&utm_campaign=appscope) our [Community Slack](https://app.slack.com/client/TD0HGJPT5/CPYBPK65V/thread/C01BM8PU30V-1611001888.001100).
+- Explore the [Loader, Library, and .yml files](/docs/loader-library).
+- View the complete [CLI Reference](/docs/cli-reference).

--- a/website/src/pages/docs/what-do-with-scope.md
+++ b/website/src/pages/docs/what-do-with-scope.md
@@ -5,7 +5,7 @@ title: Cool, but What Can I do with It?
 ## Cool, but What Can I Do with It?
 ---
 
-AppScope offers APM-like, black-box instrumentation of any unmodified Linux executable and application. You can use AppScope in single-user troubleshooting, or in a distributed production deployment, with little extra tooling infrastructure. Especially when paired with Cribl LogStream, AppScope can deliver just the data you need to your existing tools.
+AppScope offers APM-like, black-box instrumentation of any unmodified Linux executable and application. You can use AppScope in single-user troubleshooting, or in a distributed production deployment, with little extra tooling infrastructure. Especially when paired with [Cribl LogStream](https://cribl.io/product/), AppScope can deliver just the data you need to your existing tools.
 
 ### Instrument, Collect and Observe
 
@@ -25,5 +25,6 @@ AppScope collects and forwards StatsD-style metrics about running applications. 
 - Send HTTP events from Slack to a specified Splunk server.
 - Send metrics from nginx to a specified Datadog server.
 - Send metrics from a Go static application to a specified Datadog server.
+- For any of the above examples, substitute your analytics tool of choice. Optimize the data flow by mediating it through [Cribl LogStream](https://cribl.io/product/).
 - Run Firefox from the AppScope CLI, and view results on a terminal-based dashboard.
 - Run Google Chrome from the AppScope CLI, and view results on a terminal-based dashboard. And be surprised.


### PR DESCRIPTION
Includes basically:
- Added new doc section explaining scope connection to LogStream.
- Added v.0.6 Changelog entry [now assumes 4/1/21 as release date].
- Added Known Issues page [also assumes as of v.0.6, as of 4/1/21].
- Expanded instructions for displaying CLI help contents.
- Refactor the confused titling of (and kāpulu links to) the "Using the CLI" page (formerly "Quick Start Guide").
- Minor cleanup.