### PR TITLE
scope.yml copy edits

### DIFF
--- a/cli/demo/scope.yml
+++ b/cli/demo/scope.yml
@@ -18,18 +18,18 @@ event:
     buffer: line
   watch:
     - type: file
-      name: .*log.*                 # whitelist ex regex describing log file names
-      value: .*                     # whitelist ex regex describing field values
+      name: .*log.*                 # allowlist ex regex describing log file names
+      value: .*                     # allowlist ex regex describing field values
     - type: console
       name: (stdout)|(stderr)
       value: .*
     # - type: metric
     #   name: .*                      # (net.*)|(.*err.*)
-    #   field: ^[^h]+                 # whitelist ex regex describing field names
+    #   field: ^[^h]+                 # allowlist ex regex describing field names
     #   value: .*
     - type: http
       name: .*                      # .*-res | .*-req | .*-metrics
-      field: ^[^h]+                 # ^[^h]+ whitelist ex regex describing field names
+      field: ^[^h]+                 # ^[^h]+ allowlist ex regex describing field names
       value: .*
 
   

--- a/conf/scope.yml
+++ b/conf/scope.yml
@@ -110,13 +110,13 @@ libscope:
   summaryperiod : 10                # in seconds
   commanddir : '/tmp'
   #  commanddir supports changes to configuration settings of running
-  #  processes.  At every summary period the library looks in commanddir
-  #  to see if a file named scope.<pid> exists.  (where pid is the process ID
-  #  of the process running with scope.)  If it exists, it processes every
-  #  line for environment variable-style commands:
+  #  processes.  At every summary period, the library looks in commanddir
+  #  to see if a file named scope.<pid> exists. (Where <pid> is the process ID
+  #  of the process running with scope.) If this file exists, commanddir 
+  #  processes every line for environment variable–style commands:
   #      SCOPE_METRIC_VERBOSITY=9
   #  It changes the configuration to match the new settings, and deletes the
-  #  scope.<pid> file when it's complete.
+  #  scope.<pid> file when replacement is complete.
 
   log:
     level: error                    # debug, info, warning, error, none

--- a/conf/scope.yml
+++ b/conf/scope.yml
@@ -110,7 +110,7 @@ libscope:
   summaryperiod : 10                # in seconds
   commanddir : '/tmp'
   #  commanddir supports changes to configuration settings of running
-  #  processees.  At every summary period the library looks in commanddir
+  #  processes.  At every summary period the library looks in commanddir
   #  to see if a file named scope.<pid> exists.  (where pid is the process ID
   #  of the process running with scope.)  If it exists, it processes every
   #  line for environment variable-style commands:

--- a/conf/scope.yml
+++ b/conf/scope.yml
@@ -58,8 +58,8 @@ event:
     # Designed for monitoring log files, but capable of capturing
     # any file writes.
 #    - type: file
-#      name: .*log.*                 # whitelist ex regex describing log file names
-#      value: .*                     # whitelist ex regex describing field values
+#      name: .*log.*                 # allowlist ex regex describing log file names
+#      value: .*                     # allowlist ex regex describing field values
 
     # Creates events from data written to stdout, stderr, or both.
     # May be most useful for capturing debug output from processes
@@ -74,31 +74,31 @@ event:
     # high cardinality.
 #    - type: metric
 #      name: .*                      # (net.*)|(.*err.*)
-#      field: .*                     # whitelist regex describing field names
+#      field: .*                     # allowlist regex describing field names
 #      value: .*
 
     # Enable extraction of HTTP headers
 #    - type: http
 #      name: .*                      # (http-resp)|(http-metrics)
-#      field: .*                     # whitelist regex describing field names
+#      field: .*                     # allowlist regex describing field names
 #      value: .*
 
     # Creates events describing network connectivity
 #    - type: net
 #      name: .*                      #
-#      field: .*                     # whitelist regex describing field names
+#      field: .*                     # allowlist regex describing field names
 #      value: .*
 
     # Creates events describing file connectivity
 #    - type: fs
 #      name: .*                      #
-#      field: .*                     # whitelist regex describing field names
+#      field: .*                     # allowlist regex describing field names
 #      value: .*
 
     # Creates events describing dns activity
 #    - type: dns
 #      name: .*                      #
-#      field: .*                     # whitelist regex describing field names
+#      field: .*                     # allowlist regex describing field names
 #      value: .*
 
 payload:


### PR DESCRIPTION
These commits affect only the comments (not the keys/values) in both `scope.yml` files:

1. Correct 'processes' spelling.
2. Change all 'whitelist' -> 'allowlist'.
3. Clarify 'commanddir' description.