### PR TITLE
remove space between "free" identifier and its parens

### DIFF
--- a/src/report.c
+++ b/src/report.c
@@ -160,7 +160,7 @@ destroyProto(protocol_info *proto)
      * post->data is the http header and is freed in destroyHttpMap()
      * when the list entry is deleted.
      */
-    if (proto->data) free (proto->data);
+    if (proto->data) free(proto->data);
 }
 
 static int


### PR DESCRIPTION
A trivial style fix.