### PR TITLE
implement startsWith()

### DIFF
--- a/src/cfgutils.c
+++ b/src/cfgutils.c
@@ -389,9 +389,14 @@ processReloadConfig(config_t *cfg, const char* value)
 }
 
 static int
-startsWith(const char* string, const char* substring)
+startsWith(const char* str, const char* pref)
 {
-    return (strncmp(string, substring, strlen(substring)) == 0);
+    for (; *pref != '\0'; str++, pref++) {
+        if (*pref != *str) {
+            return FALSE;
+        }
+    }
+    return TRUE;
 }
 
 //


### PR DESCRIPTION
It's a bit of a premature optimization, but it's also more correct than doing this in quadratic time.

Additionally, I've spotted an usage of strncmp() in utils.c line 38 that does exactly what this function does. It would be best to move startsWith() to utils.c and look for/fix other instances of that strncmp() pattern.