### PR TITLE
Issue #260 Docs: Add blogs/videos page; add 0.6.1 changelog entry

### DIFF
--- a/website/src/data/documentationNav.yaml
+++ b/website/src/data/documentationNav.yaml
@@ -48,6 +48,9 @@
     - name: Config Files
       path: /docs/config-files
 
+    - name: Other Resources
+      path: /docs/other-resources
+
     - name: Changelog
       path: /docs/changelog
 

--- a/website/src/pages/docs/changelog.md
+++ b/website/src/pages/docs/changelog.md
@@ -4,6 +4,16 @@ title: Changelog
 
 # Changelog
 
+## AppScope 0.6.1
+
+2021-04-26 - Maintenance Pre-Release
+
+This pre-release addresses the following issues:
+
+- **Improvement**: [#238](https://github.com/criblio/appscope/issues/238) Resolve multiple issues with payloads from Node.js processes
+- **Improvement**: [#257](https://github.com/criblio/appscope/issues/257) Add missing console/log events, first observed in Python 3
+- **Improvement**: [#249](https://github.com/criblio/appscope/issues/249) Add support for Go apps built with `‑buildmode=pie`
+ 
 ## AppScope 0.6
 
 2021-03-16 - Maintenance Pre-Release

--- a/website/src/pages/docs/other-resources.md
+++ b/website/src/pages/docs/other-resources.md
@@ -1,0 +1,22 @@
+---
+title: Other Resources
+---
+
+To learn more about AppScope, see these resources from Cribl:
+
+# Blog Posts
+
+We have a growing number of AppScope-related [blog posts](https://cribl.io/blog/?s=appscope):
+
+- [Introducing AppScope: Easy Black Box Instrumentation for Everything](https://cribl.io/blog/introducing-appscope-easy-black-box-instrumentation-for-everything/)
+- [AppScope Design](https://cribl.io/blog/appscope-design/)
+- [AppScope: Interposition Mechanisms](https://cribl.io/blog/interposition-mechanisms/)
+- [AppScope: Analyzing gRPC and Protobuf](https://cribl.io/blog/analyzing-grpc-and-protobuf/)
+- [How AppScope helped resolve a DNS problem](https://cribl.io/blog/how-appscope-helped-resolve-a-dns-problem/)
+- [AppScope: Postgres SQL Observability](https://cribl.io/blog/appscope-postgres-sql-observability/)
+
+## Videos
+
+See our:
+
+- [Videos](https://cribl.io/resources/?category=videos) about all Cribl products.


### PR DESCRIPTION
* Add a new docs page linking to existing AppScope blog posts and all Cribl videos.