### PR TITLE
Fix missing _STAT_VER

### DIFF
--- a/os/linux/os.c
+++ b/os/linux/os.c
@@ -402,6 +402,12 @@ osInitTSC(platform_time_t *cfg)
     return 0;
 }
 
+#ifndef _STAT_VER
+// The version of lib6-dev on Ubuntu 21.04 no longer defines this so we'll
+// fallback to what it was set to in earlier versions.
+#define _STAT_VER 1
+#endif
+
 int
 osIsFilePresent(pid_t pid, const char *path)
 {


### PR DESCRIPTION
Newer version of glibc on Ubuntu 21.04 (specifically `libc6-dev 2.33-0ubuntu5`) doesn't define this any more. We hard code the first parameter for `__xstat()` to `1` elsewhere in `src/state/c` and in some of the tests so this seems innocuous.