### PR TITLE
Handle different gnutls_transport_get_ptr() results

### DIFF
--- a/src/wrap.c
+++ b/src/wrap.c
@@ -2584,7 +2584,8 @@ gnutls_get_fd(gnutls_session_t session)
         // gnutls_transport_get_ptr() return value is the file-descriptor,
         // not a pointer to the file-descriptor. Using gnutls_check_version()
         // got messy as we may have found this behaviour switched on and off.
-        // So, we're testing here if the 
+        // So, we're testing here if the integer value of the pointer is 
+        // below the number of file-descriptors.
         if (!g_max_fds) {
             // NB: race-condition where multiple threads get here at the same
             // time and end up setting g_max_fds more than once. Decided not

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -11,6 +11,7 @@
 #include <sys/syscall.h>
 #include <sys/stat.h>
 #include <libgen.h>
+#include <sys/resource.h>
 
 #include "atomic.h"
 #include "bashmem.h"
@@ -44,6 +45,7 @@ static bool g_replacehandler = FALSE;
 static const char *g_cmddir;
 static list_t *g_nsslist;
 static uint64_t reentrancy_guard = 0ULL;
+static rlim_t g_max_fds = 0;
 
 extern unsigned g_sendprocessstart;
 
@@ -2570,6 +2572,41 @@ SSL_write(SSL *ssl, const void *buf, int num)
     return rc;
 }
 
+static int
+gnutls_get_fd(gnutls_session_t session)
+{
+    int fd = -1;
+    gnutls_transport_ptr_t fdp;
+
+    if (SYMBOL_LOADED(gnutls_transport_get_ptr) &&
+            ((fdp = g_fn.gnutls_transport_get_ptr(session)) != NULL)) {
+	// In #279, we found that when the version of gnutls is 3.5.18, the
+	// gnutls_transport_get_ptr() return value is the file-descriptor,
+	// not a pointer to the file-descriptor. Using gnutls_check_version()
+	// got messy as we may have found this behaviour switched on and off.
+	// So, we're testing here if the 
+        if (!g_max_fds) {
+	    // NB: race-condition where multiple threads get here at the same
+	    // time and end up setting g_max_fds more than once. Decided not
+	    // to put this in the library consructor due only to sloth.
+            struct rlimit fd_limit;
+            if (getrlimit(RLIMIT_NOFILE, &fd_limit) != 0) {
+		// NB: could just assume limit is 1024 which appears to be the
+		// default in most places. Should this be logged?
+                return fd;
+            }
+            g_max_fds = fd_limit.rlim_cur;
+        }
+        if ((uint64_t)fdp >= g_max_fds) {
+            fd = *fdp;
+        } else {
+            fd = (int)(uint64_t)fdp;
+        }
+    }
+
+    return fd;
+}
+
 EXPORTON ssize_t
 gnutls_record_recv(gnutls_session_t session, void *data, size_t data_size)
 {
@@ -2580,14 +2617,7 @@ gnutls_record_recv(gnutls_session_t session, void *data, size_t data_size)
     rc = g_fn.gnutls_record_recv(session, data, data_size);
 
     if (rc > 0) {
-        int fd = -1;
-        gnutls_transport_ptr_t fdp;
-
-        if (SYMBOL_LOADED(gnutls_transport_get_ptr) &&
-            ((fdp = g_fn.gnutls_transport_get_ptr(session)) != NULL)) {
-            fd = *fdp;
-        }
-
+        int fd = gnutls_get_fd(session);
         doProtocol((uint64_t)session, fd, data, rc, TLSRX, BUF);
     }
     return rc;
@@ -2603,14 +2633,7 @@ gnutls_record_recv_early_data(gnutls_session_t session, void *data, size_t data_
     rc = g_fn.gnutls_record_recv_early_data(session, data, data_size);
 
     if (rc > 0) {
-        int fd = -1;
-        gnutls_transport_ptr_t fdp;
-
-        if (SYMBOL_LOADED(gnutls_transport_get_ptr) &&
-            ((fdp = g_fn.gnutls_transport_get_ptr(session)) != NULL)) {
-            fd = *fdp;
-        }
-
+        int fd = gnutls_get_fd(session);
         doProtocol((uint64_t)session, fd, data, rc, TLSRX, BUF);
     }
     return rc;
@@ -2641,14 +2664,7 @@ gnutls_record_recv_seq(gnutls_session_t session, void *data, size_t data_size, u
     rc = g_fn.gnutls_record_recv_seq(session, data, data_size, seq);
 
     if (rc > 0) {
-        int fd = -1;
-        gnutls_transport_ptr_t fdp;
-
-        if (SYMBOL_LOADED(gnutls_transport_get_ptr) &&
-            ((fdp = g_fn.gnutls_transport_get_ptr(session)) != NULL)) {
-            fd = *fdp;
-        }
-
+        int fd = gnutls_get_fd(session);
         doProtocol((uint64_t)session, fd, data, rc, TLSRX, BUF);
     }
     return rc;
@@ -2664,14 +2680,7 @@ gnutls_record_send(gnutls_session_t session, const void *data, size_t data_size)
     rc = g_fn.gnutls_record_send(session, data, data_size);
 
     if (rc > 0) {
-        int fd = -1;
-        gnutls_transport_ptr_t fdp;
-
-        if (SYMBOL_LOADED(gnutls_transport_get_ptr) &&
-            ((fdp = g_fn.gnutls_transport_get_ptr(session)) != NULL)) {
-            fd = *fdp;
-        }
-
+        int fd = gnutls_get_fd(session);
         doProtocol((uint64_t)session, fd, (void *)data, rc, TLSTX, BUF);
     }
     return rc;
@@ -2688,14 +2697,7 @@ gnutls_record_send2(gnutls_session_t session, const void *data, size_t data_size
     rc = g_fn.gnutls_record_send2(session, data, data_size, pad, flags);
 
     if (rc > 0) {
-        int fd = -1;
-        gnutls_transport_ptr_t fdp;
-
-        if (SYMBOL_LOADED(gnutls_transport_get_ptr) &&
-            ((fdp = g_fn.gnutls_transport_get_ptr(session)) != NULL)) {
-            fd = *fdp;
-        }
-
+        int fd = gnutls_get_fd(session);
         doProtocol((uint64_t)session, fd, (void *)data, rc, TLSTX, BUF);
     }
     return rc;
@@ -2711,14 +2713,7 @@ gnutls_record_send_early_data(gnutls_session_t session, const void *data, size_t
     rc = g_fn.gnutls_record_send_early_data(session, data, data_size);
 
     if (rc > 0) {
-        int fd = -1;
-        gnutls_transport_ptr_t fdp;
-
-        if (SYMBOL_LOADED(gnutls_transport_get_ptr) &&
-            ((fdp = g_fn.gnutls_transport_get_ptr(session)) != NULL)) {
-            fd = *fdp;
-        }
-
+        int fd = gnutls_get_fd(session);
         doProtocol((uint64_t)session, fd, (void *)data, rc, TLSTX, BUF);
     }
     return rc;
@@ -2735,14 +2730,7 @@ gnutls_record_send_range(gnutls_session_t session, const void *data, size_t data
     rc = g_fn.gnutls_record_send_range(session, data, data_size, range);
 
     if (rc > 0) {
-        int fd = -1;
-        gnutls_transport_ptr_t fdp;
-
-        if (SYMBOL_LOADED(gnutls_transport_get_ptr) &&
-            ((fdp = g_fn.gnutls_transport_get_ptr(session)) != NULL)) {
-            fd = *fdp;
-        }
-
+        int fd = gnutls_get_fd(session);
         doProtocol((uint64_t)session, fd, (void *)data, rc, TLSTX, BUF);
     }
     return rc;

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -2580,19 +2580,19 @@ gnutls_get_fd(gnutls_session_t session)
 
     if (SYMBOL_LOADED(gnutls_transport_get_ptr) &&
             ((fdp = g_fn.gnutls_transport_get_ptr(session)) != NULL)) {
-	// In #279, we found that when the version of gnutls is 3.5.18, the
-	// gnutls_transport_get_ptr() return value is the file-descriptor,
-	// not a pointer to the file-descriptor. Using gnutls_check_version()
-	// got messy as we may have found this behaviour switched on and off.
-	// So, we're testing here if the 
+        // In #279, we found that when the version of gnutls is 3.5.18, the
+        // gnutls_transport_get_ptr() return value is the file-descriptor,
+        // not a pointer to the file-descriptor. Using gnutls_check_version()
+        // got messy as we may have found this behaviour switched on and off.
+        // So, we're testing here if the 
         if (!g_max_fds) {
-	    // NB: race-condition where multiple threads get here at the same
-	    // time and end up setting g_max_fds more than once. Decided not
-	    // to put this in the library consructor due only to sloth.
+            // NB: race-condition where multiple threads get here at the same
+            // time and end up setting g_max_fds more than once. Decided not
+            // to put this in the library consructor due only to sloth.
             struct rlimit fd_limit;
             if (getrlimit(RLIMIT_NOFILE, &fd_limit) != 0) {
-		// NB: could just assume limit is 1024 which appears to be the
-		// default in most places. Should this be logged?
+                // NB: could just assume limit is 1024 which appears to be the
+                // default in most places. Should this be logged?
                 return fd;
             }
             g_max_fds = fd_limit.rlim_cur;

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -2588,12 +2588,10 @@ gnutls_get_fd(gnutls_session_t session)
         // below the number of file-descriptors.
         if (!g_max_fds) {
             // NB: race-condition where multiple threads get here at the same
-            // time and end up setting g_max_fds more than once. Decided not
-            // to put this in the library consructor due only to sloth.
+            // time and end up setting g_max_fds more than once. No problem.
             struct rlimit fd_limit;
             if (getrlimit(RLIMIT_NOFILE, &fd_limit) != 0) {
-                // NB: could just assume limit is 1024 which appears to be the
-                // default in most places. Should this be logged?
+                DBG("getrlimit(0 failed");
                 return fd;
             }
             g_max_fds = fd_limit.rlim_cur;


### PR DESCRIPTION
fix #279

Built and tested on both Ubuntu 18.04 and 20.04. 