### PR TITLE
Add `make docker-run` target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-*.swp
+**/*.swp
+.gdb_history
 scope.log
 coverage/
 # JetBrains specific directory

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.swp
+scope.log
 coverage/
 # JetBrains specific directory
 .idea

--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,10 @@ docker-run:
 		-e SCOPE_LOG_DEST=file:///root/appscope/scope.log \
 		$(TAG)
 
+# Using the docker-* targets above, many files here are created as root in the
+# container and end up inaccessible here. Added this here after getting bit
+# repeatedly.
+.PHONY: chown
+chown:
+	sudo chown -R $(USER):$(USER) .
+

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,23 @@ docker-run:
 		-e SCOPE_LOG_DEST=file:///root/appscope/scope.log \
 		$(TAG)
 
+.PHONY: docker-run-alpine
+docker-run-alpine: TAG?="appscope-builder-alpine"
+docker-run-alpine: DOCKER?=$(shell which docker 2>/dev/null)
+docker-run-alpine: PWD:=$(shell pwd)
+docker-run-alpine: BUILD_ARGS ?=
+docker-run-alpine:
+	@[ -x "$(DOCKER)" ] || \
+		( echo >&2 "error: Please install Docker first."; exit 1)
+	@$(DOCKER) build \
+		--tag $(TAG) \
+		-f docker/builder/Dockerfile.alpine \
+		$(BUILD_ARGS) .
+	@$(DOCKER) run -it --rm \
+		-v "$(shell pwd):/root/appscope" \
+		-e SCOPE_LOG_DEST=file:///root/appscope/scope.log \
+		$(TAG)
+
 # Using the docker-* targets above, many files here are created as root in the
 # container and end up inaccessible here. Added this here after getting bit
 # repeatedly.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ all:
 endif
 
 .PHONY: docker-build
-docker-build: TAG ?= "appscope-builder:$(VERSION)"
+docker-build: TAG ?= "appscope-builder"
 docker-build: DOCKER ?= $(shell which docker 2>/dev/null)
 docker-build: BUILD_ARGS ?=
 docker-build:
@@ -51,7 +51,7 @@ docker-build:
 
 # Annoyingly not DRY
 .PHONY: docker-run
-docker-run: TAG?="appscope-builder:$(VERSION)"
+docker-run: TAG?="appscope-builder"
 docker-run: DOCKER?=$(shell which docker 2>/dev/null)
 docker-run: PWD:=$(shell pwd)
 docker-run: BUILD_ARGS ?=

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -9,7 +9,7 @@
 #
 #     docker build --build-arg IMAGE=ubuntu:groovy ...
 #
-ARG IMAGE=ubuntu
+ARG IMAGE=ubuntu:18.04
 FROM $IMAGE
 
 # ---

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -5,9 +5,9 @@
 #
 
 # ---
-# Use the current Ubuntu image by default. Override this like below.
+# Use the Ubuntu 18.04 image by default. Override this like below.
 #
-#     docker build --build-arg IMAGE=ubuntu:groovy ...
+#     docker build --build-arg IMAGE=ubuntu:latest ...
 #
 ARG IMAGE=ubuntu:18.04
 FROM $IMAGE
@@ -45,9 +45,7 @@ RUN apt-get update && \
 # ---
 # Extra setup for use with `make docker-run`
 #
-RUN echo "set environment LD_PRELOAD=/root/appscope/lib/linux/libscope.so" >> /root/.gtbinit && \
-    echo "set breakpoint pending on" >> /root/.gtbinit && \
-    echo "set follow-fork-mode child" >> /root/.gtbinit
+COPY ./docker/builder/gdbinit /root/.gdbinit
 
 # ---
 # The local git clone of the project is mounted as /root/appscope. See Makefile.

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -39,8 +39,15 @@ RUN apt-get update && \
     add-apt-repository ppa:longsleep/golang-backports && \
     apt-get update && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 52B59B1571A79DBC054901C0F6BC817356A3D45E && \
-    apt-get install -y $GOLANG git autoconf automake libtool cmake lcov upx make && \
+    apt-get install -y $GOLANG git autoconf automake libtool cmake lcov upx make gdb vim emacs strace lsof && \
     apt-get clean
+
+# ---
+# Extra setup for use with `make docker-run`
+#
+RUN echo "set environment LD_PRELOAD=/root/appscope/lib/linux/libscope.so" >> /root/.gtbinit && \
+    echo "set breakpoint pending on" >> /root/.gtbinit && \
+    echo "set follow-fork-mode child" >> /root/.gtbinit
 
 # ---
 # The local git clone of the project is mounted as /root/appscope. See Makefile.

--- a/docker/builder/Dockerfile.alpine
+++ b/docker/builder/Dockerfile.alpine
@@ -1,0 +1,32 @@
+# ---
+# Cribl AppScope - Build under Docker
+#
+# by Paul Dugas <paul@dugas.cc>
+#
+
+# ---
+# Use the Ubuntu 18.04 image by default. Override this like below.
+#
+#     docker build --build-arg IMAGE=ubuntu:latest ...
+#
+ARG IMAGE=alpine:latest
+FROM $IMAGE
+
+# ---
+# Install packages.
+#
+RUN apk add --no-cache go gdb git make vim emacs strace tcpdump
+
+# ---
+# Extra setup for use with `make docker-run`
+#
+COPY ./docker/builder/gdbinit /root/.gdbinit
+
+# ---
+# The local git clone of the project is mounted as /root/appscope. See Makefile.
+#
+#     docker run -v $(pwd):/root/appscope ...
+#
+WORKDIR /root/appscope
+
+# fini

--- a/docker/builder/gdbinit
+++ b/docker/builder/gdbinit
@@ -1,0 +1,13 @@
+# Preload the library
+set environment LD_PRELOAD=/root/appscope/lib/linux/libscope.so
+
+# Allow breakpoints on function not yet found without confirmation
+set breakpoint pending on
+
+# Set this when crashing in a child process
+#set follow-fork-mode child
+
+# Save command history
+set history filename /root/appscope/.gdb_history
+set history save on
+set history remove-duplicates unlimited


### PR DESCRIPTION
This adds a target to the top-level Makefile so we can `make docker-run` to fire up a working environment when we're on a host where this difficult (i.e. my Ubuntu 21.04 machine). Should work on MacOS too.

I've also tweaked the `docker/builder/Dockerfile` to use Ubuntu 18.04 instead of "latest" (which is 20.04 currently).