### PR TITLE
attach command

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -18,7 +18,11 @@ GO_VER_FLAGS=$(shell cd $(DIR) && $(GOPATH)/bin/govvv -flags)
 build: deps
 	cd $(DIR) && GOOS=linux $(GO) build -ldflags="$(GO_VER_FLAGS)" -o $(GOPATH)/bin/scope
 
-## cliall: install dependencies and install the scope binary in appscope/build with compression
+## debug: build, but with gdb support
+debug: deps
+	cd $(DIR) && GOOS=linux $(GO) build -ldflags="$(GO_VER_FLAGS)" -gcflags=all="-N -l" -o $(GOPATH)/bin/scope
+
+## cliall (popular): install dependencies and install the scope binary in appscope/build with compression
 cliall: deps scope compressscope
 
 ## cliclean: remove the binary from appscope/build and your GOPATH/bin directory

--- a/cli/cmd/attach.go
+++ b/cli/cmd/attach.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/criblio/scope/internal"
+	"github.com/spf13/cobra"
+)
+
+// attachCmd represents the run command
+var attachCmd = &cobra.Command{
+	Use:   "attach [flags] [PID]",
+	Short: "Scope an existing PID",
+	Long: `Attach scopes an existing PID. Scope allows for additional arguments to be passed to attach to capture payloads or to up metric 
+verbosity. 
+
+The --*dest flags accept file names like /tmp/scope.log or URLs like file:///tmp/scope.log. They may also
+be set to sockets with tcp://hostname:port, udp://hostname:port, or tls://hostname:port.`,
+	Example: `scope attach 1000
+scope attach --payloads 2000`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		internal.InitConfig()
+		rc.Run(args, true)
+	},
+}
+
+func init() {
+	runCmdFlags(attachCmd, rc)
+	// This may be a bad assumption, if we have any args preceding this it might fail
+	attachCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		internal.InitConfig()
+		attachCmd.Run(cmd, os.Args[2:])
+		return nil
+	})
+	RootCmd.AddCommand(attachCmd)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -15,7 +15,7 @@ var cfgFile string
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "scope",
-	Short: "Command line interface for working with Cribl AppScope.\n\nBy default, calling scope with no subcommands will execute run for args after scope.",
+	Short: "Command line interface for working with Cribl AppScope.\n\nBy default, calling scope with no subcommands will execute the run command.",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -35,7 +35,7 @@ func Execute() {
 			// If we're not a known command, exec ldscope
 			internal.InitConfig()
 			rc := run.Config{}
-			rc.Run(os.Args[1:])
+			rc.Run(os.Args[1:], false)
 		}
 		fmt.Println(err)
 		os.Exit(1)

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -12,7 +12,7 @@ var rc *run.Config = &run.Config{}
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{
-	Use:   "run [flags]",
+	Use:   "run [flags] [command]",
 	Short: "Executes a scoped command",
 	Long: `Run executes a scoped command. By default, calling scope with no subcommands will execute run for args after 
 scope. However, scope allows for additional arguments to be passed to run to capture payloads or to up metric 
@@ -28,7 +28,7 @@ scope run -- curl https://wttr.in/94105`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()
-		rc.Run(args)
+		rc.Run(args, false)
 	},
 }
 

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -55,6 +55,5 @@ func runCmdFlags(cmd *cobra.Command, rc *run.Config) {
 	cmd.Flags().BoolVarP(&rc.Payloads, "payloads", "p", false, "Capture payloads of network transactions")
 	cmd.Flags().StringVar(&rc.Loglevel, "loglevel", "", "Set ldscope log level (debug, warning, info, error, none)")
 	cmd.Flags().StringVarP(&rc.LibraryPath, "librarypath", "l", "", "Set path for dynamic libraries")
-	cmd.Flags().IntVarP(&rc.AttachPID, "attach", "a", 0, "Attach to a currently running process by PID")
 	metricAndEventDestFlags(cmd, rc)
 }

--- a/cli/cmd/watch.go
+++ b/cli/cmd/watch.go
@@ -27,9 +27,9 @@ scope watch --interval=10s -- curl https://wttr.in/94105`,
 		dur, err := time.ParseDuration(interval)
 		util.CheckErrSprintf(err, "error parsing time duration string \"%s\": %v", interval, err)
 		timer := time.Tick(dur)
-		rc.Run(args)
+		rc.Run(args, false)
 		for range timer {
-			rc.Run(args)
+			rc.Run(args, false)
 		}
 	},
 }

--- a/cli/flows/flow_file_test.go
+++ b/cli/flows/flow_file_test.go
@@ -18,9 +18,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"net/http"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,7 +88,6 @@ func (fi bindataFileInfo) IsDir() bool {
 func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
-
 
 type assetFile struct {
 	*bytes.Reader
@@ -448,13 +447,13 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"args.json":                                              argsJson,
-	"events.json":                                            eventsJson,
-	"ldscope.log":                                            ldscopeLog,
-	"metric_format":                                          metric_format,
-	"metrics.json":                                           metricsJson,
-	"scope.log":                                              scopeLog,
-	"scope.yml":                                              scopeYml,
+	"args.json":     argsJson,
+	"events.json":   eventsJson,
+	"ldscope.log":   ldscopeLog,
+	"metric_format": metric_format,
+	"metrics.json":  metricsJson,
+	"scope.log":     scopeLog,
+	"scope.yml":     scopeYml,
 	"payloads/548213_13.226.220.53:443_172.17.0.2:50466.in":  payloads548213_1322622053443_172170250466In,
 	"payloads/548213_13.226.220.53:443_172.17.0.2:50466.out": payloads548213_1322622053443_172170250466Out,
 	"payloads/548213_192.168.65.5:53_0.0.0.0:0.in":           payloads548213_19216865553_00000In,

--- a/cli/history/sessions_test.go
+++ b/cli/history/sessions_test.go
@@ -23,11 +23,11 @@ func TestMain(m *testing.M) {
 	case "run":
 		internal.InitConfig()
 		rc := run.Config{}
-		rc.Run([]string{"/bin/echo", "true"})
+		rc.Run([]string{"/bin/echo", "true"}, false)
 	case "slow":
 		internal.InitConfig()
 		rc := run.Config{}
-		rc.Run([]string{"/bin/sleep", "10"})
+		rc.Run([]string{"/bin/sleep", "10"}, false)
 	default:
 		os.Exit(m.Run())
 	}

--- a/cli/run/run.go
+++ b/cli/run/run.go
@@ -31,14 +31,13 @@ type Config struct {
 	Subprocess    bool
 	Loglevel      string
 	LibraryPath   string
-	AttachPID     int
 
 	now func() time.Time
 	sc  *ScopeConfig
 }
 
 // Run executes a scoped command
-func (rc *Config) Run(args []string) {
+func (rc *Config) Run(args []string, attach bool) {
 	if err := createLdscope(); err != nil {
 		util.ErrAndExit("error creating ldscope: %v", err)
 	}
@@ -54,13 +53,13 @@ func (rc *Config) Run(args []string) {
 		// Prepend "-f" [PATH] to args
 		args = append([]string{"-f", rc.LibraryPath}, args...)
 	}
-	if rc.AttachPID > 0 {
+	if attach {
 		// Validate PID exists
-		if !util.CheckDirExists(fmt.Sprintf("/proc/%d", rc.AttachPID)) {
-			util.ErrAndExit("PID does not exist: \"%d\"", rc.AttachPID)
+		if !util.CheckDirExists(fmt.Sprintf("/proc/%s", args[0])) {
+			util.ErrAndExit("PID does not exist: \"%s\"", args[0])
 		}
-		// Prepend "--attach" [PID] to args
-		args = append([]string{"--attach", strconv.Itoa(rc.AttachPID)}, args...)
+		// Prepend "--attach" to args
+		args = append([]string{"--attach"}, args...)
 	}
 	if !rc.Passthrough {
 		rc.setupWorkDir(args)

--- a/cli/run/run_test.go
+++ b/cli/run/run_test.go
@@ -98,7 +98,7 @@ func TestMain(m *testing.M) {
 	case "runpassthrough":
 		internal.InitConfig()
 		rc := Config{Passthrough: true}
-		rc.Run([]string{"/bin/echo", "true"})
+		rc.Run([]string{"/bin/echo", "true"}, false)
 	case "createWorkDir":
 		internal.InitConfig()
 		rc := Config{}
@@ -106,7 +106,7 @@ func TestMain(m *testing.M) {
 	case "run":
 		internal.InitConfig()
 		rc := Config{}
-		rc.Run([]string{"/bin/echo", "true"})
+		rc.Run([]string{"/bin/echo", "true"}, false)
 	default:
 		os.Exit(m.Run())
 	}
@@ -310,7 +310,7 @@ func TestSubprocess(t *testing.T) {
 	// Test SetupWorkDir, successfully
 	internal.InitConfig()
 	rc := Config{Subprocess: true}
-	rc.Run([]string{"/bin/echo", "true"})
+	rc.Run([]string{"/bin/echo", "true"}, false)
 	files, _ := ioutil.ReadDir(".test/history")
 	matched := false
 	wdbase := fmt.Sprintf("%s_%d", "echo", 1)


### PR DESCRIPTION
- make "attach" a command, not a flag, so that users can call "scope attach [PID]"
- make some of the help messages friendlier
- add a debug command to the makefile