### PR TITLE
fix #319 - Attach to background process is no bueno

### DIFF
--- a/src/inject.c
+++ b/src/inject.c
@@ -179,6 +179,12 @@ inject(pid_t pid, uint64_t dlopenAddr, char *path)
     ptrace(PTRACE_CONT, pid, NULL, NULL);
     waitpid(pid, &status, WUNTRACED);
 
+    // if process has been stopped by SIGSTOP send SIGCONT signal along with PTRACE_CONT call
+    if (WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP) {
+        ptrace(PTRACE_CONT, pid, SIGCONT, NULL);
+        waitpid(pid, &status, WUNTRACED);
+    }
+
     // make sure the target process was stoppend by SIGTRAP triggered by int 0x3
     if (WIFSTOPPED(status) && WSTOPSIG(status) == SIGTRAP) {
 


### PR DESCRIPTION
This is fix that allows injecting scope into a stopped process. Tested with the `top` command (in batch mode):
```
janusz@nuc:~/dev/appscope$ top -b & kill -s SIGSTOP $(pidof top)
[1] 977900

[1]+  Stopped                 top -b
janusz@nuc:~/dev/appscope$ sudo ./bin/linux/ldscopedyn --attach $(pidof top)
Attaching to process 977900
Appscope library injected at 0x561f4faa2f00
janusz@nuc:~/dev/appscope$ fg
top -b
top - 10:52:53 up 5 days,  2:13,  3 users,  load average: 0,29, 0,44, 0,62
Tasks: 328 total,   1 running, 327 sleeping,   0 stopped,   0 zombie
%Cpu(s):  0,8 us,  1,6 sy,  0,0 ni, 97,3 id,  0,0 wa,  0,0 hi,  0,3 si,  0,0 st
MiB Mem :  64036,8 total,  53957,5 free,   1513,1 used,   8566,2 buff/cache
MiB Swap:   2048,0 total,   2048,0 free,      0,0 used.  61664,3 avail Mem
....
```