### PR TITLE
Build scope as a static executable #175

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -16,11 +16,11 @@ GO_VER_FLAGS=$(shell cd $(DIR) && $(GOPATH)/bin/govvv -flags)
 
 ## build (default): install dependencies and install the scope binary in your GOPATH/bin directory
 build: deps
-	cd $(DIR) && GOOS=linux $(GO) build -ldflags="$(GO_VER_FLAGS)" -o $(GOPATH)/bin/scope
+	cd $(DIR) && GOOS=linux CGO_ENABLED=0 $(GO) build -ldflags="$(GO_VER_FLAGS)" -o $(GOPATH)/bin/scope
 
 ## debug: build, but with gdb support
 debug: deps
-	cd $(DIR) && GOOS=linux $(GO) build -ldflags="$(GO_VER_FLAGS)" -gcflags=all="-N -l" -o $(GOPATH)/bin/scope
+	cd $(DIR) && GOOS=linux CGO_ENABLED=0 $(GO) build -ldflags="$(GO_VER_FLAGS)" -gcflags=all="-N -l" -o $(GOPATH)/bin/scope
 
 ## cliall (popular): install dependencies and install the scope binary in appscope/build with compression
 cliall: deps scope compressscope
@@ -49,7 +49,7 @@ run/bundle.go:
 	cd $(DIR) && $(GOPATH)/bin/go-bindata -o run/bundle.go -pkg run build
 
 scope: run/bundle.go
-	cd $(DIR) && GOOS=linux $(GO) build -ldflags="$(GO_VER_FLAGS)" -o $(DIR)../bin/linux/scope
+	cd $(DIR) && GOOS=linux CGO_ENABLED=0 $(GO) build -ldflags="$(GO_VER_FLAGS)" -o $(DIR)../bin/linux/scope
 
 compressscope:
 	upx -9 $(DIR)../bin/linux/scope

--- a/test/testContainers/alpine/Dockerfile
+++ b/test/testContainers/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add go openssl make bash curl autoconf automake libtool openssl-dev rust nodejs ruby python3 php php-openssl apache2 apache2-ssl python3-dev py3-pip libffi-dev cargo && \
+RUN apk add go openssl make file bash curl autoconf automake libtool openssl-dev rust nodejs ruby python3 php php-openssl apache2 apache2-ssl python3-dev py3-pip libffi-dev cargo && \
     go clean -cache
 
 RUN mkdir -p /go

--- a/test/testContainers/alpine/Dockerfile
+++ b/test/testContainers/alpine/Dockerfile
@@ -98,6 +98,7 @@ COPY ./tls/gdbinit /root/.gdbinit
 COPY ./alpine/test_go.sh /go
 COPY ./go/test_go_struct.sh /go
 COPY ./alpine/test_tls.sh /opt/test/bin/test_tls.sh
+COPY ./alpine/test_scope.sh /opt/test/bin/test_scope.sh
 COPY ./alpine/test_all.sh /opt/test/bin/test_all.sh
 
 ENV SCOPE_LOG_LEVEL=error

--- a/test/testContainers/alpine/test_all.sh
+++ b/test/testContainers/alpine/test_all.sh
@@ -10,4 +10,8 @@ export SCOPE_EVENT_DEST=file:///opt/test/logs/events.log
 /opt/test/bin/test_tls.sh
 ERR+=$?
 
+export SCOPE_EVENT_DEST=file:///opt/test/logs/events.log
+/opt/test/bin/test_scope.sh
+ERR+=$?
+
 exit ${ERR}

--- a/test/testContainers/alpine/test_scope.sh
+++ b/test/testContainers/alpine/test_scope.sh
@@ -45,16 +45,41 @@ endtest(){
 
 ################ BEGIN TESTS ################
 
+#
+# static 
+# 
+starttest static
+
+# Assert that scope is built as a static executable in order to be portable to Alpine/musl.
+file /usr/bin/scope | grep "statically linked"
+if [ $? -eq 0 ]; then
+	echo "PASS Scope is a static executable"
+else
+	echo "FAIL Scope is a dynamic executable"
+	ERR+=1
+fi
+
+evaltest
+
+endtest
+
+
+
+
+
 
 #
 # scope
-# The scope executable should be built as a static executable in order to be portable to Alpine/musl.
-# This test validates that the scope executable runs on alpine.
 #
 starttest scope
 
-scope
-ERR+=$?
+# Assert that the scope executable runs on alpine.
+if [ scope ]; then
+	echo "PASS Scope is a static executable"
+else
+	echo "FAIL Scope is a dynamic executable"
+	ERR+=1
+fi
 
 evaltest
 

--- a/test/testContainers/alpine/test_scope.sh
+++ b/test/testContainers/alpine/test_scope.sh
@@ -1,0 +1,81 @@
+#! /bin/bash
+
+DEBUG=0  # set this to 1 to capture the EVT_FILE for each test
+
+FAILED_TEST_LIST=""
+FAILED_TEST_COUNT=0
+
+EVT_FILE="/opt/test/logs/events.log"
+
+starttest(){
+    CURRENT_TEST=$1
+    echo "==============================================="
+    echo "             Testing $CURRENT_TEST             "
+    echo "==============================================="
+    ERR=0
+}
+
+evaltest(){
+    echo "             Evaluating $CURRENT_TEST"
+}
+
+endtest(){
+    if [ $ERR -eq "0" ]; then
+        RESULT=PASSED
+    else
+        RESULT=FAILED
+        FAILED_TEST_LIST+=$CURRENT_TEST
+        FAILED_TEST_LIST+=" "
+        FAILED_TEST_COUNT=$(($FAILED_TEST_COUNT + 1))
+    fi
+
+    echo "*************** $CURRENT_TEST $RESULT ***************"
+    echo ""
+    echo ""
+
+    # copy the EVT_FILE to help with debugging
+    if (( $DEBUG )) || [ $RESULT == "FAILED" ]; then
+        cp $EVT_FILE $EVT_FILE.$CURRENT_TEST
+    fi
+
+    rm $EVT_FILE
+    touch $EVT_FILE
+}
+
+
+################ BEGIN TESTS ################
+
+
+#
+# scope
+#
+starttest scope
+
+scope
+ERR+=$?
+
+evaltest
+
+endtest
+
+
+################ END TESTS ################
+
+
+unset SCOPE_PAYLOAD_ENABLE
+unset SCOPE_PAYLOAD_HEADER
+
+if (( $FAILED_TEST_COUNT == 0 )); then
+    echo ""
+    echo ""
+    echo "*************** ALL TESTS PASSED ***************"
+else
+    echo "*************** SOME TESTS FAILED ***************"
+    echo "Failed tests: $FAILED_TEST_LIST"
+    echo "Refer to these files for more info:"
+    for FAILED_TEST in $FAILED_TEST_LIST; do
+        echo "  $EVT_FILE.$FAILED_TEST"
+    done
+fi
+
+exit ${FAILED_TEST_COUNT}

--- a/test/testContainers/alpine/test_scope.sh
+++ b/test/testContainers/alpine/test_scope.sh
@@ -48,6 +48,8 @@ endtest(){
 
 #
 # scope
+# The scope executable should be built as a static executable in order to be portable to Alpine/musl.
+# This test validates that the scope executable runs on alpine.
 #
 starttest scope
 


### PR DESCRIPTION
- add `CGO_ENABLED=0` to go build targets in the `cli/ Makefile`, to build scope as a static executable
- add an integration test in alpine to ensure that `scope` runs and exits without failure
- add an integration test in alpine to ensure that `scope` is a static executable