### PR TITLE
MKTG-614 Docs: Tabs ++page titles

### DIFF
--- a/website/src/components/MarkDownBlock.js
+++ b/website/src/components/MarkDownBlock.js
@@ -8,7 +8,7 @@ export default function MarkDownBlock({ data }) {
   const post = data.markdownRemark;
   return (
     <>
-      <Helmet title={"AppScope - " + post.frontmatter.title} />
+      <Helmet title={post.frontmatter.title} />
       <Layout>
         <div
           className="code-container"

--- a/website/src/components/MarkDownBlock.js
+++ b/website/src/components/MarkDownBlock.js
@@ -1,17 +1,21 @@
 import React from "react";
 import { graphql } from "gatsby";
+import Helmet from "react-helmet";
 import Layout from "./layouts/documentationLayout";
 import "prismjs/themes/prism.css";
 
 export default function MarkDownBlock({ data }) {
   const post = data.markdownRemark;
   return (
-    <Layout>
-      <div
-        className="code-container"
-        dangerouslySetInnerHTML={{ __html: post.html }}
-      />
-    </Layout>
+    <>
+      <Helmet title={"AppScope - " + post.frontmatter.title} />
+      <Layout>
+        <div
+          className="code-container"
+          dangerouslySetInnerHTML={{ __html: post.html }}
+        />
+      </Layout>
+    </>
   );
 }
 
@@ -19,6 +23,9 @@ export const query = graphql`
   query($slug: String!) {
     markdownRemark(fields: { slug: { eq: $slug } }) {
       html
+      frontmatter {
+        title
+      }
     }
   }
 `;

--- a/website/src/components/MarkDownBlock.js
+++ b/website/src/components/MarkDownBlock.js
@@ -8,7 +8,7 @@ export default function MarkDownBlock({ data }) {
   const post = data.markdownRemark;
   return (
     <>
-      <Helmet title={post.frontmatter.title+ " | AppScope"} />
+      <Helmet title={post.frontmatter.title+ " | AppScope Docs"} />
       <Layout>
         <div
           className="code-container"

--- a/website/src/components/MarkDownBlock.js
+++ b/website/src/components/MarkDownBlock.js
@@ -8,7 +8,7 @@ export default function MarkDownBlock({ data }) {
   const post = data.markdownRemark;
   return (
     <>
-      <Helmet title={post.frontmatter.title} />
+      <Helmet title={post.frontmatter.title+ " | AppScope"} />
       <Layout>
         <div
           className="code-container"

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,5 +1,4 @@
 import * as React from "react";
-import Helmet from "react-helmet";
 import Header from "../components/Header";
 import Hero from "../components/Hero";
 import Highlights from "../components/Highlights";


### PR DESCRIPTION
* Successor to [PR # 326](https://github.com/criblio/appscope/pull/326/).
* Cherry-picked @timothymwilson's 2 commits from "big" [PR # 326](https://github.com/criblio/appscope/pull/326/).
* Restored " | AppScope Docs" branding, at end of tab titles.
* Can we use this branch/PR to experiment with MKTG-654: Swap in AppScope-specific favicon, for docs/Gatsby subsite ONLY?