### PR TITLE
Resolve lint issues in the Cli

### DIFF
--- a/cli/.golangci.yml
+++ b/cli/.golangci.yml
@@ -10,9 +10,9 @@ run:
 linters:
   disable-all: true
   enable:
+    - goconst
     - errcheck
     - deadcode
-    - goconst
     - goimports
     - gosimple
     - ineffassign
@@ -28,3 +28,9 @@ linters-settings:
 
 issues:
   exclude-rules:
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -64,7 +64,7 @@ fmt:
 
 ## lint: lint all Go files
 lint: 
-	golangci-lint run ./...
+	golangci-lint --new-from-rev=HEAD~1 run ./...
 
 ## vet: vet all Go files
 vet: 
@@ -75,7 +75,7 @@ cover:
 	cd $(DIR) && $(GO) tool cover -html=coverage.out -o coverage.html
 
 ## check: format, vet, lint and test all Go files
-check: fmt vet lint test
+check: fmt vet lint clitest
 
 help: Makefile
 	@echo

--- a/cli/bolton/bolton.go
+++ b/cli/bolton/bolton.go
@@ -83,7 +83,7 @@ func logoTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "logo.txt", size: 113020, mode: os.FileMode(511), modTime: time.Unix(1492060977, 0)}
+	info := bindataFileInfo{name: "logo.txt", size: 113020, mode: os.FileMode(0777), modTime: time.Unix(1492060977, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/cli/cmd/dash.go
+++ b/cli/cmd/dash.go
@@ -73,7 +73,7 @@ func readMetrics(workDir string, w *widgets) {
 
 	for m := range in {
 		// Every 10 seconds, flush current values, setting 0 for those values which are not present
-		if m.Time.Sub(lastT) > time.Duration(10*time.Second) {
+		if m.Time.Sub(lastT) > 10*time.Second {
 			mnames := []string{"proc.cpu_perc",
 				"proc.mem",
 				"proc.fd",
@@ -459,13 +459,13 @@ func (w widgets) newGrid(ctx context.Context) ([]container.Option, error) {
 
 func writeSingleValue(s *segmentdisplay.SegmentDisplay, val interface{}) {
 	var chunk *segmentdisplay.TextChunk
-	switch val.(type) {
+	switch res := val.(type) {
 	case int:
-		chunk = segmentdisplay.NewChunk(fmt.Sprintf("%d", val))
+		chunk = segmentdisplay.NewChunk(fmt.Sprintf("%d", res))
 	case float64:
-		chunk = segmentdisplay.NewChunk(fmt.Sprintf("%.0f", val))
+		chunk = segmentdisplay.NewChunk(fmt.Sprintf("%.0f", res))
 	case string:
-		chunk = segmentdisplay.NewChunk(val.(string))
+		chunk = segmentdisplay.NewChunk(res)
 	}
 	if err := s.Write([]*segmentdisplay.TextChunk{chunk}); err != nil {
 		panic(err)

--- a/cli/cmd/events.go
+++ b/cli/cmd/events.go
@@ -147,7 +147,7 @@ scope events -n 1000 -e 'sourcetype!="console" && source.indexOf("cribl.log") ==
 			em.AllEvents = false
 		}
 
-		in := make(chan map[string]interface{}, 0)
+		in := make(chan map[string]interface{})
 		go func() {
 			err := em.Events(file, in)
 			if err != nil && strings.Contains(err.Error(), "Error searching for Offset: EOF") {
@@ -214,9 +214,9 @@ func printEvents(cmd *cobra.Command, in chan map[string]interface{}) {
 			v, err := vm.RunProgram(prog)
 			util.CheckErrSprintf(err, "error evaluating JavaScript expression: %v", err)
 			res := v.Export()
-			switch res.(type) {
+			switch r := res.(type) {
 			case bool:
-				if !res.(bool) {
+				if !r {
 					continue
 				}
 			default:

--- a/cli/cmd/flows.go
+++ b/cli/cmd/flows.go
@@ -172,7 +172,7 @@ scope flows --out 124x3c   # Displays the outbound payload of that flow
 			{Name: "Host Port", Field: "net_host_port"},
 			{Name: "Peer IP", Field: "net_peer_ip"},
 			{Name: "Peer Port", Field: "net_peer_port"},
-			{Name: "Last Sent", Field: "last_sent_time", Transform: func(obj interface{}) string { return util.GetHumanDuration(time.Now().Sub(obj.(time.Time))) }},
+			{Name: "Last Sent", Field: "last_sent_time", Transform: func(obj interface{}) string { return util.GetHumanDuration(time.Since(obj.(time.Time))) }},
 			{Name: "Duration", Field: "duration"},
 		}
 		if termWidth > 145 {

--- a/cli/cmd/history.go
+++ b/cli/cmd/history.go
@@ -89,7 +89,7 @@ cat $(scope hist -d)/args.json   # Outputs contents of args.json in the scope hi
 				{Name: "Command", Field: "cmd"},
 				{Name: "Cmdline", Field: "args", Transform: func(obj interface{}) string { return util.TruncWithElipsis(shellquote.Join(obj.([]string)...), 25) }},
 				{Name: "PID", Field: "pid"},
-				{Name: "Age", Field: "timestamp", Transform: func(obj interface{}) string { return util.GetHumanDuration(time.Now().Sub(time.Unix(0, obj.(int64)))) }},
+				{Name: "Age", Field: "timestamp", Transform: func(obj interface{}) string { return util.GetHumanDuration(time.Since(time.Unix(0, obj.(int64)))) }},
 				{Name: "Duration", Field: "duration", Transform: func(obj interface{}) string { return util.GetHumanDuration(obj.(time.Duration)) }},
 				{Name: "Total Events", Field: "eventCount", Transform: func(obj interface{}) string {
 					if obj.(int) == -1 {

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -40,7 +40,7 @@ var logsCmd = &cobra.Command{
 			util.ErrAndExit("No logs generated")
 		}
 		util.CheckErrSprintf(err, "error seeking last N offset: %v", err)
-		_, err = logFile.Seek(int64(offset), io.SeekStart)
+		_, err = logFile.Seek(offset, io.SeekStart)
 		util.CheckErrSprintf(err, "error seeking log file: %v", err)
 		util.NewlineReader(logFile, util.MatchAlways, func(idx int, Offset int64, b []byte) error {
 			fmt.Printf("%s\n", b)

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -24,11 +24,11 @@ scope prune -a`,
 		del, _ := cmd.Flags().GetInt("delete")
 
 		count := ""
-		if keep == -1 && del == -1 && all == false {
+		if keep == -1 && del == -1 && !all {
 			helpErrAndExit(cmd, "Must specify keep, delete, or all")
-		} else if all != false && keep > -1 {
+		} else if all && keep > -1 {
 			helpErrAndExit(cmd, "Cannot specify keep and all")
-		} else if all != false && del > -1 {
+		} else if all && del > -1 {
 			helpErrAndExit(cmd, "Cannot specify delete and all")
 		} else if keep > -1 && del > -1 {
 			helpErrAndExit(cmd, "Cannot specify delete and keep")
@@ -36,7 +36,7 @@ scope prune -a`,
 			count = fmt.Sprintf("all but %d", keep)
 		} else if del > -1 {
 			count = fmt.Sprintf("the last %d", del)
-		} else if all != false {
+		} else if all {
 			count = "all"
 		}
 		if !force {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -10,8 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cfgFile string
-
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "scope",

--- a/cli/events/events.go
+++ b/cli/events/events.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/criblio/scope/util"
 	"github.com/rs/zerolog/log"
@@ -71,7 +70,7 @@ func (em EventMatch) Events(file io.ReadSeeker, in chan map[string]interface{}) 
 			em.Offset = int64(0)
 		}
 	}
-	_, err = file.Seek(int64(em.Offset), os.SEEK_SET)
+	_, err = file.Seek(em.Offset, io.SeekStart)
 	if err != nil {
 		return fmt.Errorf("error seeking events file: %v", err)
 	}

--- a/cli/flows/flow.go
+++ b/cli/flows/flow.go
@@ -108,7 +108,7 @@ func getFlowFiles(path string) (FlowMap, error) {
 			return err
 		}
 		stat := info.Sys().(*syscall.Stat_t)
-		ctime := time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec))
+		ctime := time.Unix(stat.Ctim.Sec, stat.Ctim.Nsec)
 		flow.StartTime = ctime
 		flow.LastSentTime = info.ModTime()
 		flow.Duration = flow.LastSentTime.Sub(flow.StartTime)

--- a/cli/flows/flow_test.go
+++ b/cli/flows/flow_test.go
@@ -52,6 +52,7 @@ func TestGetFlowFiles(t *testing.T) {
 
 	RestoreAssets("testflows", "")
 	flows, err = getFlowFiles("./testflows/payloads")
+	assert.NoError(t, err)
 	flowList := flows.List()
 	sort.Slice(flowList, func(i, j int) bool { return flowList[i].BytesSent < flowList[j].BytesSent })
 	assert.Equal(t, 548213, flowList[0].Pid)

--- a/cli/main.go
+++ b/cli/main.go
@@ -5,9 +5,6 @@ import (
 	"github.com/criblio/scope/internal"
 )
 
-// GitBranch is set by govvv and represents the branch we were built on
-var GitBranch string
-
 // GitSummary is produced by govvv and stores tag, commit and branch status
 var GitSummary string
 

--- a/cli/metrics/metric.go
+++ b/cli/metrics/metric.go
@@ -97,13 +97,13 @@ func parseJSONMetric(b []byte) (Metric, error) {
 	delete(metricMap, "_time")
 	for k, v := range metricMap {
 		t := MetricTag{Name: k}
-		switch v.(type) {
+		switch res := v.(type) {
 		case float64:
-			t.Value = fmt.Sprintf("%.0f", v.(float64))
+			t.Value = fmt.Sprintf("%.0f", res)
 		case int:
-			t.Value = fmt.Sprintf("%d", v.(int))
+			t.Value = fmt.Sprintf("%d", res)
 		case string:
-			t.Value = v.(string)
+			t.Value = res
 		}
 		m.Tags = append(m.Tags, t)
 	}

--- a/cli/util/newlinereader.go
+++ b/cli/util/newlinereader.go
@@ -99,35 +99,29 @@ func MatchAlways(in string) bool {
 // MatchString searches for a given string
 func MatchString(search string) MatchFunc {
 	return func(in string) bool {
-		if strings.Contains(in, search) {
-			return true
-		}
-		return false
+		return strings.Contains(in, search)
 	}
 }
 
 // MatchField searches for a given JSON key/value
 func MatchField(key string, val interface{}) MatchFunc {
 	strval := ""
-	switch val.(type) {
+	switch res := val.(type) {
 	case float64:
-		strval = strconv.FormatFloat(val.(float64), 'f', -1, 64)
+		strval = strconv.FormatFloat(res, 'f', -1, 64)
 	case float32:
 		strval = strconv.FormatFloat(val.(float64), 'f', -1, 32)
 	case int64, int32, int:
 		strval = fmt.Sprintf("%d", val)
 	case string:
-		strval = fmt.Sprintf("\"%s", val)
+		strval = fmt.Sprintf("\"%s", res)
 	default:
-		strval = fmt.Sprintf("%v", val)
+		strval = fmt.Sprintf("%v", res)
 	}
 	search := fmt.Sprintf("%s\":%s", key, strval)
 	return func(in string) bool {
 		// fmt.Printf("in: %s\n", in)
-		if strings.Contains(in, search) {
-			return true
-		}
-		return false
+		return strings.Contains(in, search)
 	}
 }
 

--- a/cli/util/table.go
+++ b/cli/util/table.go
@@ -117,9 +117,9 @@ func printObj(fields []ObjField, obj interface{}) error {
 			if field.Transform != nil {
 				val = field.Transform(v)
 			} else {
-				switch v.(type) {
+				switch res := v.(type) {
 				case map[string]interface{}:
-					subtable := indentedSubtable(v.(map[string]interface{}), "  ")
+					subtable := indentedSubtable(res, "  ")
 					if len(subtable) > 0 {
 						table.Append([]string{color.GreenString(fmt.Sprintf("%s:", field.Name)), ""})
 						for _, row := range subtable {
@@ -130,7 +130,7 @@ func printObj(fields []ObjField, obj interface{}) error {
 					}
 					continue
 				case []string:
-					rows := v.([]string)
+					rows := res
 					if len(rows) > 0 {
 						table.Append([]string{color.GreenString(fmt.Sprintf("%s:", field.Name)), ""})
 						for _, row := range rows {
@@ -139,18 +139,17 @@ func printObj(fields []ObjField, obj interface{}) error {
 					}
 					continue
 				case float64:
-					val = color.HiBlueString("%v", v)
+					val = color.HiBlueString("%v", res)
 				case float32:
-					val = color.HiBlueString("%v", v)
+					val = color.HiBlueString("%v", res)
 				case int64:
-					val = color.HiBlueString("%v", v)
+					val = color.HiBlueString("%v", res)
 				case int32:
-					val = color.HiBlueString("%v", v)
+					val = color.HiBlueString("%v", res)
 				case int:
-					val = color.HiBlueString("%v", v)
-					val = color.HiBlueString("%v", v)
+					val = color.HiBlueString("%v", res)
 				default:
-					val = fmt.Sprintf("%v", v)
+					val = fmt.Sprintf("%v", res)
 				}
 			}
 			table.Append([]string{color.GreenString("%s:", field.Name), val})
@@ -169,12 +168,12 @@ func indentedSubtable(obj map[string]interface{}, indent string) [][]string {
 	sort.Strings(keys)
 	for _, k := range keys {
 		v := obj[k]
-		switch v.(type) {
+		switch res := v.(type) {
 		case map[string]interface{}:
 			ret = append(ret, []string{fmt.Sprintf("%s%s", indent, k), ""})
-			ret = append(ret, indentedSubtable(v.(map[string]interface{}), fmt.Sprintf("%s  ", indent))...)
+			ret = append(ret, indentedSubtable(res, fmt.Sprintf("%s  ", indent))...)
 		default:
-			ret = append(ret, []string{fmt.Sprintf("%s%s", indent, k), fmt.Sprintf("%v", v)})
+			ret = append(ret, []string{fmt.Sprintf("%s%s", indent, k), fmt.Sprintf("%v", res)})
 		}
 	}
 	return ret

--- a/cli/util/table_test.go
+++ b/cli/util/table_test.go
@@ -36,7 +36,7 @@ func TestPrintObjWithMap(t *testing.T) {
 
 	// os.Stdout.Write(buf.Bytes())
 
-	rows := strings.Split(string(buf.Bytes()), "\n")
+	rows := strings.Split(buf.String(), "\n")
 
 	// First row contains capital Field 1 and value1
 	assert.True(t, strings.Contains(rows[0], "Field 1"))
@@ -101,7 +101,7 @@ func TestPrintObjWithStruct(t *testing.T) {
 
 	// os.Stdout.Write(buf.Bytes())
 
-	rows := strings.Split(string(buf.Bytes()), "\n")
+	rows := strings.Split(buf.String(), "\n")
 
 	// First row contains capital Field 1 and value1
 	assert.True(t, strings.Contains(rows[0], "Field 1"))
@@ -163,7 +163,7 @@ func TestPrintObjSliceMap(t *testing.T) {
 
 	// os.Stdout.Write(buf.Bytes())
 
-	rows := strings.Split(string(buf.Bytes()), "\n")
+	rows := strings.Split(buf.String(), "\n")
 
 	// First row contains headers
 	assert.True(t, strings.Contains(rows[0], "FIELD 1"))

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -255,7 +255,7 @@ func EncodeOffset(offset int64) string {
 	}
 	for offset > 0 {
 		ch := codes[offset%64]
-		str = append(str, byte(ch))
+		str = append(str, ch)
 		offset /= 64
 	}
 	return string(str)


### PR DESCRIPTION
Changes in this PR fix a majority of lint issues generated by the `golangci-lint` linter.
Now that these changes have been made to historical work, I have added the argument `--new-from-rev=HEAD~1` to the linter, so that we will only be warned about new lint issues.