### PR TITLE
Bugathon dockerfile

### DIFF
--- a/test/testContainers/bugathon/Dockerfile
+++ b/test/testContainers/bugathon/Dockerfile
@@ -1,1 +1,1 @@
-FROM cribl/scope:0.7.0-rc7
+FROM cribl/scope:latest

--- a/test/testContainers/bugathon/Dockerfile
+++ b/test/testContainers/bugathon/Dockerfile
@@ -1,0 +1,1 @@
+FROM cribl/scope:0.7.0-rc7

--- a/test/testContainers/bugathon/README.md
+++ b/test/testContainers/bugathon/README.md
@@ -1,0 +1,34 @@
+# AppScope Bugathon
+
+The included Dockerfile provides all tools necessary to run scope and perform bugathon testing.
+
+## Build and Run
+
+You must have docker installed in order to build and run the scope bugathon container.
+
+From this directory, run:
+
+```bash
+docker build -t scope-bugathon .
+docker run -it scope-bugathon
+```
+
+The scope product is installed in `/usr/local/bin`. You can start exploring your applications using the scope executable: Enter `scope` with no arguments to see help, or use `scope --help`.
+
+To see detailed help for a given argument, use scope help <argument>.
+
+## Additional Shells
+
+You may connect to the docker container in another terminal window with:
+
+```bash
+docker exec -it <Container ID> /bin/bash
+```
+
+...where the Container ID can be found in:
+
+```bash
+docker ps
+```
+
+

--- a/test/testContainers/bugathon/README.md
+++ b/test/testContainers/bugathon/README.md
@@ -2,6 +2,19 @@
 
 The included Dockerfile provides all tools necessary to run scope and perform bugathon testing.
 
+## Download
+
+```bash
+git clone git@github.com:criblio/appscope.git
+cd appscope/test/testContainers/bugathon
+```
+-or if you already have it locally-
+```bash
+git checkout master
+git pull
+cd test/testContainers/bugathon
+```
+
 ## Build and Run
 
 You must have docker installed in order to build and run the scope bugathon container.


### PR DESCRIPTION
- Add a dockerfile to allow bugathon testers to work inside a container that includes scope, and all test dependencies
- Add a README to describe usage