### PR TITLE
Fix default value bug in scope prune

### DIFF
--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -24,17 +24,17 @@ scope prune -a`,
 		del, _ := cmd.Flags().GetInt("delete")
 
 		count := ""
-		if keep == -1 && del == -1 && !all {
+		if keep == 0 && del == 0 && !all {
 			helpErrAndExit(cmd, "Must specify keep, delete, or all")
-		} else if all && keep > -1 {
+		} else if all && keep > 0 {
 			helpErrAndExit(cmd, "Cannot specify keep and all")
-		} else if all && del > -1 {
+		} else if all && del > 0 {
 			helpErrAndExit(cmd, "Cannot specify delete and all")
-		} else if keep > -1 && del > -1 {
+		} else if keep > 0 && del > 0 {
 			helpErrAndExit(cmd, "Cannot specify delete and keep")
-		} else if keep > -1 {
+		} else if keep > 0 {
 			count = fmt.Sprintf("all but %d", keep)
-		} else if del > -1 {
+		} else if del > 0 {
 			count = fmt.Sprintf("the last %d", del)
 		} else if all {
 			count = "all"
@@ -54,12 +54,12 @@ scope prune -a`,
 		if all {
 			countD = len(sessions)
 			sessions.Remove()
-		} else if keep > -1 {
+		} else if keep > 0 {
 			toRemove := len(sessions) - keep
 			removeS := sessions.First(toRemove)
 			countD = len(removeS)
 			removeS.Remove()
-		} else if del > -1 {
+		} else if del > 0 {
 			removeS := sessions.Last(del)
 			countD = len(removeS)
 			removeS.Remove()
@@ -71,8 +71,8 @@ scope prune -a`,
 
 func init() {
 	RootCmd.AddCommand(pruneCmd)
-	pruneCmd.Flags().IntP("keep", "k", -1, "Keep last <keep> sessions")
-	pruneCmd.Flags().IntP("delete", "d", -1, "Delete last <delete> sessions")
+	pruneCmd.Flags().IntP("keep", "k", 0, "Keep last <keep> sessions")
+	pruneCmd.Flags().IntP("delete", "d", 0, "Delete last <delete> sessions")
 	pruneCmd.Flags().BoolP("all", "a", false, "Delete all sessions")
 	pruneCmd.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
 }


### PR DESCRIPTION
Currently there is a bug where the default for `scope prune -d` and `scope prune -k` is set to -1. This is not the intended user default. This fixes that.
- Change the default flag values to 0, so no default.
- Change the tests for keep and delete to look for >0 instead of >-1