### PR TITLE
Add cribl no breaker option

### DIFF
--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -47,6 +47,7 @@ func metricAndEventDestFlags(cmd *cobra.Command, rc *run.Config) {
 	cmd.Flags().StringVar(&rc.MetricsFormat, "metricformat", "ndjson", "Set format of metrics output (statsd|ndjson)")
 	cmd.Flags().StringVarP(&rc.MetricsDest, "metricdest", "m", "", "Set destination for metrics (host:port defaults to tls://)")
 	cmd.Flags().StringVarP(&rc.EventsDest, "eventdest", "e", "", "Set destination for events (host:port defaults to tls://)")
+	cmd.Flags().BoolVarP(&rc.NoBreaker, "nobreaker", "n", false, "Set Cribl to not break streams into events.")
 }
 
 func runCmdFlags(cmd *cobra.Command, rc *run.Config) {

--- a/cli/run/attach.go
+++ b/cli/run/attach.go
@@ -59,7 +59,7 @@ func (rc *Config) Attach(args []string) {
 	// directory and has a command directory configured in that directory.
 	env := os.Environ()
 	if rc.NoBreaker {
-		env = append(env, "CRIBL_NO_BREAKER=true")
+		env = append(env, "SCOPE_CRIBL_NO_BREAKER=true")
 	}
 	if !rc.Passthrough {
 		rc.setupWorkDir(args, true)

--- a/cli/run/attach.go
+++ b/cli/run/attach.go
@@ -58,6 +58,9 @@ func (rc *Config) Attach(args []string) {
 	// Directory contains scope.yml which is configured to output to that
 	// directory and has a command directory configured in that directory.
 	env := os.Environ()
+	if rc.NoBreaker {
+		env = append(env, "CRIBL_NO_BREAKER=true")
+	}
 	if !rc.Passthrough {
 		rc.setupWorkDir(args, true)
 		env = append(env, "SCOPE_CONF_PATH="+filepath.Join(rc.WorkDir, "scope.yml"))

--- a/cli/run/run.go
+++ b/cli/run/run.go
@@ -24,6 +24,7 @@ type Config struct {
 	Subprocess    bool
 	Loglevel      string
 	LibraryPath   string
+	NoBreaker     bool
 
 	now func() time.Time
 	sc  *ScopeConfig
@@ -38,6 +39,9 @@ func (rc *Config) Run(args []string) {
 	// Directory contains scope.yml which is configured to output to that
 	// directory and has a command directory configured in that directory.
 	env := os.Environ()
+	if rc.NoBreaker {
+		env = append(env, "CRIBL_NO_BREAKER=true")
+	}
 	if !rc.Passthrough {
 		rc.setupWorkDir(args, false)
 		env = append(env, "SCOPE_CONF_PATH="+filepath.Join(rc.WorkDir, "scope.yml"))

--- a/cli/run/run.go
+++ b/cli/run/run.go
@@ -40,7 +40,7 @@ func (rc *Config) Run(args []string) {
 	// directory and has a command directory configured in that directory.
 	env := os.Environ()
 	if rc.NoBreaker {
-		env = append(env, "CRIBL_NO_BREAKER=true")
+		env = append(env, "SCOPE_CRIBL_NO_BREAKER=true")
 	}
 	if !rc.Passthrough {
 		rc.setupWorkDir(args, false)

--- a/src/cfgutils.c
+++ b/src/cfgutils.c
@@ -399,150 +399,156 @@ processEnvStyleInput(config_t *cfg, const char *env_line)
 
     if (!cfg || !env_line) return;
 
-    char* env_ptr, *value;
-    if (!(env_ptr = strchr(env_line, '='))) return;
-    if (!(value = doEnvVariableSubstitution(&env_ptr[1]))) return;
+    char *env_name = NULL;
+    char *value = NULL;
+    char *env_ptr;
+    env_name = strdup(env_line);
+    if (!env_name) goto cleanup;
+    if (!(env_ptr = strchr(env_name, '='))) goto cleanup;
+    *env_ptr = '\0'; // Delimiting env_name
+    if (!(value = doEnvVariableSubstitution(&env_ptr[1]))) goto cleanup;
 
-    if (startsWith(env_line, "SCOPE_METRIC_ENABLE")) {
+    if (!strcmp(env_name, "SCOPE_METRIC_ENABLE")) {
         cfgMtcEnableSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_METRIC_FORMAT")) {
+    } else if (!strcmp(env_name, "SCOPE_METRIC_FORMAT")) {
         cfgMtcFormatSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_STATSD_PREFIX")) {
+    } else if (!strcmp(env_name, "SCOPE_STATSD_PREFIX")) {
         cfgMtcStatsDPrefixSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_STATSD_MAXLEN")) {
+    } else if (!strcmp(env_name, "SCOPE_STATSD_MAXLEN")) {
         cfgMtcStatsDMaxLenSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_SUMMARY_PERIOD")) {
+    } else if (!strcmp(env_name, "SCOPE_SUMMARY_PERIOD")) {
         cfgMtcPeriodSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_CMD_DIR")) {
+    } else if (!strcmp(env_name, "SCOPE_CMD_DIR")) {
         cfgCmdDirSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_CONFIG_EVENT")) {
+    } else if (!strcmp(env_name, "SCOPE_CONFIG_EVENT")) {
         cfgConfigEventSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_METRIC_VERBOSITY")) {
+    } else if (!strcmp(env_name, "SCOPE_METRIC_VERBOSITY")) {
         cfgMtcVerbositySetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_LOG_LEVEL")) {
+    } else if (!strcmp(env_name, "SCOPE_LOG_LEVEL")) {
         cfgLogLevelSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_METRIC_DEST")) {
+    } else if (!strcmp(env_name, "SCOPE_METRIC_DEST")) {
         cfgTransportSetFromStr(cfg, CFG_MTC, value);
-    } else if (startsWith(env_line, "SCOPE_METRIC_TLS_ENABLE")) {
+    } else if (!strcmp(env_name, "SCOPE_METRIC_TLS_ENABLE")) {
         cfgTransportTlsEnableSetFromStr(cfg, CFG_MTC, value);
-    } else if (startsWith(env_line, "SCOPE_METRIC_TLS_VALIDATE_SERVER")) {
+    } else if (!strcmp(env_name, "SCOPE_METRIC_TLS_VALIDATE_SERVER")) {
         cfgTransportTlsValidateServerSetFromStr(cfg, CFG_MTC, value);
-    } else if (startsWith(env_line, "SCOPE_METRIC_TLS_CA_CERT_PATH")) {
+    } else if (!strcmp(env_name, "SCOPE_METRIC_TLS_CA_CERT_PATH")) {
         cfgTransportTlsCACertPathSetFromStr(cfg, CFG_MTC, value);
-    } else if (startsWith(env_line, "SCOPE_LOG_DEST")) {
+    } else if (!strcmp(env_name, "SCOPE_LOG_DEST")) {
         cfgTransportSetFromStr(cfg, CFG_LOG, value);
-    } else if (startsWith(env_line, "SCOPE_LOG_TLS_ENABLE")) {
+    } else if (!strcmp(env_name, "SCOPE_LOG_TLS_ENABLE")) {
         cfgTransportTlsEnableSetFromStr(cfg, CFG_LOG, value);
-    } else if (startsWith(env_line, "SCOPE_LOG_TLS_VALIDATE_SERVER")) {
+    } else if (!strcmp(env_name, "SCOPE_LOG_TLS_VALIDATE_SERVER")) {
         cfgTransportTlsValidateServerSetFromStr(cfg, CFG_LOG, value);
-    } else if (startsWith(env_line, "SCOPE_LOG_TLS_CA_CERT_PATH")) {
+    } else if (!strcmp(env_name, "SCOPE_LOG_TLS_CA_CERT_PATH")) {
         cfgTransportTlsCACertPathSetFromStr(cfg, CFG_LOG, value);
-    } else if (startsWith(env_line, "SCOPE_TAG_")) {
-        processCustomTag(cfg, env_line, value);
-    } else if (startsWith(env_line, "SCOPE_PAYLOAD_ENABLE")) {
+    } else if (!strcmp(env_name, "SCOPE_PAYLOAD_ENABLE")) {
         cfgPayEnableSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_PAYLOAD_DIR")) {
+    } else if (!strcmp(env_name, "SCOPE_PAYLOAD_DIR")) {
         cfgPayDirSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_CMD_DBG_PATH")) {
+    } else if (!strcmp(env_name, "SCOPE_CMD_DBG_PATH")) {
         processCmdDebug(value);
-    } else if (startsWith(env_line, "SCOPE_CONF_RELOAD")) {
+    } else if (!strcmp(env_name, "SCOPE_CONF_RELOAD")) {
         processReloadConfig(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_DEST")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_DEST")) {
         cfgTransportSetFromStr(cfg, CFG_CTL, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_TLS_ENABLE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_TLS_ENABLE")) {
         cfgTransportTlsEnableSetFromStr(cfg, CFG_CTL, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_TLS_VALIDATE_SERVER")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_TLS_VALIDATE_SERVER")) {
         cfgTransportTlsValidateServerSetFromStr(cfg, CFG_CTL, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_TLS_CA_CERT_PATH")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_TLS_CA_CERT_PATH")) {
         cfgTransportTlsCACertPathSetFromStr(cfg, CFG_CTL, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_ENABLE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_ENABLE")) {
         cfgEvtEnableSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_FORMAT")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_FORMAT")) {
         cfgEventFormatSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_MAXEPS")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_MAXEPS")) {
         cfgEvtRateLimitSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_ENHANCE_FS")) {
+    } else if (!strcmp(env_name, "SCOPE_ENHANCE_FS")) {
         cfgEnhanceFsSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_LOGFILE_NAME")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_LOGFILE_NAME")) {
         cfgEvtFormatNameFilterSetFromStr(cfg, CFG_SRC_FILE, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_CONSOLE_NAME")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_CONSOLE_NAME")) {
         cfgEvtFormatNameFilterSetFromStr(cfg, CFG_SRC_CONSOLE, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_SYSLOG_NAME")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_SYSLOG_NAME")) {
         cfgEvtFormatNameFilterSetFromStr(cfg, CFG_SRC_SYSLOG, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_METRIC_NAME")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_METRIC_NAME")) {
         cfgEvtFormatNameFilterSetFromStr(cfg, CFG_SRC_METRIC, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_HTTP_NAME")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_HTTP_NAME")) {
         cfgEvtFormatNameFilterSetFromStr(cfg, CFG_SRC_HTTP, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_HTTP_HEADER")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_HTTP_HEADER")) {
         cfgEvtFormatHeaderSetFromStr(cfg, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_NET_NAME")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_NET_NAME")) {
         cfgEvtFormatNameFilterSetFromStr(cfg, CFG_SRC_NET, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_FS_NAME")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_FS_NAME")) {
         cfgEvtFormatNameFilterSetFromStr(cfg, CFG_SRC_FS, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_DNS_NAME")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_DNS_NAME")) {
         cfgEvtFormatNameFilterSetFromStr(cfg, CFG_SRC_DNS, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_LOGFILE_FIELD")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_LOGFILE_FIELD")) {
         cfgEvtFormatFieldFilterSetFromStr(cfg, CFG_SRC_FILE, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_CONSOLE_FIELD")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_CONSOLE_FIELD")) {
         cfgEvtFormatFieldFilterSetFromStr(cfg, CFG_SRC_CONSOLE, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_SYSLOG_FIELD")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_SYSLOG_FIELD")) {
         cfgEvtFormatFieldFilterSetFromStr(cfg, CFG_SRC_SYSLOG, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_METRIC_FIELD")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_METRIC_FIELD")) {
         cfgEvtFormatFieldFilterSetFromStr(cfg, CFG_SRC_METRIC, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_HTTP_FIELD")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_HTTP_FIELD")) {
         cfgEvtFormatFieldFilterSetFromStr(cfg, CFG_SRC_HTTP, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_NET_FIELD")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_NET_FIELD")) {
         cfgEvtFormatFieldFilterSetFromStr(cfg, CFG_SRC_NET, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_FS_FIELD")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_FS_FIELD")) {
         cfgEvtFormatFieldFilterSetFromStr(cfg, CFG_SRC_FS, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_DNS_FIELD")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_DNS_FIELD")) {
         cfgEvtFormatFieldFilterSetFromStr(cfg, CFG_SRC_DNS, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_LOGFILE_VALUE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_LOGFILE_VALUE")) {
         cfgEvtFormatValueFilterSetFromStr(cfg, CFG_SRC_FILE, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_CONSOLE_VALUE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_CONSOLE_VALUE")) {
         cfgEvtFormatValueFilterSetFromStr(cfg, CFG_SRC_CONSOLE, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_SYSLOG_VALUE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_SYSLOG_VALUE")) {
         cfgEvtFormatValueFilterSetFromStr(cfg, CFG_SRC_SYSLOG, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_METRIC_VALUE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_METRIC_VALUE")) {
         cfgEvtFormatValueFilterSetFromStr(cfg, CFG_SRC_METRIC, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_HTTP_VALUE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_HTTP_VALUE")) {
         cfgEvtFormatValueFilterSetFromStr(cfg, CFG_SRC_HTTP, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_NET_VALUE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_NET_VALUE")) {
         cfgEvtFormatValueFilterSetFromStr(cfg, CFG_SRC_NET, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_FS_VALUE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_FS_VALUE")) {
         cfgEvtFormatValueFilterSetFromStr(cfg, CFG_SRC_FS, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_DNS_VALUE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_DNS_VALUE")) {
         cfgEvtFormatValueFilterSetFromStr(cfg, CFG_SRC_DNS, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_LOGFILE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_LOGFILE")) {
         cfgEvtFormatSourceEnabledSetFromStr(cfg, CFG_SRC_FILE, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_CONSOLE")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_CONSOLE")) {
         cfgEvtFormatSourceEnabledSetFromStr(cfg, CFG_SRC_CONSOLE, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_SYSLOG")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_SYSLOG")) {
         cfgEvtFormatSourceEnabledSetFromStr(cfg, CFG_SRC_SYSLOG, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_METRIC")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_METRIC")) {
         cfgEvtFormatSourceEnabledSetFromStr(cfg, CFG_SRC_METRIC, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_HTTP")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_HTTP")) {
         cfgEvtFormatSourceEnabledSetFromStr(cfg, CFG_SRC_HTTP, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_NET")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_NET")) {
         cfgEvtFormatSourceEnabledSetFromStr(cfg, CFG_SRC_NET, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_FS")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_FS")) {
         cfgEvtFormatSourceEnabledSetFromStr(cfg, CFG_SRC_FS, value);
-    } else if (startsWith(env_line, "SCOPE_EVENT_DNS")) {
+    } else if (!strcmp(env_name, "SCOPE_EVENT_DNS")) {
         cfgEvtFormatSourceEnabledSetFromStr(cfg, CFG_SRC_DNS, value);
-    } else if (startsWith(env_line, "SCOPE_CRIBL_TLS_ENABLE")) {
+    } else if (!strcmp(env_name, "SCOPE_CRIBL_TLS_ENABLE")) {
         cfgTransportTlsEnableSetFromStr(cfg, CFG_LS, value);
-    } else if (startsWith(env_line, "SCOPE_CRIBL_TLS_VALIDATE_SERVER")) {
+    } else if (!strcmp(env_name, "SCOPE_CRIBL_TLS_VALIDATE_SERVER")) {
         cfgTransportTlsValidateServerSetFromStr(cfg, CFG_LS, value);
-    } else if (startsWith(env_line, "SCOPE_CRIBL_TLS_CA_CERT_PATH")) {
+    } else if (!strcmp(env_name, "SCOPE_CRIBL_TLS_CA_CERT_PATH")) {
         cfgTransportTlsCACertPathSetFromStr(cfg, CFG_LS, value);
-    } else if (startsWith(env_line, "SCOPE_CRIBL_CLOUD")) {
+    } else if (!strcmp(env_name, "SCOPE_CRIBL_CLOUD")) {
         cfgCriblEnableSetFromStrEnv(cfg, CFG_LOGSTREAM_CLOUD, value);
-    } else if (startsWith(env_line, "SCOPE_CRIBL")) {
+    } else if (!strcmp(env_name, "SCOPE_CRIBL")) {
         cfgCriblEnableSetFromStrEnv(cfg, CFG_LOGSTREAM, value);
+    } else if (startsWith(env_name, "SCOPE_TAG_")) {
+        processCustomTag(cfg, env_line, value);
     }
 
-
-    free(value);
+cleanup:
+    if (value) free(value);
+    if (env_name) free(env_name);
 }
 
 

--- a/src/com.c
+++ b/src/com.c
@@ -258,9 +258,10 @@ msgStart(proc_id_t *proc, config_t *cfg, which_transport_t who)
         if (!cJSON_AddStringToObjLN(json_root, "format", "scope")) goto err;
     } else {
         if (!cJSON_AddStringToObjLN(json_root, "format", "ndjson")) goto err;
-	if (checkEnv("SCOPE_CRIBL_NO_BREAKER", "true")) {
-		if (!cJSON_AddStringToObjLN(json_root, "breaker", "Cribl - Do Not Break Ruleset")) goto err;
-	}
+        if (checkEnv("SCOPE_CRIBL_NO_BREAKER", "true")) {
+                if (!cJSON_AddStringToObjLN(json_root, "breaker",
+                                    "Cribl - Do Not Break Ruleset")) goto err;
+        }
     }
 
     if (!(json_info = cJSON_AddObjectToObjLN(json_root, "info"))) goto err;

--- a/src/com.c
+++ b/src/com.c
@@ -3,6 +3,7 @@
 
 #include "com.h"
 #include "dbg.h"
+#include "utils.h"
 
 bool g_need_stack_expand = FALSE;
 unsigned g_sendprocessstart = 0;
@@ -257,6 +258,9 @@ msgStart(proc_id_t *proc, config_t *cfg, which_transport_t who)
         if (!cJSON_AddStringToObjLN(json_root, "format", "scope")) goto err;
     } else {
         if (!cJSON_AddStringToObjLN(json_root, "format", "ndjson")) goto err;
+	if (checkEnv("SCOPE_CRIBL_NO_BREAKER", "true")) {
+		if (!cJSON_AddStringToObjLN(json_root, "breaker", "Cribl - Do Not Break Ruleset")) goto err;
+	}
     }
 
     if (!(json_info = cJSON_AddObjectToObjLN(json_root, "info"))) goto err;

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -902,16 +902,13 @@ main(int argc, char **argv, char **env)
         }
 
         // add the env vars we want in the library
-        char *env;
         dprintf(fd, "SCOPE_LIB_PATH=%s\n", libdirGetLibrary());
-        if ((env = getenv("SCOPE_EXEC_PATH"))) {
-            dprintf(fd, "SCOPE_EXEC_PATH=%s\n", env);
-        }
-        if ((env = getenv("SCOPE_CONF_PATH"))) {
-            dprintf(fd, "SCOPE_CONF_PATH=%s\n", env);
-        }
-        if ((env = getenv("SCOPE_HOME"))) {
-            dprintf(fd, "SCOPE_HOME=%s\n", env);
+
+        int i;
+        for (i = 0; environ[i]; i++) {
+            if (strlen(environ[i]) > 6 && strncmp(environ[i], "SCOPE_", 6) == 0) {
+                dprintf(fd, "%s\n", environ[i]);
+            }
         }
 
         // done

--- a/src/scopetypes.h
+++ b/src/scopetypes.h
@@ -164,6 +164,7 @@ typedef unsigned int bool;
 //    SCOPE_EXEC_TYPE                internal use only
 //    SCOPE_EXECVE                   "false" disables scope of child procs
 //    SCOPE_EXEC_PATH                specifies path to ldscope executable
+//    SCOPE_CRIBL_NO_BREAKER         adds breaker property to process start message
 //    SCOPE_LIB_PATH                 specifies path to libscope.so library
 //    SCOPE_GO_STRUCT_PATH           for internal testing
 //    SCOPE_HTTP_SERIALIZE_ENABLE    "true" adds guard for race condition


### PR DESCRIPTION
- Allow the user to set a flag `-n` or `--nobreaker` that will set an environment variable `SCOPE_CRIBL_NO_BREAKER` to `true` when starting scope with run or attach.
- Add `"breaker": "Cribl - Do Not Break Ruleset"` to the process start message when `SCOPE_CRIBL_NO_BREAKER` is true.
- Improve the way environment variables are read in ProcessEnvStyleInput by using `strcmp()` on the environment name in most cases, instead of "`startsWith()`.

Now, when the user sets `-n` in scope, the process start message looks as follows:
`{"format":"ndjson","breaker":"Cribl - Do Not Break Ruleset","info":{"process":...`