### PR TITLE
Only deploy website on changed

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
       - staging
+    paths:
+      - 'website/**'
 jobs:
   website:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should skip the website workflow when we commit to master without any changes in the `website/` content. Currently, we're redeploying the website when we commit anything to `master`.