### PR TITLE
run `make docker-build` as non-root user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# List stuff never needed when building container images from this directory
+**/core
+.cache/
+coverage/
+go/
+test/testContainers
+website/

--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,34 @@
-**/*.swp
+# Compiler Results
 *.o
 *.gcno
-.gdb_history
+*.pyc
+
+# Logs
 scope.log
-coverage/
-# JetBrains specific directory
+
+# Editor Temps
+**/*.swp
 .idea
 .DS_Store
-*.pyc
+
+# Test Leftovers
 venv
+coverage/
 test/selfinterpose/
+test/testContainers/logs
+**/*.gcda
+**/*.gcov
+newdir/
+testtempdir1/
+testtempdir2/
+
+# Contribs
 contrib/funchook/build/
 contrib/pcre2/build
 contrib/openssl/
 
-test/testContainers/logs
-
-#website
+# Website Temps
 website/.env
 website/public/
 website/node_modules/
 website/.cache/
-

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ clean:
 	$(MAKE) -f os/linux/Makefile core$@
 	$(MAKE) -f cli/Makefile cli$@
 	$(MAKE) -C contrib $@
+	@$(RM) -rf newdir testtempdir1 testtempdir2 coverage go .bash_history .cache .viminfo scope.log *.gcda
 
 test:
 	$(MAKE) -f os/linux/Makefile core$@
@@ -37,6 +38,7 @@ endif
 docker-build: TAG ?= "appscope-builder"
 docker-build: DOCKER ?= $(shell which docker 2>/dev/null)
 docker-build: BUILD_ARGS ?=
+docker-build: CMD ?= make all test
 docker-build:
 	@[ -x "$(DOCKER)" ] || \
 		( echo >&2 "error: Please install Docker first."; exit 1)
@@ -45,16 +47,16 @@ docker-build:
 		-f docker/builder/Dockerfile \
 		$(BUILD_ARGS) .
 	$(DOCKER) run -it --rm \
-		-v "$(shell pwd):/root/appscope" \
+		-v "$(shell pwd):/home/builder/appscope" \
+		-u $(shell id -u):$(shell id -g) \
 		--entrypoint /bin/bash \
 		$(TAG) \
-		-c "make all test"
+		-c "$(CMD)"
 
 # Annoyingly not DRY
 .PHONY: docker-run
 docker-run: TAG?="appscope-builder"
 docker-run: DOCKER?=$(shell which docker 2>/dev/null)
-docker-run: PWD:=$(shell pwd)
 docker-run: BUILD_ARGS ?=
 docker-run:
 	@[ -x "$(DOCKER)" ] || \
@@ -64,14 +66,13 @@ docker-run:
 		-f docker/builder/Dockerfile \
 		$(BUILD_ARGS) .
 	@$(DOCKER) run -it --rm \
-		-v "$(shell pwd):/root/appscope" \
-		-e SCOPE_LOG_DEST=file:///root/appscope/scope.log \
+		-v "$(shell pwd):/home/builder/appscope" \
+		-u $(shell id -u):$(shell id -g) \
 		$(TAG)
 
 .PHONY: docker-run-alpine
 docker-run-alpine: TAG?="appscope-builder-alpine"
 docker-run-alpine: DOCKER?=$(shell which docker 2>/dev/null)
-docker-run-alpine: PWD:=$(shell pwd)
 docker-run-alpine: BUILD_ARGS ?=
 docker-run-alpine:
 	@[ -x "$(DOCKER)" ] || \
@@ -81,14 +82,6 @@ docker-run-alpine:
 		-f docker/builder/Dockerfile.alpine \
 		$(BUILD_ARGS) .
 	@$(DOCKER) run -it --rm \
-		-v "$(shell pwd):/root/appscope" \
-		-e SCOPE_LOG_DEST=file:///root/appscope/scope.log \
+		-v "$(shell pwd):/home/builder/appscope" \
+		-u $(shell id -u):$(shell id -g) \
 		$(TAG)
-
-# Using the docker-* targets above, many files here are created as root in the
-# container and end up inaccessible here. Added this here after getting bit
-# repeatedly.
-.PHONY: chown
-chown:
-	sudo chown -R $(USER):$(USER) .
-

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ docker-run:
 	@$(DOCKER) run -it --rm \
 		-v "$(shell pwd):/home/builder/appscope" \
 		-u $(shell id -u):$(shell id -g) \
-		$(TAG)
+		$(TAG) bash --login
 
 .PHONY: docker-run-alpine
 docker-run-alpine: TAG?="appscope-builder-alpine"
@@ -84,4 +84,4 @@ docker-run-alpine:
 	@$(DOCKER) run -it --rm \
 		-v "$(shell pwd):/home/builder/appscope" \
 		-u $(shell id -u):$(shell id -g) \
-		$(TAG)
+		$(TAG) bash --login

--- a/cli/util/proc_test.go
+++ b/cli/util/proc_test.go
@@ -33,10 +33,14 @@ func TestProcessesByName(t *testing.T) {
 // Assertions:
 // - The expected user value is returned
 func TestPidUser(t *testing.T) {
+	/*
+	 * Disabled since we run as "builder" for `make docker-build`.
+	 * 
 	// Process 1 owner
 	pid := 1
 	result := PidUser(pid)
 	assert.Equal(t, "root", result)
+	*/
 
 	// Current process owner
 	currentUser, err := user.Current()
@@ -44,8 +48,8 @@ func TestPidUser(t *testing.T) {
 		t.Fatal(err)
 	}
 	username := currentUser.Username
-	pid = os.Getpid()
-	result = PidUser(pid)
+	pid := os.Getpid()
+	result := PidUser(pid)
 	assert.Equal(t, username, result)
 }
 

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -24,6 +24,7 @@ ENV GOLANG=$GOLANG
 # These are needed to bypass the prompts when tzdata is installed.
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV TZ="America/New_York"
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # ---
 # Install packages. Note extra PPA for Go.
@@ -39,19 +40,29 @@ RUN apt-get update && \
     add-apt-repository ppa:longsleep/golang-backports && \
     apt-get update && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 52B59B1571A79DBC054901C0F6BC817356A3D45E && \
-    apt-get install -y $GOLANG git autoconf automake libtool cmake lcov upx make gdb vim emacs strace lsof && \
+    apt-get install -y $GOLANG git autoconf automake libtool cmake lcov upx make gdb vim emacs strace lsof tzdata && \
+    dpkg-reconfigure --frontend noninteractive tzdata && \
     apt-get clean
 
-# ---
-# Extra setup for use with `make docker-run`
-#
-COPY ./docker/builder/gdbinit /root/.gdbinit
+RUN useradd -d /home/builder -m builder && \
+    \
+    echo "alias ll='ls -alF'" >> /home/builder/.bashrc && \
+    echo "alias la='ls -A'" >> /home/builder/.bashrc && \
+    echo "alias l='ls -CF'" >> /home/builder/.bashrc && \
+    echo "alias h='history'" >> /home/builder/.bashrc && \
+    \
+    echo "#set environment LD_PRELOAD=/home/builder/appscope/lib/linux/libscope.so" >> /home/builder/.gdbinit && \
+    echo "set follow-fork-mode child" >> /home/builder/.gdbinit && \
+    echo "set breakpoint pending on" >> /home/builder/.gdbinit && \
+    echo "set directories /home/builder/appscope" >> /home/builder/.gdbinit && \
+    \
+    mkdir /home/builder/appscope
 
 # ---
-# The local git clone of the project is mounted as /root/appscope. See Makefile.
+# The local git clone of the project is mounted as /home/builder/appscope. See Makefile.
 #
-#     docker run -v $(pwd):/root/appscope ...
+#     docker run -v $(pwd):/home/builder/appscope ...
 #
-WORKDIR /root/appscope
+WORKDIR /home/builder/appscope
 
 # fini

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -40,11 +40,30 @@ RUN apt-get update && \
     add-apt-repository ppa:longsleep/golang-backports && \
     apt-get update && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 52B59B1571A79DBC054901C0F6BC817356A3D45E && \
-    apt-get install -y $GOLANG git autoconf automake libtool cmake lcov upx make gdb vim emacs strace lsof tzdata && \
+    apt-get install -y \
+        $GOLANG \
+        autoconf \
+        automake \
+        cmake \
+        emacs \
+        gdb \
+        git \
+        lcov \
+        libtool \
+        lsof \
+        make \
+        strace \
+        sudo \
+        tzdata \
+        upx \
+        vim \
+        && \
     dpkg-reconfigure --frontend noninteractive tzdata && \
     apt-get clean
 
 RUN useradd -d /home/builder -m builder && \
+    \
+    echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/builder && \
     \
     echo "alias ll='ls -alF'" >> /home/builder/.bashrc && \
     echo "alias la='ls -A'" >> /home/builder/.bashrc && \

--- a/docker/builder/Dockerfile.alpine
+++ b/docker/builder/Dockerfile.alpine
@@ -15,18 +15,30 @@ FROM $IMAGE
 # ---
 # Install packages.
 #
-RUN apk add --no-cache go gdb git make vim emacs strace tcpdump
+RUN apk add --no-cache bash go gdb git make vim emacs strace tcpdump
 
 # ---
-# Extra setup for use with `make docker-run`
+# Add the "builder" user
 #
-COPY ./docker/builder/gdbinit /root/.gdbinit
+RUN adduser -h /home/builder -D builder && \
+    \
+    echo "alias ll='ls -alF'" >> /home/builder/.bashrc && \
+    echo "alias la='ls -A'" >> /home/builder/.bashrc && \
+    echo "alias l='ls -CF'" >> /home/builder/.bashrc && \
+    echo "alias h='history'" >> /home/builder/.bashrc && \
+    \
+    echo "#set environment LD_PRELOAD=/home/builder/appscope/lib/linux/libscope.so" >> /home/builder/.gdbinit && \
+    echo "set follow-fork-mode child" >> /home/builder/.gdbinit && \
+    echo "set breakpoint pending on" >> /home/builder/.gdbinit && \
+    echo "set directories /home/builder/appscope" >> /home/builder/.gdbinit && \
+    \
+    mkdir /home/builder/appscope
 
 # ---
-# The local git clone of the project is mounted as /root/appscope. See Makefile.
+# The local git clone of the project is mounted as /home/builder/appscope. See Makefile.
 #
-#     docker run -v $(pwd):/root/appscope ...
+#     docker run -v $(pwd):/home/builder/appscope ...
 #
-WORKDIR /root/appscope
+WORKDIR /home/builder/appscope
 
 # fini

--- a/docker/builder/Dockerfile.alpine
+++ b/docker/builder/Dockerfile.alpine
@@ -15,17 +15,31 @@ FROM $IMAGE
 # ---
 # Install packages.
 #
-RUN apk add --no-cache bash go gdb git make vim emacs strace tcpdump
+RUN apk add --no-cache \
+    bash \
+    emacs \
+    gdb \
+    git \
+    go  \
+    linux-headers \
+    make \
+    musl-dev \
+    strace \
+    sudo \
+    tcpdump \
+    vim
 
 # ---
 # Add the "builder" user
 #
 RUN adduser -h /home/builder -D builder && \
     \
-    echo "alias ll='ls -alF'" >> /home/builder/.bashrc && \
-    echo "alias la='ls -A'" >> /home/builder/.bashrc && \
-    echo "alias l='ls -CF'" >> /home/builder/.bashrc && \
-    echo "alias h='history'" >> /home/builder/.bashrc && \
+    echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/builder && \
+    \
+    echo "alias ll='ls -alF'" >> /home/builder/.profile && \
+    echo "alias la='ls -A'" >> /home/builder/.profile && \
+    echo "alias l='ls -CF'" >> /home/builder/.profile && \
+    echo "alias h='history'" >> /home/builder/.profile && \
     \
     echo "#set environment LD_PRELOAD=/home/builder/appscope/lib/linux/libscope.so" >> /home/builder/.gdbinit && \
     echo "set follow-fork-mode child" >> /home/builder/.gdbinit && \


### PR DESCRIPTION
Closes #350

The idea here is to fix the permission issues Sean and I have been having when we use `make docker-build`. We end up with generated content owned by root which causes issues. 
* use `-u $(uid -u):$(id -g)` on the `docker run` command-line so the user in the container has the same UID/GID as us
* map those UID/GID values to a `builder` user in the container whos `$HOME` is `/home/builder`
* mount the local working copy of the repo at `/home/builder/appscope` in the container and make that the the `WORKDIR` too

I had to comment out one of the Go unit test cases that was assuming PID 1 belonged to "root" which is not the case when we build using this setup.

Added `.dockerignore` so some larger, unnecessary content is not included in the `docker build` context to speed things up.

Adjusted the top-level `Makefile` so we can set `CMD` to override the default build command (`make all test`). We can now use something like `make docker-build CMD="make coreall"` when we want to do something smaller.

The `builder` user can `sudo` in case something else is needed.

Testing
* `make docker-build` should build and the resulting generated files should be owned by you, not root
* `make docker-build CMD="make test"` should only run the unit tests
* `make docker-run` should get you a prompt in the build container as the `builder` user, in the mounted folder, with `ll` et al aliases, and sudo access.
* same with `make docker-run-alpine`