### PR TITLE
Scope flows bug #310

### DIFF
--- a/cli/flows/flow.go
+++ b/cli/flows/flow.go
@@ -211,9 +211,9 @@ func (f *Flow) mergeEventFlow(ef Flow) {
 
 func parseFlowFileName(filename string) (Flow, error) {
 	ret := Flow{}
-	re := regexp.MustCompile(`(\d+)_([0-9\.]+):(\d+)_([0-9\.]+):(\d+).(in|out)`)
+	re := regexp.MustCompile(`(\d+)_([0-9.:a-f]+|af_unix|netrx|nettx|tlsrx|tlstx):(\d+)_([0-9.:a-f]+|af_unix|netrx|nettx|tlsrx|tlstx):(\d+)\.(in|out)`)
 	parts := re.FindStringSubmatch(filename)
-	if parts == nil {
+	if len(parts) < 7 {
 		return ret, fmt.Errorf("error parsing filename: %s", filename)
 	}
 	var err error


### PR DESCRIPTION
- Fixes the bug listed in #310 by updating the regular expression.
- Tested with regular expression generator https://regexr.com/61eu8
- Validates these 3 filename formats generated by src/report.c: doPayload():
`44603_af_unix:198372_af_unix:198371.in`
`44603_127.0.0.53:53_0.0.0.0:0.in`
`44603_tlsrx:0_tlsrx:0.in`

Does not validate the `pid.na` format. This format will cause an error to be returned in `cli/flows/flow.go`. Should we expect to handle these pid.na files? @jrcheli 