### PR TITLE
Scope flows bug #309

### DIFF
--- a/cli/cmd/flows.go
+++ b/cli/cmd/flows.go
@@ -49,7 +49,12 @@ scope flows --out 124x3c   # Displays the outbound payload of that flow
 		// }
 
 		termWidth, _, err := terminal.GetSize(0)
-		util.CheckErrSprintf(err, "error getting terminal width: %v", err)
+		if err != nil {
+			// If we cannot get the terminal size, we are dealing with redirected stdin
+			// as opposed to an actual terminal, so we will assume terminal width is
+			// 160, to show all columns.
+			termWidth = 160
+		}
 
 		sessions := sessionByID(id)
 

--- a/cli/flows/flow.go
+++ b/cli/flows/flow.go
@@ -211,9 +211,9 @@ func (f *Flow) mergeEventFlow(ef Flow) {
 
 func parseFlowFileName(filename string) (Flow, error) {
 	ret := Flow{}
-	re := regexp.MustCompile(`(\d+)_([0-9\.]+):(\d+)_([0-9\.]+):(\d+).(in|out)`)
+	re := regexp.MustCompile(`(\d+)_([0-9.:a-f]+|af_unix|netrx|nettx|tlsrx|tlstx):(\d+)_([0-9.:a-f]+|af_unix|netrx|nettx|tlsrx|tlstx):(\d+)\.(in|out)`)
 	parts := re.FindStringSubmatch(filename)
-	if parts == nil {
+	if len(parts) < 7 {
 		return ret, fmt.Errorf("error parsing filename: %s", filename)
 	}
 	var err error


### PR DESCRIPTION
- Fixes the issue where redirecting stdin to `scope flows` displays an error.

The problem is that terminal size cannot be detected when using redirected std input. In this PR, instead of throwing an error, we will now assume a default terminal size of 160, greater than the threshold for displaying all fields.

@coccyx we also grab terminal size in cmd/events, cmd/metrics and cmd/dash. do you want me to make this change in those files also? i.e. are we likely to pipe something into `scope events`, `scope metrics` or `scope dash`?