### PR TITLE
MKTG-648 Docs ++visible heading links, --PrismJS highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/website/gatsby-browser.js
+++ b/website/gatsby-browser.js
@@ -1,3 +1,3 @@
 import "bootstrap/dist/css/bootstrap.css";
 import "./src/scss/global.scss";
-require("prismjs/themes/prism-okaidia.css");
+// require("prismjs/themes/prism-okaidia.css");

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -55,18 +55,14 @@ module.exports = {
     {
       resolve: "gatsby-transformer-remark",
       options: {
+        // Footnotes mode (default: true)
+        // footnotes: true,
+        // GitHub Flavored Markdown mode (default: true)
+        gfm: true,
+        // Plugins configs
         plugins: [
-          {
-            resolve: "gatsby-remark-prismjs",
-            options: {},
-          },
-        ],
-      },
-    },
-    {
-      resolve: "gatsby-transformer-remark",
-      options: {
-        plugins: [
+          `gatsby-remark-autolink-headers`,
+          `gatsby-remark-prismjs`,
           {
             resolve: "gatsby-remark-images",
             options: {

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -62,7 +62,7 @@ module.exports = {
         // Plugins configs
         plugins: [
           `gatsby-remark-autolink-headers`,
-          `gatsby-remark-prismjs`,
+          // `gatsby-remark-prismjs`,
           {
             resolve: "gatsby-remark-images",
             options: {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10537,6 +10537,38 @@
         }
       }
     },
+    "gatsby-remark-autolink-headers": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-4.6.0.tgz",
+      "integrity": "sha512-r2NFFdF+OHGuSnbhlgfzEnXx8SnbBi4YnlpgyT1RkW3uQHpVfCIuZdT/Gs8ozAQIDhnMDttNA4/J1gW8xZSJYQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "github-slugger": "^1.3.0",
+        "lodash": "^4.17.21",
+        "mdast-util-to-string": "^2.0.0",
+        "unist-util-visit": "^2.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "mdast-util-to-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
+        }
+      }
+    },
     "gatsby-remark-highlight-code": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/gatsby-remark-highlight-code/-/gatsby-remark-highlight-code-2.1.1.tgz",

--- a/website/package.json
+++ b/website/package.json
@@ -39,6 +39,7 @@
     "gatsby-plugin-sharp": "^2.12.1",
     "gatsby-plugin-sitemap": "^2.10.0",
     "gatsby-plugin-styled-components": "^3.9.0",
+    "gatsby-remark-autolink-headers": "^4.6.0",
     "gatsby-remark-highlight-code": "^2.1.1",
     "gatsby-remark-images": "^3.10.0",
     "gatsby-remark-prismjs": "^3.12.0",

--- a/website/src/components/MarkDownBlock.js
+++ b/website/src/components/MarkDownBlock.js
@@ -2,7 +2,7 @@ import React from "react";
 import { graphql } from "gatsby";
 import Helmet from "react-helmet";
 import Layout from "./layouts/documentationLayout";
-import "prismjs/themes/prism.css";
+// import "prismjs/themes/prism.css";
 
 export default function MarkDownBlock({ data }) {
   const post = data.markdownRemark;

--- a/website/src/scss/_documentation.scss
+++ b/website/src/scss/_documentation.scss
@@ -48,6 +48,7 @@
   pre {
     font-size: 16px;
     margin: 10px 0;
+    color: #2d9b0d;
   }
   ol {
     /* padding: 0; */


### PR DESCRIPTION
This PR does 3 things, each in 1+ separate commits:
1. Adds (industry-standard) visible & clickable links to the left of AppScope docs' headings.
2. Comments out all references to the PrismJS syntax highlighter. (We've never enabled this plug-in; it was lurking in the Gatsby codebase; and when we refactored the `gatsby-config.js` file's elements, to enable the links plug-in, that unleashed the Kraken and broke builds. We're not using it, so 'bye.)
3. Gives code blocks (`<pre>`) a 1980s green CRT foreground, matching the green color we've had all along on inline code (`<code>`).

This achieves the same result as its (closed) predecessor https://github.com/criblio/appscope/pull/375, but with a less-convoluted commit history. Here's that result, all elements visible on the **Using TLS** doc page:

![image](https://user-images.githubusercontent.com/12901606/124878704-42d59180-df81-11eb-8991-d5b715e722f0.png)

**Ignore everything below. The final 2 commits remove all references to our unused prismjs, so Gatsby will build the project without the 2 prismjs CSS files' being present. Yes!**

BUT it's a little less honest/complete, because `npm run develop` wouldn't successfully build & run the Gatsby `website` until I added back these 2 CSS files from PR #375 – additions not recorded here, because they're in an untracked subdirectory:

* `.../website/node_modules/prismjs/themes/prism.css`
* `.../website/node_modules/prismjs/themes/prism-okaidia.css`

So to be honest, we should cherry-pick these 2 commits into here – which would make the commit history more complicated again:

* 0830d670daba3619679a128638b68b0a67fb6ebe | Conform primsjs CSS to our published site's native `_documentation.scss`
* 0bdd394d7c19a37d864240430abb55d2889ad2d1 | Conform `prism.css` code blocks to green CRT text (color: `#2d9b0d;`)

So ¯\\\_(ツ)\_/¯

