### PR TITLE
fix hanging alpine tests

### DIFF
--- a/src/wrap.c
+++ b/src/wrap.c
@@ -3557,7 +3557,7 @@ __stdio_write(struct MUSL_IO_FILE *stream, const unsigned char *buf, size_t len)
         }
     }
 
-    if (dothis == 1) doWrite(fileno((FILE *)stream), initialTime, (rc != -1),
+    if (dothis == 1) doWrite(stream->fd, initialTime, (rc != -1),
                              iov, rc, "__stdio_write", IOV, iovcnt);
     return rc;
 }


### PR DESCRIPTION
While working on integration tests, I found the Alpine test was reliably stalling when run at GitHub but ran fine locally with `docker-compose run alpine`. Eventually discovered we could repeat the issue locally using `docker-compose up alpine` (`up` instead of `run`).

The call to `fileno()` was hanging due to it calling `FLOCK()` internally. Looking at other musl libc code, it looks like they're skipping `fileno()` and just using `f->fd` instead so we're now doing the same and the integration tests are passing.