### PR TITLE
improve log file regex, update UT

### DIFF
--- a/cli/run/scopeconfig.go
+++ b/cli/run/scopeconfig.go
@@ -367,5 +367,6 @@ func (c *Config) WriteScopeConfig(path string, filePerms os.FileMode) error {
 }
 
 func scopeLogRegex() string {
-	return `[\s\/\\\.]log[s]?[\/\\\.]?`
+	// see scopeconfig_test.go for example paths that match
+	return `(\/logs?\/)|(\.log$)|(\.log[.\d])`;
 }

--- a/cli/run/scopeconfig_test.go
+++ b/cli/run/scopeconfig_test.go
@@ -238,10 +238,22 @@ func TestScopeLogRegex(t *testing.T) {
 		Matches bool
 	}{
 		{"/var/log/messages", true},
+		{"/app/logs/stdout", true},
+		{"/app/logs/stderr", true},
+		{"/opt/cribl/log/foo.txt", true},
 		{"/opt/cribl/log/cribl.log", true},
 		{"/some/container/path.log", true},
+		{"/some/container/path.log1", true},
+		{"/some/container/path.log42", true},
+		{"/some/container/path.log.1", true},
+		{"/some/container/path.log.2", true},
+		{"/some/container/path.log.fancy", true},
+		// negative tests
 		{"/opt/cribl/blog/foo.txt", false},
-		{"/opt/cribl/log/foo.txt", true},
+		{"/opt/cribl/log420/foo.txt", false},
+		{"/opt/cribl/local/logger.yml", false},
+		{"/opt/cribl/local/file.logger", false},
+		{"/opt/cribl/local/file.420", false},
 	}
 
 	re := regexp.MustCompile(scopeLogRegex())

--- a/cli/run/setup_test.go
+++ b/cli/run/setup_test.go
@@ -156,7 +156,7 @@ event:
       cacertpath: ""
   watch:
   - type: file
-    name: '[\s\/\\\.]log[s]?[\/\\\.]?'
+    name: (\/logs?\/)|(\.log$)|(\.log[.\d])
     value: .*
   - type: console
     name: (stdout|stderr)

--- a/conf/scope.yml
+++ b/conf/scope.yml
@@ -58,7 +58,8 @@ event:
     # Designed for monitoring log files, but capable of capturing
     # any file writes.
     - type: file
-      name: .*log.*                 # whitelist ex regex describing log file names
+      name: (\/logs?\/)|(\.log$)|(\.log[.\d]) # whitelist ex regex
+                                              # describing log file names
       value: .*                     # whitelist ex regex describing field values
 
     # Creates events from data written to stdout, stderr, or both.

--- a/src/scopetypes.h
+++ b/src/scopetypes.h
@@ -93,7 +93,7 @@ typedef unsigned int bool;
 #define DEFAULT_SRC_NET_FIELD ".*"
 #define DEFAULT_SRC_FS_FIELD ".*"
 #define DEFAULT_SRC_DNS_FIELD ".*"
-#define DEFAULT_SRC_FILE_NAME ".*log.*"
+#define DEFAULT_SRC_FILE_NAME "(\\/logs?\\/)|(\\.log$)|(\\.log[.\\d])"
 #define DEFAULT_SRC_CONSOLE_NAME "(stdout)|(stderr)"
 #define DEFAULT_SRC_SYSLOG_NAME ".*"
 #define DEFAULT_SRC_METRIC_NAME ".*"


### PR DESCRIPTION
Prior to this, we're mistakenly reporting access to things like `.../config/logger.yaml` as `log` events. See the updated test for expectations.