### PR TITLE
Add Missing CA Certs to Container

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,2 +1,7 @@
 FROM ubuntu:20.04
+
+RUN apt update -y && \
+    apt install -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY bin/linux/scope /usr/local/bin/scope


### PR DESCRIPTION
Using the scope in our container with the TLS transport enabled isn't working because we don't have the CS certificates installed. This adds those certs. 