### PR TITLE
Prevent negative numbers in scope prune

### DIFF
--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -24,7 +24,10 @@ scope prune -a`,
 		del, _ := cmd.Flags().GetInt("delete")
 
 		count := ""
-		if keep == 0 && del == 0 && !all {
+
+		if keep < 0 || del < 0 {
+			helpErrAndExit(cmd, "Must be a positive number")
+		} else if keep == 0 && del == 0 && !all {
 			helpErrAndExit(cmd, "Must specify keep, delete, or all")
 		} else if all && keep > 0 {
 			helpErrAndExit(cmd, "Cannot specify keep and all")


### PR DESCRIPTION
- Provide an error message if a negative number is entered for `scope prune --keep X` or `scope prune --delete X`.
Closes https://github.com/criblio/appscope/issues/407