### PR TITLE
Add timer to metric types

### DIFF
--- a/cli/metrics/metric.go
+++ b/cli/metrics/metric.go
@@ -46,6 +46,7 @@ func (mt MetricType) String() string {
 var metricTypesToCodes map[string]MetricType = map[string]MetricType{
 	"counter": Count,
 	"gauge":   Gauge,
+	"timer":   Timer,
 }
 
 // Reader reads dogstatsd metrics from a file


### PR DESCRIPTION
- Added "Timer" to the metric types array, so that timer metrics can be displayed with the correct unit.

Closes https://github.com/criblio/appscope/issues/400