### PR TITLE
Improve scope history output when there is no event history

### DIFF
--- a/cli/cmd/history.go
+++ b/cli/cmd/history.go
@@ -70,7 +70,12 @@ cat $(scope hist -d)/args.json   # Outputs contents of args.json in the scope hi
 				{Name: "PID", Field: "pid"},
 				{Name: "Timestamp", Field: "timestamp", Transform: func(obj interface{}) string { return time.Unix(int64(0), obj.(int64)).Format(time.Stamp) }},
 				{Name: "End Timestamp", Field: "endtimestamp", Transform: func(obj interface{}) string { return time.Unix(int64(0), obj.(int64)).Format(time.Stamp) }},
-				{Name: "Duration", Field: "duration", Transform: func(obj interface{}) string { return util.GetHumanDuration(obj.(time.Duration)) }},
+				{Name: "Duration", Field: "duration", Transform: func(obj interface{}) string {
+					if obj.(time.Duration) == -1 {
+						return "NA"
+					}
+					return util.GetHumanDuration(obj.(time.Duration))
+				}},
 				{Name: "Total Events", Field: "eventCount", Transform: func(obj interface{}) string {
 					if obj.(int) == -1 {
 						return "NA"
@@ -90,7 +95,12 @@ cat $(scope hist -d)/args.json   # Outputs contents of args.json in the scope hi
 				{Name: "Cmdline", Field: "args", Transform: func(obj interface{}) string { return util.TruncWithElipsis(shellquote.Join(obj.([]string)...), 25) }},
 				{Name: "PID", Field: "pid"},
 				{Name: "Age", Field: "timestamp", Transform: func(obj interface{}) string { return util.GetHumanDuration(time.Since(time.Unix(0, obj.(int64)))) }},
-				{Name: "Duration", Field: "duration", Transform: func(obj interface{}) string { return util.GetHumanDuration(obj.(time.Duration)) }},
+				{Name: "Duration", Field: "duration", Transform: func(obj interface{}) string {
+					if obj.(time.Duration) == -1 {
+						return "NA"
+					}
+					return util.GetHumanDuration(obj.(time.Duration))
+				}},
 				{Name: "Total Events", Field: "eventCount", Transform: func(obj interface{}) string {
 					if obj.(int) == -1 {
 						return "NA"

--- a/cli/history/sessions.go
+++ b/cli/history/sessions.go
@@ -149,6 +149,7 @@ func (sessions SessionList) CountAndDuration() (ret SessionList) {
 		if err != nil {
 			if util.CheckFileExists(s.EventsDestPath) {
 				s.EventCount = -1
+				s.Duration = -1
 			}
 		} else {
 			file, err := os.Open(s.EventsPath)


### PR DESCRIPTION
- Set the `Duration` field in `scope history` to be `NA` whenever there is no event history (i.e. due to events being exported to cribl or another destination). The `Total Events` is already set to `NA` under this condition.

Closes https://github.com/criblio/appscope/issues/404