### PR TITLE
TLS shutdown handling bugfix

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -308,7 +308,7 @@ shutdownTlsSession(transport_t *trans)
                 // shutdown not complete, call again
                 char buf[4096];
                 while(1) {
-                   ret = SSL_read(trans->net.tls.ssl, buf, sizeof(buf));
+                   ret = SCOPE_SSL_read(trans->net.tls.ssl, buf, sizeof(buf));
                    if (ret <= 0) {
                        break;
                    }


### PR DESCRIPTION
- fixes https://github.com/criblio/appscope/issues/418

Prior to this fix, when a server closed the connection prematurely, we were getting into a loop where SSL_read returned -1 continuously, and we were not able to break out of it.