### PR TITLE
Wait for connection before calling doEvent

### DIFF
--- a/src/scopetypes.h
+++ b/src/scopetypes.h
@@ -174,6 +174,7 @@ typedef unsigned int bool;
 //    SCOPE_PID                      provided by library
 //    SCOPE_PAYLOAD_HEADER           write payload headers to files
 //    SCOPE_ALLOW_MUSL_ATTACH        allows attach for musl processes
+//    SCOPE_CONNECT_TIMEOUT_SECS     set the maximum time to wait for a connection to be established
 
 #define SCOPE_PID_ENV "SCOPE_PID"
 #define PRESERVE_PERF_REPORTING "SCOPE_PERF_PRESERVE"

--- a/src/transport.c
+++ b/src/transport.c
@@ -672,6 +672,9 @@ checkPendingSocketStatus(transport_t *trans)
     fd_set pending_results = trans->net.pending_connect;
     rc = g_fn.select(FD_SETSIZE, NULL, &pending_results, NULL, &tv);
     if (rc < 0) {
+        if (errno == EINTR) {
+          return 0;
+        }
         DBG(NULL);
         transportDisconnect(trans);
         return 0;
@@ -982,7 +985,7 @@ transportConnect(transport_t *trans)
                 // If it does, we're done.
                 if (socketConnectionStart(trans)) return 1;
             }
-            // Check to see if the a pending connetion has been successful.
+            // Check to see if the a pending connection has been successful.
             return checkPendingSocketStatus(trans);
         case CFG_FILE:
             return transportConnectFile(trans);

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -12,6 +12,7 @@
 #include <sys/stat.h>
 #include <libgen.h>
 #include <sys/resource.h>
+#include <errno.h>
 
 #include "atomic.h"
 #include "bashmem.h"
@@ -910,9 +911,24 @@ reportPeriodicStuff(void)
 void
 handleExit(void)
 {
-    if (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
-        struct timespec ts = {.tv_sec = 0, .tv_nsec = 10000}; // 10 us
+    struct timespec ts = {.tv_sec = 0, .tv_nsec = 10000}; // 10 us
 
+    char *wait;
+    if ((wait = getenv("SCOPE_CONNECT_TIMEOUT_SECS")) != NULL) {
+        // wait for a connection to be established 
+        // before we call doEvent
+        int wait_time;
+        errno = 0;
+        wait_time = strtoul(wait, NULL, 10);
+        if (!errno && wait_time) {
+            for (int i = 0; i < 100000 * wait_time; i++) {
+                if (!ctlNeedsConnection(g_ctl, CFG_CTL)) break; 
+                sigSafeNanosleep(&ts);
+            }
+        }
+    }
+
+    if (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
         // let the periodic thread finish
         while (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
             sigSafeNanosleep(&ts);


### PR DESCRIPTION
If a connection is required, we can now wait for it to be made for SCOPE_CONNECT_TIMEOUT_SECS before calling doEvent.
If we do not wait, and there is some connection latency, doEvent will not see a connection, and will not try to pull any data from the queue for sending.

Closes #395