### PR TITLE
Resolve npm/git hangs due to bad file descriptor

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -74,6 +74,13 @@ logConnect(log_t* log)
 }
 
 int
+logConnection(log_t *log)
+{
+    if (!log) return -1;
+    return transportConnection(log->transport);
+}
+
+int
 logDisconnect(log_t* log)
 {
     if (!log) return 0;

--- a/src/log.h
+++ b/src/log.h
@@ -17,6 +17,7 @@ void                logFlush(log_t*);
 // Setters (modifies log_t, but does not persist modifications)
 int                 logNeedsConnection(log_t*);
 int                 logConnect(log_t*);
+int                 logConnection(log_t*);
 int                 logDisconnect(log_t*);
 int                 logReconnect(log_t*);
 void                logTransportSet(log_t*, transport_t*);

--- a/src/mtc.c
+++ b/src/mtc.c
@@ -87,6 +87,13 @@ mtcConnect(mtc_t *mtc)
 }
 
 int
+mtcConnection(mtc_t *mtc)
+{
+    if (!mtc || (cfgLogStream(g_cfg.staticfg))) return -1;
+    return transportConnection(mtc->transport);
+}
+
+int
 mtcDisconnect(mtc_t *mtc)
 {
     if (!mtc || (cfgLogStream(g_cfg.staticfg))) return 0;

--- a/src/mtc.h
+++ b/src/mtc.h
@@ -19,12 +19,12 @@ void                mtcFlush(mtc_t*);
 // Setters (modifies mtc_t, but does not persist modifications)
 int                 mtcNeedsConnection(mtc_t *);
 int                 mtcConnect(mtc_t *);
+int                 mtcConnection(mtc_t*);
 int                 mtcDisconnect(mtc_t *);
 int                 mtcReconnect(mtc_t *);
 void                mtcEnabledSet(mtc_t*, unsigned);
 void                mtcTransportSet(mtc_t*, transport_t*);
 void                mtcFormatSet(mtc_t*, mtc_fmt_t*);
-
 
 #endif // __MTC_H__
 

--- a/src/scopetypes.h
+++ b/src/scopetypes.h
@@ -174,6 +174,7 @@ typedef unsigned int bool;
 //    SCOPE_PID                      provided by library
 //    SCOPE_PAYLOAD_HEADER           write payload headers to files
 //    SCOPE_ALLOW_MUSL_ATTACH        allows attach for musl processes
+//    SCOPE_CONNECT_TIMEOUT_SECS     set the maximum time to wait for a connection to be established
 
 #define SCOPE_PID_ENV "SCOPE_PID"
 #define PRESERVE_PERF_REPORTING "SCOPE_PERF_PRESERVE"

--- a/src/scopetypes.h
+++ b/src/scopetypes.h
@@ -174,7 +174,6 @@ typedef unsigned int bool;
 //    SCOPE_PID                      provided by library
 //    SCOPE_PAYLOAD_HEADER           write payload headers to files
 //    SCOPE_ALLOW_MUSL_ATTACH        allows attach for musl processes
-//    SCOPE_CONNECT_TIMEOUT_SECS     set the maximum time to wait for a connection to be established
 
 #define SCOPE_PID_ENV "SCOPE_PID"
 #define PRESERVE_PERF_REPORTING "SCOPE_PERF_PRESERVE"

--- a/src/transport.c
+++ b/src/transport.c
@@ -698,11 +698,13 @@ checkPendingSocketStatus(transport_t *trans)
     // We have a connection
     scopeLog("connect successful", trans->net.pending_connect, CFG_LOG_INFO);
 
-    // Socket no longer pending
-    trans->net.pending_connect = -1;
-
     // Move this descriptor up out of the way
     trans->net.sock = placeDescriptor(trans->net.pending_connect, trans);
+
+    // Remove the pending status from the transport
+    trans->net.pending_connect = -1;
+
+    // If the placeDescriptor call failed, we're done
     if (trans->net.sock == -1) return 0;
 
     // Set the TCP socket to blocking

--- a/src/transport.c
+++ b/src/transport.c
@@ -38,7 +38,7 @@ struct _transport_t
     union {
         struct {
             int sock;
-            fd_set pending_connect;
+            int pending_connect;
             char *host;
             char *port;
             struct sockaddr_storage gai_addr;
@@ -198,7 +198,10 @@ transportConnection(transport_t *trans)
     switch(trans->type) {
         case CFG_UDP:
         case CFG_TCP:
-            return trans->net.sock;
+            if (trans->net.sock) {
+                return trans->net.sock;
+            }
+            return trans->net.pending_connect;
         case CFG_FILE:
             if (trans->file.stream) {
                 return fileno(trans->file.stream);
@@ -474,12 +477,9 @@ transportDisconnect(transport_t *trans)
         case CFG_TCP:
             // appropriate for both tls and non-tls connections...
             shutdownTlsSession(trans);
-
-            int i;
-            for (i=0; i<FD_SETSIZE; i++) {
-                if (!FD_ISSET(i, &trans->net.pending_connect)) continue;
-                g_fn.close(i);
-                FD_CLR(i, &trans->net.pending_connect);
+            if (trans->net.pending_connect) {
+                g_fn.close(trans->net.pending_connect);
+                trans->net.pending_connect = -1;
             }
             break;
         case CFG_FILE:
@@ -656,11 +656,7 @@ setSocketBlocking(transport_t *trans, int sock, bool block)
 static int
 socketConnectIsPending(transport_t *trans)
 {
-    int i;
-    for (i=0; i<FD_SETSIZE; i++) {
-        if (FD_ISSET(i, &trans->net.pending_connect)) return TRUE;
-    }
-    return FALSE;
+    return (!trans || trans->net.pending_connect < 0) ? FALSE : TRUE;
 }
 
 static int
@@ -669,7 +665,10 @@ checkPendingSocketStatus(transport_t *trans)
     if (!trans) return 0;
     int rc;
     struct timeval tv = {0};
-    fd_set pending_results = trans->net.pending_connect;
+
+    fd_set pending_results;
+    FD_ZERO(&pending_results);
+    FD_SET(trans->net.pending_connect, &pending_results);
     rc = g_fn.select(FD_SETSIZE, NULL, &pending_results, NULL, &tv);
     if (rc < 0) {
         if (errno == EINTR) {
@@ -683,61 +682,43 @@ checkPendingSocketStatus(transport_t *trans)
         return 0;
     }
 
-    int i;
-    rc = 0;
-    for (i=0; i<FD_SETSIZE; i++) {
-        if (!FD_ISSET(i, &pending_results)) continue;
-
-        // If we can't get socket status, or the status is an error, close the
-        // socket that failed to connect and remove it from the pending list.
-        int opt;
-        socklen_t optlen = sizeof(opt);
-        if ((getsockopt(i, SOL_SOCKET, SO_ERROR, (void*)(&opt), &optlen) < 0)
+    // If we can't get socket status, or the status is an error, close the
+    // socket that failed to connect and remove it from the pending list.
+    int opt;
+    socklen_t optlen = sizeof(opt);
+    if ((getsockopt(trans->net.pending_connect, SOL_SOCKET, SO_ERROR, (void*)(&opt), &optlen) < 0)
             || opt) {
-            scopeLog("connect failed", i, CFG_LOG_INFO);
+        scopeLog("connect failed", trans->net.pending_connect, CFG_LOG_INFO);
 
-            FD_CLR(i, &trans->net.pending_connect);
-            g_fn.close(i);
-            continue;
-        }
-
-        scopeLog("connect successful", i, CFG_LOG_INFO);
-
-        // Hey!  We found one that will work!
-        // Move this descriptor up out of the way
-        FD_CLR(i, &trans->net.pending_connect);
-        trans->net.sock = placeDescriptor(i, trans);
-        if (trans->net.sock == -1) continue;
-
-        // Set the TCP socket to blocking
-        if ((trans->type == CFG_TCP) && !setSocketBlocking(trans, trans->net.sock, TRUE)) {
-            DBG("%d %s %s", trans->net.sock, trans->net.host, trans->net.port);
-        }
-
-        // We have a connected socket!  Woot!
-        // Do the tls stuff for this connection as needed.
-        if (trans->net.tls.enable) {
-            // when successful, we'll have a connected tls socket.
-            // when not, this will cleanup, disconnecting the socket.
-            establishTlsSession(trans);
-        }
-
-        break;
+        g_fn.close(trans->net.pending_connect);
+        trans->net.pending_connect = -1;
+        return 0;
     }
 
-    // If we were successful, we can stop looking.  Clean up pending sockets.
-    if (trans->net.sock != -1) {
-        rc = 1;
-        for (i=0; i<FD_SETSIZE; i++) {
-            if (FD_ISSET(i, &trans->net.pending_connect)) {
-                scopeLog("abandoning connect due to previous success", i, CFG_LOG_INFO);
-                g_fn.close(i);
-                FD_CLR(i, &trans->net.pending_connect);
-            }
-        }
+    // We have a connection
+    scopeLog("connect successful", trans->net.pending_connect, CFG_LOG_INFO);
+
+    // Move this descriptor up out of the way
+    trans->net.sock = placeDescriptor(trans->net.pending_connect, trans);
+    if (trans->net.sock == -1) return 0;
+
+    // Socket no longer pending
+    trans->net.pending_connect = -1;
+
+    // Set the TCP socket to blocking
+    if ((trans->type == CFG_TCP) && !setSocketBlocking(trans, trans->net.sock, TRUE)) {
+        DBG("%d %s %s", trans->net.sock, trans->net.host, trans->net.port);
     }
 
-    return rc;
+    // We have a connected socket!  Woot!
+    // Do the tls stuff for this connection as needed.
+    if (trans->net.tls.enable) {
+        // when successful, we'll have a connected tls socket.
+        // when not, this will cleanup, disconnecting the socket.
+        establishTlsSession(trans);
+    }
+
+    return 1;
 }
 
 static void
@@ -887,7 +868,7 @@ socketConnectionStart(transport_t *trans)
                 if (logmsg) free(logmsg);
             }
 
-            FD_SET(sock, &trans->net.pending_connect);
+            trans->net.pending_connect = sock;
             break;  // replace w/continue for a shotgun start.
         }
 
@@ -1009,7 +990,7 @@ transportCreateTCP(const char *host, const char *port, unsigned int enable,
 
     trans->type = CFG_TCP;
     trans->net.sock = -1;
-    FD_ZERO(&trans->net.pending_connect);
+    trans->net.pending_connect = -1;
     trans->net.host = strdup(host);
     trans->net.port = strdup(port);
     trans->net.tls.enable = enable;
@@ -1039,7 +1020,7 @@ transportCreateUdp(const char* host, const char* port)
 
     t->type = CFG_UDP;
     t->net.sock = -1;
-    FD_ZERO(&t->net.pending_connect);
+    t->net.pending_connect = -1;
     t->net.host = strdup(host);
     t->net.port = strdup(port);
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -672,6 +672,9 @@ checkPendingSocketStatus(transport_t *trans)
     fd_set pending_results = trans->net.pending_connect;
     rc = g_fn.select(FD_SETSIZE, NULL, &pending_results, NULL, &tv);
     if (rc < 0) {
+        if (errno == EINTR) {
+          return 0;
+        }
         DBG(NULL);
         transportDisconnect(trans);
         return 0;
@@ -982,7 +985,7 @@ transportConnect(transport_t *trans)
                 // If it does, we're done.
                 if (socketConnectionStart(trans)) return 1;
             }
-            // Check to see if the a pending connetion has been successful.
+            // Check to see if the a pending connection has been successful.
             return checkPendingSocketStatus(trans);
         case CFG_FILE:
             return transportConnectFile(trans);

--- a/src/transport.c
+++ b/src/transport.c
@@ -198,7 +198,7 @@ transportConnection(transport_t *trans)
     switch(trans->type) {
         case CFG_UDP:
         case CFG_TCP:
-            if (trans->net.sock) {
+            if (trans->net.sock != -1) {
                 return trans->net.sock;
             }
             return trans->net.pending_connect;
@@ -662,7 +662,7 @@ socketConnectIsPending(transport_t *trans)
 static int
 checkPendingSocketStatus(transport_t *trans)
 {
-    if (!trans) return 0;
+    if (!trans || trans->net.pending_connect == -1) return 0;
     int rc;
     struct timeval tv = {0};
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -698,12 +698,12 @@ checkPendingSocketStatus(transport_t *trans)
     // We have a connection
     scopeLog("connect successful", trans->net.pending_connect, CFG_LOG_INFO);
 
+    // Socket no longer pending
+    trans->net.pending_connect = -1;
+
     // Move this descriptor up out of the way
     trans->net.sock = placeDescriptor(trans->net.pending_connect, trans);
     if (trans->net.sock == -1) return 0;
-
-    // Socket no longer pending
-    trans->net.pending_connect = -1;
 
     // Set the TCP socket to blocking
     if ((trans->type == CFG_TCP) && !setSocketBlocking(trans, trans->net.sock, TRUE)) {

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -3278,11 +3278,13 @@ close(int fd)
 {
     WRAP_CHECK(close, -1);
 
-    if ((fd = ctlConnection(g_ctl, CFG_CTL)) || 
-    (fd = ctlConnection(g_ctl, CFG_LS)) ||
-    (fd = mtcConnection(g_mtc, CFG_CTL)) ||
-    (fd = logConnection(g_log))) {
-        return 0;
+    if (fd != -1) {
+        if ((fd == ctlConnection(g_ctl, CFG_CTL)) || 
+        (fd == ctlConnection(g_ctl, CFG_LS)) ||
+        (fd == mtcConnection(g_mtc)) ||
+        (fd == logConnection(g_log))) {
+            return 0;
+        }
     }
 
     int rc = g_fn.close(fd);

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -12,7 +12,6 @@
 #include <sys/stat.h>
 #include <libgen.h>
 #include <sys/resource.h>
-#include <errno.h>
 
 #include "atomic.h"
 #include "bashmem.h"
@@ -911,24 +910,9 @@ reportPeriodicStuff(void)
 void
 handleExit(void)
 {
-    struct timespec ts = {.tv_sec = 0, .tv_nsec = 10000}; // 10 us
-
-    char *wait;
-    if ((wait = getenv("SCOPE_CONNECT_TIMEOUT_SECS")) != NULL) {
-        // wait for a connection to be established 
-        // before we call doEvent
-        int wait_time;
-        errno = 0;
-        wait_time = strtoul(wait, NULL, 10);
-        if (!errno && wait_time) {
-            for (int i = 0; i < 100000 * wait_time; i++) {
-                if (!ctlNeedsConnection(g_ctl, CFG_CTL)) break; 
-                sigSafeNanosleep(&ts);
-            }
-        }
-    }
-
     if (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
+        struct timespec ts = {.tv_sec = 0, .tv_nsec = 10000}; // 10 us
+
         // let the periodic thread finish
         while (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
             sigSafeNanosleep(&ts);

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -12,6 +12,7 @@
 #include <sys/stat.h>
 #include <libgen.h>
 #include <sys/resource.h>
+#include <errno.h>
 
 #include "atomic.h"
 #include "bashmem.h"
@@ -910,9 +911,24 @@ reportPeriodicStuff(void)
 void
 handleExit(void)
 {
-    if (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
-        struct timespec ts = {.tv_sec = 0, .tv_nsec = 10000}; // 10 us
+    struct timespec ts = {.tv_sec = 0, .tv_nsec = 10000}; // 10 us
 
+    char *wait;
+    if ((wait = getenv("SCOPE_CONNECT_TIMEOUT_SECS")) != NULL) {
+        // wait for a connection to be established 
+        // before we call doEvent
+        int wait_time;
+        errno = 0;
+        wait_time = strtoul(wait, NULL, 10);
+        if (!errno && wait_time) {
+            for (int i = 0; i < 100000 * wait_time; i++) {
+                if (!ctlNeedsConnection(g_ctl, CFG_CTL)) break; 
+                sigSafeNanosleep(&ts);
+            }
+        }
+    }
+
+    if (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
         // let the periodic thread finish
         while (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
             sigSafeNanosleep(&ts);

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -3278,6 +3278,13 @@ close(int fd)
 {
     WRAP_CHECK(close, -1);
 
+    if ((fd = ctlConnection(g_ctl, CFG_CTL)) || 
+    (fd = ctlConnection(g_ctl, CFG_LS)) ||
+    (fd = mtcConnection(g_mtc, CFG_CTL)) ||
+    (fd = logConnection(g_log))) {
+        return 0;
+    }
+
     int rc = g_fn.close(fd);
 
     doCloseAndReportFailures(fd, (rc != -1), "close");


### PR DESCRIPTION
npm uses git, which uses ssh. ssh has code that iterates through proc/pid/fds, and closes any file descriptors that don't belong to it. some of these file descriptors belong to us, and closing them results in a "bad file descriptor" error or a hang when we try to use them.

this PR fixes the complications that arise from the above, by effectively intercepting the close function to prevent scoped applications from closing file descriptors that our transport object is maintaining.