### PR TITLE
disable UPX compression of the CLI executable

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -32,7 +32,8 @@ debug:
 	$(MAKE) scope BUILD_OPTS="-gcflags=all=\"-N -l\""
 
 ## all: build and compress \`scope\`
-all: scope compressscope
+all: scope
+	@[ -z "$(COMPRESS)" ] || $(MAKE) -s compressscope
 
 ## clean: remove the built binary
 clean:

--- a/os/linux/Makefile
+++ b/os/linux/Makefile
@@ -66,7 +66,7 @@ $(LDSCOPE): src/scope_static.c src/libdir.c $(LDSCOPEDYN) $(LIBSCOPE)
 	@[ -z "$(CI)" ] || echo "::endgroup::"
 
 coreclean:
-	$(RM) $(LIBSCOPE) $(LDSCOPE) $(LDSCOPEDYN) contrib/build/funchook/*.a
+	$(RM) $(LIBSCOPE) $(LDSCOPE) $(LDSCOPEDYN)
 
 SRC_C_FILES:=$(wildcard src/*.c)
 SRC_C_FILES:=$(filter-out src/wrap.c, $(SRC_C_FILES))


### PR DESCRIPTION
Closes #449

Use `make build CMD="make all test COMPRESS=1"` to re-enable it at build time.