### PR TITLE
fix dependencies in contribs

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -19,11 +19,11 @@ clean:
 .PHONY: all clean
 
 cJSON: cJSON/libcjson.a
-cmocka: build/cmocka
-funchook: build/funchook
-libyaml: build/libyaml
-openssl: build/openssl
-pcre2: build/pcre2
+cmocka: build/cmocka/src/libcmocka.so
+funchook: build/funchook/libfunchook.a
+libyaml: build/libyaml/src/.libs/libyaml.a
+openssl: build/openssl/libssl.a build/openssl/libcrypto.a
+pcre2: build/pcre2/libpcre2-posix.a build/pcre2/libpcre2-8.a
 .PHONY: cJSON cmocka funchook libyaml openssl pcre2
 
 # Can't be cached because the build is in the source folder.
@@ -32,15 +32,17 @@ cJSON/libcjson.a:
 	cd cJSON && $(MAKE)
 	@[ -z "$(CI)" ] || echo "::endgroup::"
 
-build/cmocka:
+build/cmocka/src/libcmocka.so:
 	@echo "$${CI:+::group::}Building cmocka"
-	mkdir build/cmocka
+	@$(RM) -r build/cmocka
+	@mkdir build/cmocka
 	cd build/cmocka && cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug ../../cmocka && $(MAKE)
 	@[ -z "$(CI)" ] || echo "::endgroup::"
 
-build/funchook:
+build/funchook/libfunchook.a:
 	@echo "$${CI:+::group::}Building funchook"
-	mkdir build/funchook
+	@$(RM) -r build/funchook
+	@mkdir build/funchook
 	if [ "x86_64" = "$(ARCH)" ]; then \
 		cd build/funchook && cmake -DCMAKE_BUILD_TYPE=Release -DFUNCHOOK_DISASM=capstone ../../funchook; \
 	elif [ "aarch64" = "$(ARCH)" ]; then \
@@ -53,24 +55,27 @@ build/funchook:
 	@[ -z "$(CI)" ] || echo "::endgroup::"
 
 # Can't be cached because we have to `autoreconf` the source folder.
-build/libyaml:
+build/libyaml/src/.libs/libyaml.a:
 	@echo "$${CI:+::group::}Building libyaml"
-	mkdir build/libyaml
+	@$(RM) -r build/libyaml
+	@mkdir build/libyaml
 	cd build/libyaml && autoreconf -fvi ../../libyaml && ../../libyaml/configure LIBS=-ldl && $(MAKE)
 	@[ -z "$(CI)" ] || echo "::endgroup::"
 
-build/openssl:
+build/openssl/libssl.a build/openssl/libcrypto.a:
 	@echo "$${CI:+::group::}Building openssl"
-	mkdir build/openssl
-	cd build/openssl && ../../openssl/Configure no-async && make -j8
+	@$(RM) -r build/openssl
+	@mkdir build/openssl
+	cd build/openssl && ../../openssl/Configure no-async no-tests no-unit-test && make -j8
 	# Yuck.  Avoids naming conflict between our wrap.c and libssl.a
 	objcopy --redefine-sym SSL_read=SCOPE_SSL_read build/openssl/libssl.a
 	objcopy --redefine-sym SSL_write=SCOPE_SSL_write build/openssl/libssl.a
 	@[ -z "$(CI)" ] || echo "::endgroup::"
 
-build/pcre2:
+build/pcre2/libpcre2-posix.a build/pcre2/libpcre2-8.a:
 	@echo "$${CI:+::group::}Building pcre2"
-	mkdir build/pcre2
+	@$(RM) -r build/pcre2
+	@mkdir build/pcre2
 	cd build/pcre2 && cmake ../../pcre2 && $(MAKE)
 	@[ -z "$(CI)" ] || echo "::endgroup::"
 


### PR DESCRIPTION
Also added `no-tests no-unit-test` to the openssl build to save ~8secs
on x86 and ~2mins on ARM.

Closes #452 