### PR TITLE
fix the nginx integration test

### DIFF
--- a/test/testContainers/nginx/Dockerfile
+++ b/test/testContainers/nginx/Dockerfile
@@ -19,6 +19,8 @@ RUN mkdir /opt/test-runner/logs/
 #RUN source scl_source enable rh-python36 && virtualenv /opt/test-runner/
 
 ENV SCOPE_METRIC_DEST=udp://localhost:8125
+ENV SCOPE_EVENT_DEST=file:///dev/null
+ENV SCOPE_EVENT_ENABLE=false
 ENV SCOPE_LOG_LEVEL=info
 ENV SCOPE_LOG_DEST=file:///opt/test-runner/logs/scope.log
 ENV SCOPE_METRIC_VERBOSITY=4
@@ -35,8 +37,6 @@ COPY ./test_runner/requirements.txt /opt/test-runner/requirements.txt
 RUN python3 -m pip install -r /opt/test-runner/requirements.txt
 
 COPY ./test_runner/ /opt/test-runner/
-
-RUN yum -y install net-tools
 
 ENV PATH="/usr/local/scope:/usr/local/scope/bin:${PATH}"
 COPY scope-profile.sh /etc/profile.d/scope.sh

--- a/test/testContainers/test_runner/ab.py
+++ b/test/testContainers/test_runner/ab.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 
 from utils import extract_num
@@ -17,6 +18,9 @@ def run_apache_benchmark(url, requests=10, concur=4, post_file=None):
     command = f"ab -n {requests} -c {concur} {post_param} {url}"
 
     logging.debug("Running Apache Benchmark. Command " + command)
+
+    # We're not testing scoped `ab` so disable this
+    os.unsetenv('LD_PRELOAD')
 
     out = subprocess.run(command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
                          shell=True)


### PR DESCRIPTION
We found the default behavior of scope to reconnect to tcp:9109 for
events was impacting operation of Nginx. Not sure how - another ticket
coming for that. In the mean time, we've adjusted the env vars to
disable events and set the event destination to a file instead of a
socket.

We've also unset LD_PRELOAD when running `ab` since the intention of
this is to test scoped Nginx, not Apache Benchmark.

Closes #450