### PR TITLE
Add timeouts to handleExit and doEvent

### DIFF
--- a/src/report.c
+++ b/src/report.c
@@ -2445,7 +2445,15 @@ doEvent()
 
     if (ready == FALSE) return;
 
+    elapsed_t time = {0};
+    time.initial = getTime();
+
     while ((data = msgEventGet(g_ctl)) != -1) {
+
+        // timeout after 1 second
+        time.duration = getDuration(time.initial);
+        if (time.duration > 1) break;
+
         if (data) {
             evt_type *event = (evt_type *)data;
             net_info *net;

--- a/src/report.h
+++ b/src/report.h
@@ -78,7 +78,6 @@ typedef enum {
     STREAM,
 } fs_type_t;
 
-
 // Interfaces
 extern mtc_t *g_mtc;
 extern ctl_t *g_ctl;

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,11 +2,17 @@
 #define __UTILS_H__
 
 #include <time.h>
+#include <stdint.h>
 
 typedef struct {
     const char *str;
     unsigned val;
 } enum_map_t;
+
+typedef struct {
+    uint64_t initial;
+    uint64_t duration;
+} elapsed_t;
 
 unsigned int strToVal(enum_map_t[], const char*);
 const char* valToStr(enum_map_t[], unsigned int);

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -933,10 +933,10 @@ handleExit(void)
     }
 
     if (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
-        struct timespec ts = {.tv_sec = 0, .tv_nsec = 10000}; // 10 us
-
         // let the periodic thread finish
-        while (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
+        // or timeout after 1 second
+        for (int i = 0; i < 100000; i++) {
+            if (atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) break;
             sigSafeNanosleep(&ts);
         }
         doEvent();

--- a/src/wrap.h
+++ b/src/wrap.h
@@ -30,11 +30,6 @@ typedef struct thread_timing_t {
     const struct sigaction *act;
 } thread_timing;
 
-typedef struct {
-    uint64_t initial;
-    uint64_t duration;
-} elapsed_t;
-
 extern int close$NOCANCEL(int);
 extern int guarded_close_np(int, void *);
 


### PR DESCRIPTION
We cannot have potentially infinite loops during graceful exit of scope. We are introducing timeouts to two loops:

Add a 1 second timeout in `handleExit()` - in the wait for the periodic thread to finish
Add a 1 second timeout in `doEvent()` - when reading events