### PR TITLE
Add authtoken to config regardless of -c

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -69,7 +69,7 @@ scope: $(SCOPE)
 
 $(SCOPE): export GOOS=linux
 $(SCOPE): export CGO_ENABLED=0
-$(SCOPE): run/bundle.go $(GOVVV)
+$(SCOPE): run/bundle.go $(GOVVV) $(filter-out %_test.go,$(shell find . -type f -name '*.go'))
 	$(GO) build \
 		-ldflags="$(shell $(GOVVV) -flags)" \
 		$(BUILD_OPTS) \

--- a/cli/run/scopeconfig.go
+++ b/cli/run/scopeconfig.go
@@ -313,6 +313,10 @@ func (c *Config) configFromRunOpts() error {
 		}
 	}
 
+	// Add AuthToken to config regardless of cribldest being set
+	// To support mixing of config and environment variables
+	c.sc.Cribl.AuthToken = c.AuthToken
+
 	if c.CriblDest != "" {
 		err := parseDest(&c.sc.Cribl.Transport, c.CriblDest)
 		if err != nil {
@@ -323,7 +327,6 @@ func (c *Config) configFromRunOpts() error {
 		c.sc.Metric.Transport = ScopeTransport{}
 		c.sc.Event.Transport = ScopeTransport{}
 		c.sc.Libscope.ConfigEvent = true
-		c.sc.Cribl.AuthToken = c.AuthToken
 	}
 
 	if c.Loglevel != "" {
@@ -372,5 +375,5 @@ func (c *Config) WriteScopeConfig(path string, filePerms os.FileMode) error {
 
 func scopeLogRegex() string {
 	// see scopeconfig_test.go for example paths that match
-	return `(\/logs?\/)|(\.log$)|(\.log[.\d])`;
+	return `(\/logs?\/)|(\.log$)|(\.log[.\d])`
 }


### PR DESCRIPTION
Unconditionally add authtoken to scopeconfig, regardless of whether or not -c is set.
This supports mixing of the environment variable `SCOPE_CRIBL` and the `--authtoken` flag.

Closes #469