### PR TITLE
Exit scope metrics if metrics file is empty

### DIFF
--- a/cli/cmd/events.go
+++ b/cli/cmd/events.go
@@ -130,7 +130,7 @@ scope events -n 1000 -e 'sourcetype!="console" && source.indexOf("cribl.log") ==
 		if err != nil && strings.Contains(err.Error(), "events.json: no such file or directory") {
 			if util.CheckFileExists(sessions[0].EventsDestPath) {
 				dest, _ := ioutil.ReadFile(sessions[0].EventsDestPath)
-				fmt.Printf("events were output to %s\n", dest)
+				fmt.Printf("Events were output to %s\n", dest)
 				os.Exit(0)
 			}
 			promptClean(sessions[0:1])

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -35,7 +35,7 @@ var metricsCmd = &cobra.Command{
 		sessions := sessionByID(id)
 
 		if graph && len(names) == 0 {
-			helpErrAndExit(cmd, "Must specify a metric names with --graph")
+			helpErrAndExit(cmd, "Must specify metric names with --graph")
 		} else if cols && len(names) == 0 {
 			helpErrAndExit(cmd, "Must specify metric names with --cols")
 		}
@@ -109,6 +109,10 @@ var metricsCmd = &cobra.Command{
 		}
 
 		if graph {
+			if len(values) == 0 {
+				util.ErrAndExit("Valid metric names required with --graph")
+			}
+
 			termWidth, _, err := terminal.GetSize(0)
 			if err != nil {
 				// If we cannot get the terminal size, we are dealing with redirected stdin

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -44,7 +44,7 @@ var metricsCmd = &cobra.Command{
 		if err != nil && strings.Contains(err.Error(), "metrics.json: no such file or directory") {
 			if util.CheckFileExists(sessions[0].MetricsDestPath) {
 				dest, _ := ioutil.ReadFile(sessions[0].MetricsDestPath)
-				fmt.Printf("metrics were output to %s\n", dest)
+				fmt.Printf("Metrics were output to %s\n", dest)
 				os.Exit(0)
 			}
 			promptClean(sessions[0:1])
@@ -57,6 +57,7 @@ var metricsCmd = &cobra.Command{
 			util.ErrAndExit("Couldn't stat file: %s", file.Name())
 		}
 		if fstat.Size() == 0 {
+			fmt.Println("No metrics available")
 			os.Exit(0)
 		}
 

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -49,6 +49,17 @@ var metricsCmd = &cobra.Command{
 			}
 			promptClean(sessions[0:1])
 		}
+		defer file.Close()
+
+		// Check for empty metrics file
+		fstat, err := file.Stat()
+		if err != nil {
+			util.ErrAndExit("Couldn't stat file: %s", file.Name())
+		}
+		if fstat.Size() == 0 {
+			os.Exit(0)
+		}
+
 		in := make(chan metrics.Metric)
 		offsetChan := make(chan int)
 		filters := []util.MatchFunc{}

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -26,7 +26,7 @@ func sessionByID(id int) history.SessionList {
 }
 
 func promptClean(sl history.SessionList) {
-	fmt.Print("Invalid session, likely an invalid command was scoped. Would you like to delete this session? (default: yes) [y/n] ")
+	fmt.Print("Invalid session, likely an invalid command was scoped or a session file was modified. Would you like to delete this session? (default: yes) [y/n] ")
 	var response string
 	_, err := fmt.Scanf("%s", &response)
 	util.CheckErrSprintf(err, "error reading response: %v", err)


### PR DESCRIPTION
Prior to this, scope would attempt to create a graph when there are no metrics available, causing errors.

Closes #467