### PR TITLE
Extend scope with "completion" command

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/criblio/scope/util"
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh]",
+	Short: "Generate completion code for specified shell",
+	Example: `scope completion bash > /etc/bash_completion.d/scope # Generates and install scope autocompletion for bash
+source <(scope completion bash)                      # Generates and load scope autocompletion for bash
+`,
+	ValidArgs: []string{"bash", "zsh"},
+	Args:      cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		switch args[0] {
+		case "bash":
+			err = cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			err = cmd.Root().GenZshCompletion(os.Stdout)
+		default:
+			util.ErrAndExit("Unsupported shell type %q", args[0])
+		}
+		if err != nil {
+			util.ErrAndExit("Unable to generate completion script")
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(completionCmd)
+}

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt update -y && \
-    apt install -y ca-certificates && \
+    apt install -y bash-completion ca-certificates && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -21,3 +21,5 @@ COPY bin/linux/aarch64/* /usr/local/scope/aarch64/
 COPY conf/scope.yml      /usr/local/scope/aarch64/scope.yml
 
 RUN rm -f /usr/local/scope/*/.gitignore
+RUN echo "source /etc/profile.d/bash_completion.sh" >> ~/.bashrc && \
+    echo "source <(/usr/local/bin/scope completion bash)" >> ~/.bashrc


### PR DESCRIPTION
Completion of commands is enabled by calling:
source <(./bin/linux/x86_64/scope completion bash)

Fixes #361
Ref: https://github.com/spf13/cobra/blob/master/shell_completions.md#creating-your-own-completion-command

Tested with following binary: ./bin/linux/x86_64/scope

TODO:

- [x] Extend Docker etc shell completion configuration with scope completion config