### PR TITLE
Updated the sequence of steps taken on exit.

### DIFF
--- a/src/report.c
+++ b/src/report.c
@@ -2417,10 +2417,9 @@ doNetMetric(metric_t type, net_info *net, control_type_t source, ssize_t size)
     }
 }
 
-void
-doEvent()
+bool
+doConnection(void)
 {
-    uint64_t data;
     bool ready = FALSE;
 
     // if no connection, don't pull data from the queue
@@ -2443,7 +2442,15 @@ doEvent()
         }
     }
 
-    if (ready == FALSE) return;
+    return ready;
+}
+
+void
+doEvent()
+{
+    uint64_t data;
+
+    if (doConnection() == FALSE) return;
 
     while ((data = msgEventGet(g_ctl)) != -1) {
         if (data) {

--- a/src/report.h
+++ b/src/report.h
@@ -92,5 +92,6 @@ void doTotal(metric_t);
 void doTotalDuration(metric_t);
 void doEvent(void);
 void doPayload(void);
+bool doConnection(void);
 
 #endif // __REPORT_H__


### PR DESCRIPTION
Resolves #395 

Changed the sequence of events on exit. We weren't creating the connection until the periodic thread ran, which created more of a delay than was needed. We should report periodic detail instead of processing events during exit handling when the connection is established.