### PR TITLE
Detect binary data and avoid emits it

### DIFF
--- a/os/linux/Makefile
+++ b/os/linux/Makefile
@@ -87,21 +87,21 @@ coretest: export USER ?= $(shell id -u -n)
 coretest: $(C_FILES) $(YAML_AR) $(JSON_AR) $(TEST_LIB)
 	@echo "$${CI:+::group::}Building Tests"
 	$(CC) -c $(TEST_CFLAGS) $(C_FILES) $(INCLUDES) $(TEST_INCLUDES)
-	$(CC) $(TEST_CFLAGS) -o test/$(OS)/cfgutilstest cfgutilstest.o cfgutils.o cfg.o mtc.o log.o evtformat.o ctl.o transport.o mtcformat.o com.o dbg.o circbuf.o linklist.o fn.o utils.o os.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
+	$(CC) $(TEST_CFLAGS) -o test/$(OS)/cfgutilstest cfgutilstest.o cfgutils.o cfg.o mtc.o log.o evtformat.o ctl.o transport.o mtcformat.o com.o dbg.o circbuf.o linklist.o fn.o utils.o os.o test.o report.o search.o httpagg.o state.o httpstate.o plattime.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/cfgtest cfgtest.o cfg.o dbg.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/transporttest transporttest.o transport.o dbg.o log.o fn.o utils.o os.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/logtest logtest.o log.o transport.o dbg.o fn.o utils.o os.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
-	$(CC) $(TEST_CFLAGS) -o test/$(OS)/mtctest mtctest.o mtc.o log.o transport.o mtcformat.o com.o ctl.o evtformat.o cfg.o cfgutils.o dbg.o circbuf.o linklist.o fn.o utils.o os.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
-	$(CC) $(TEST_CFLAGS) -o test/$(OS)/evtformattest evtformattest.o evtformat.o log.o transport.o mtcformat.o dbg.o cfg.o com.o ctl.o mtc.o circbuf.o cfgutils.o linklist.o fn.o utils.o os.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
-	$(CC) $(TEST_CFLAGS) -o test/$(OS)/ctltest ctltest.o ctl.o log.o transport.o dbg.o cfgutils.o cfg.o com.o mtc.o evtformat.o mtcformat.o circbuf.o linklist.o fn.o utils.o os.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
+	$(CC) $(TEST_CFLAGS) -o test/$(OS)/mtctest mtctest.o mtc.o log.o transport.o mtcformat.o com.o ctl.o evtformat.o cfg.o cfgutils.o dbg.o circbuf.o linklist.o fn.o utils.o os.o test.o report.o search.o httpagg.o state.o httpstate.o plattime.o $(TEST_AR) $(TEST_LD_FLAGS)
+	$(CC) $(TEST_CFLAGS) -o test/$(OS)/evtformattest evtformattest.o evtformat.o log.o transport.o mtcformat.o dbg.o cfg.o com.o ctl.o mtc.o circbuf.o cfgutils.o linklist.o fn.o utils.o os.o test.o report.o search.o httpagg.o state.o httpstate.o plattime.o $(TEST_AR) $(TEST_LD_FLAGS)
+	$(CC) $(TEST_CFLAGS) -o test/$(OS)/ctltest ctltest.o ctl.o log.o transport.o dbg.o cfgutils.o cfg.o com.o mtc.o evtformat.o mtcformat.o circbuf.o linklist.o fn.o utils.o os.o test.o report.o search.o httpagg.o state.o httpstate.o plattime.o $(TEST_AR) $(TEST_LD_FLAGS) -Wl,--wrap=cbufGet
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/httpstatetest httpstatetest.o httpstate.o plattime.o search.o fn.o utils.o os.o dbg.o test.o $(TEST_AR) $(TEST_LD_FLAGS) -lrt
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/httpheadertest httpheadertest.o report.o httpagg.o state.o com.o httpstate.o plattime.o fn.o utils.o os.o ctl.o log.o transport.o dbg.o cfgutils.o cfg.o mtc.o evtformat.o mtcformat.o circbuf.o linklist.o search.o test.o $(TEST_AR) $(TEST_LD_FLAGS) -Wl,--wrap=cmdSendHttp -Wl,--wrap=cmdPostEvent
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/httpaggtest httpaggtest.o httpagg.o fn.o utils.o dbg.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/reporttest reporttest.o report.o httpagg.o state.o httpstate.o com.o plattime.o fn.o utils.o os.o ctl.o log.o transport.o dbg.o cfgutils.o cfg.o mtc.o evtformat.o mtcformat.o circbuf.o linklist.o search.o test.o $(TEST_AR) $(TEST_LD_FLAGS) -Wl,--wrap=cmdSendEvent -Wl,--wrap=cmdSendMetric
-	$(CC) $(TEST_CFLAGS) -o test/$(OS)/mtcformattest mtcformattest.o mtcformat.o dbg.o log.o transport.o com.o ctl.o mtc.o evtformat.o cfg.o cfgutils.o linklist.o fn.o utils.o circbuf.o os.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
+	$(CC) $(TEST_CFLAGS) -o test/$(OS)/mtcformattest mtcformattest.o mtcformat.o dbg.o log.o transport.o com.o ctl.o mtc.o evtformat.o cfg.o cfgutils.o linklist.o fn.o utils.o circbuf.o os.o test.o report.o search.o httpagg.o state.o httpstate.o plattime.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/circbuftest circbuftest.o circbuf.o dbg.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/linklisttest linklisttest.o linklist.o dbg.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
-	$(CC) $(TEST_CFLAGS) -o test/$(OS)/comtest comtest.o com.o ctl.o log.o transport.o evtformat.o circbuf.o mtcformat.o cfgutils.o cfg.o mtc.o dbg.o linklist.o fn.o utils.o os.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
+	$(CC) $(TEST_CFLAGS) -o test/$(OS)/comtest comtest.o com.o ctl.o log.o transport.o evtformat.o circbuf.o mtcformat.o cfgutils.o cfg.o mtc.o dbg.o linklist.o fn.o utils.o os.o test.o report.o search.o httpagg.o state.o httpstate.o plattime.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/dbgtest dbgtest.o dbg.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/glibcvertest glibcvertest.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/selfinterposetest selfinterposetest.o $(TEST_AR) $(TEST_LD_FLAGS)

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -783,7 +783,7 @@ ctlPostEvent(ctl_t *ctl, char *event)
     return 0;
 }
 
-log_event_t *
+static log_event_t *
 createInternalLogEvent(int fd, const char *path, const void *buf, size_t count, uint64_t uid, proc_id_t *proc, watch_t logType, regex_t *valfilter)
 {
     log_event_t *event = calloc(1, sizeof(*event));
@@ -815,7 +815,7 @@ createInternalLogEvent(int fd, const char *path, const void *buf, size_t count, 
     return event;
 }
 
-void
+static void
 destroyInternalLogEvent(log_event_t **eventptr)
 {
     if (!eventptr || !*eventptr) return;

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -11,6 +11,7 @@
 #include "dbg.h"
 #include "com.h"
 #include "fn.h"
+#include "state.h"
 
 #define FS_ENTRIES 1024
 #define DEFAULT_LOG_MAX_AGG_BYTES 32768
@@ -18,6 +19,9 @@
 
 #define CHANNEL "_channel"
 #define ID "id"
+
+#define BINARY_DATA_MSG "Binary data detected--- message"
+#define DEFAULT_BINARY_DATA_SAMPLE_SIZE (256U)
 
 typedef struct {
     char *buf;
@@ -827,6 +831,20 @@ destroyInternalLogEvent(log_event_t **eventptr)
     *eventptr = NULL;
 }
 
+static bool
+is_data_binary(const void *buf, size_t count)
+{
+    const char* b_buf = (const char *)buf;
+    size_t min_len = (count < DEFAULT_BINARY_DATA_SAMPLE_SIZE) ? count : DEFAULT_BINARY_DATA_SAMPLE_SIZE;
+    size_t i;
+    for (i = 0; i < min_len; i++) {
+        if (!isprint(b_buf[i]) && (!isspace(b_buf[i]))) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
 int
 ctlSendLog(ctl_t *ctl, int fd, const char *path, const void *buf, size_t count, uint64_t uid, proc_id_t *proc)
 {
@@ -851,8 +869,24 @@ ctlSendLog(ctl_t *ctl, int fd, const char *path, const void *buf, size_t count, 
     // it to be used later, after we've created a string from the data.
     filter = evtFormatValueFilter(ctl->evt, logType);
 
-    log_event_t *logevent;
-    logevent = createInternalLogEvent(fd, path, buf, count, uid, proc, logType, filter);
+    log_event_t *logevent = NULL;
+    if (logType == CFG_SRC_CONSOLE) {
+        bool binary_state = getFSBinaryDataState(fd);
+        if (binary_state) {
+            // Handle only first event of binary data, drop and ignore rest
+            return -1;
+        }
+        binary_state = is_data_binary(buf, count);
+        setFSBinaryDataState(fd, binary_state);
+        if (binary_state) {
+            logevent = createInternalLogEvent(fd, path, BINARY_DATA_MSG, sizeof(BINARY_DATA_MSG) - 1, uid, proc, logType, filter);
+        }
+    }
+
+    // This will be true for CFG_SRC_FILE, or if CFG_SRC_CONSOLE is TEXT.
+    if (!logevent) {
+        logevent = createInternalLogEvent(fd, path, buf, count, uid, proc, logType, filter);
+    }
 
     if (cbufPut(ctl->log.ringbuf, (uint64_t)logevent) == -1) {
         // Full; drop and ignore

--- a/src/state.c
+++ b/src/state.c
@@ -1298,6 +1298,28 @@ setRemoteClose(int sd, int err)
     }
 }
 
+bool
+getFSBinaryDataState(int fd)
+{
+    struct fs_info_t *fs = getFSEntry(fd);
+    if (fs) {
+       return fs->binary_data;
+    }
+    DBG(NULL);
+    return FALSE;
+}
+
+void
+setFSBinaryDataState(int fd, bool state)
+{
+    struct fs_info_t *fs = getFSEntry(fd);
+    if (fs) {
+        fs->binary_data = state;
+    } else {
+        DBG(NULL);
+    }
+}
+
 void
 addSock(int fd, int type, int family)
 {

--- a/src/state.h
+++ b/src/state.h
@@ -65,5 +65,7 @@ int doSSL(uint64_t, int, void *, size_t, metric_t, src_data_t, char *);
 bool addProtocol(request_t *);
 bool delProtocol(request_t *);
 void setRemoteClose(int, int);
+void setFSBinaryDataState(int, bool);
+bool getFSBinaryDataState(int);
 
 #endif // __STATE_H__

--- a/src/state_private.h
+++ b/src/state_private.h
@@ -194,6 +194,7 @@ typedef struct fs_info_t {
     metric_t data_type;
     int fd;
     int active;
+    bool binary_data;
     fs_type_t type;
     counters_element_t numOpen;
     counters_element_t numClose;

--- a/test/testContainers/README.md
+++ b/test/testContainers/README.md
@@ -63,7 +63,7 @@ AppScope Integration Test Runner
   `make (test)` - run a single test
   `make (test)-shell` - run a shell in the test's container
   `make (test)-build` - build the test's image
-Tests: alpine bash cribl detect-proto elastic gogen go-1.2 go-1.3 go-1.4 go-1.5 go-1.6 go-1.7 go-1.8 go-1.9 go-1.10 go-1.11 go-1.12 go-1.13 go-1.14 go-1.15 go-1.16 java6 java7 java8 java9 java10 java11 java12 java13 java14 kafka nginx oracle-java6 oracle-java7 oracle-java8 oracle-java9 oracle-java10 oracle-java11 oracle-java12 oracle-java13 oracle-java14 splunk syscalls tls
+Tests: alpine bash console cribl detect-proto elastic gogen go-1.2 go-1.3 go-1.4 go-1.5 go-1.6 go-1.7 go-1.8 go-1.9 go-1.10 go-1.11 go-1.12 go-1.13 go-1.14 go-1.15 go-1.16 java6 java7 java8 java9 java10 java11 java12 java13 java14 kafka nginx oracle-java6 oracle-java7 oracle-java8 oracle-java9 oracle-java10 oracle-java11 oracle-java12 oracle-java13 oracle-java14 splunk syscalls tls
 $
 ```
 

--- a/test/testContainers/console/Dockerfile
+++ b/test/testContainers/console/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update \
+    && apt install -y \
+      curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/test/log
+
+ENV SCOPE_LOG_LEVEL=error
+ENV SCOPE_METRIC_VERBOSITY=4
+ENV SCOPE_EVENT_LOGFILE=true
+ENV SCOPE_EVENT_CONSOLE=true
+ENV SCOPE_EVENT_METRIC=true
+ENV SCOPE_EVENT_HTTP=true
+ENV SCOPE_EVENT_DEST=file:///opt/test/log/events.log
+
+ENV PATH="/usr/local/scope:/usr/local/scope/bin:${PATH}"
+COPY scope-profile.sh /etc/profile.d/scope.sh
+COPY gdbinit /root/.gdbinit
+
+RUN  mkdir /usr/local/scope && \
+     mkdir /usr/local/scope/bin && \
+     mkdir /usr/local/scope/lib && \
+     ln -s /opt/appscope/bin/linux/$(uname -m)/scope /usr/local/scope/bin/scope && \
+     ln -s /opt/appscope/bin/linux/$(uname -m)/ldscope /usr/local/scope/bin/ldscope && \
+     ln -s /opt/appscope/lib/linux/$(uname -m)/libscope.so /usr/local/scope/lib/libscope.so
+
+COPY ./console/scope-test /usr/local/scope/scope-test
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["test"]

--- a/test/testContainers/console/scope-test
+++ b/test/testContainers/console/scope-test
@@ -1,0 +1,108 @@
+#!/bin/bash
+DEBUG=0  # set this to 1 to capture the EVT_FILE for each test
+
+FAILED_TEST_LIST=""
+FAILED_TEST_COUNT=0
+
+EVT_FILE="/opt/test/log/events.log"
+BINARY_MSG="Binary data detected--- message"
+
+starttest(){
+    CURRENT_TEST=$1
+    echo "==============================================="
+    echo "             Testing $CURRENT_TEST             "
+    echo "==============================================="
+    ERR=0
+}
+
+evaltest(){
+    echo "             Evaluating $CURRENT_TEST"
+}
+
+endtest(){
+    if [ $ERR -eq "0" ]; then
+        RESULT=PASSED
+    else
+        RESULT=FAILED
+        FAILED_TEST_LIST+=$CURRENT_TEST
+        FAILED_TEST_LIST+=" "
+        FAILED_TEST_COUNT=$(($FAILED_TEST_COUNT + 1))
+    fi
+
+    echo "*************** $CURRENT_TEST $RESULT ***************"
+    echo ""
+    echo ""
+
+    # copy the EVT_FILE to help with debugging
+    if (( $DEBUG )) || [ $RESULT == "FAILED" ]; then
+        cp -f $EVT_FILE $EVT_FILE.$CURRENT_TEST
+    fi
+
+    rm -f $EVT_FILE
+}
+
+export SCOPE_PAYLOAD_ENABLE=true
+export SCOPE_PAYLOAD_HEADER=true
+
+#
+# cat html (negative test)
+#
+
+starttest cat_html
+
+ldscope cat docker/demo/nginx/html/index.html > /dev/null
+evaltest
+
+grep "$BINARY_MSG" $EVT_FILE > /dev/null
+if [ $? -eq 0 ]; then
+    ERR+=1
+fi
+
+endtest
+
+#
+# cat binary file
+#
+
+starttest cat_binary
+
+ldscope cat /usr/local/scope/bin/ldscope > /dev/null
+evaltest
+
+grep "$BINARY_MSG" $EVT_FILE > /dev/null
+ERR+=$?
+
+endtest
+
+
+#
+# curl png
+#
+
+starttest curl_png
+
+ldscope curl https://upload.wikimedia.org/wikipedia/commons/e/e9/Felis_silvestris_silvestris_small_gradual_decrease_of_quality.png --output - > /dev/null
+evaltest
+
+grep "$BINARY_MSG" $EVT_FILE > /dev/null
+ERR+=$?
+
+endtest
+
+unset SCOPE_PAYLOAD_ENABLE
+unset SCOPE_PAYLOAD_HEADER
+
+if (( $FAILED_TEST_COUNT == 0 )); then
+    echo ""
+    echo ""
+    echo "*************** ALL TESTS PASSED ***************"
+else
+    echo "*************** SOME TESTS FAILED ***************"
+    echo "Failed tests: $FAILED_TEST_LIST"
+    echo "Refer to these files for more info:"
+    for FAILED_TEST in $FAILED_TEST_LIST; do
+        echo "  $EVT_FILE.$FAILED_TEST"
+    done
+fi
+
+exit ${FAILED_TEST_COUNT}

--- a/test/testContainers/docker-compose.yml
+++ b/test/testContainers/docker-compose.yml
@@ -136,4 +136,13 @@ services:
       - "9000:9000"
     <<: *scope-common
 
+  console:
+    image: ghcr.io/criblio/appscope-test-console:${TAG:?Missing TAG environment variable}
+    build:
+      cache_from: 
+        - ghcr.io/criblio/appscope-test-console:${TAG:?Missing TAG environment variable}
+      context: .
+      dockerfile: ./console/Dockerfile
+    <<: *scope-common
+
 # vim: ts=2 sw=2 et :


### PR DESCRIPTION
Local test pass with a simple:
 LD_PRELOAD=lib/linux/x86_64/libscope.so cat png file
and
/bin/linux/scope run -- cat png file

~Fail with curl command~

isprint - accepts besides digits, letters, space characters and punctuation characters which could be presented in the beginning of the e.g. HTML files
isspace - accepts characters like '\n' or '\r'

- Operation is done on ctlFlushLog on report side layer
- Verify beginning of the data to lookout for characters
  different from printable or white-space
- Ref:
  https://www.cplusplus.com/reference/cctype/isprint/
  https://www.cplusplus.com/reference/cctype/isspace/
