### PR TITLE
fix build caching issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
     branches:
       - 'main'
       - 'master'
-      - 'releases/*'
+      - 'release/*'
 
 jobs:
 
@@ -178,8 +178,6 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-${{ steps.env.outputs.arch }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.env.outputs.arch }}-buildx-
           upload-chunk-size: 1000000
 
       # Cache downloaded Go dependencies.
@@ -193,8 +191,6 @@ jobs:
             cli/.gocache
             cli/.gomod
           key: ${{ runner.os }}-${{ steps.env.outputs.arch }}-go-${{ hashFiles('cli/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.env.outputs.arch }}-go-
           upload-chunk-size: 1000000
 
       # Cache the cmocka build. Use a key based on a hash of all the files used
@@ -204,8 +200,6 @@ jobs:
         with:
           path: contrib/build/cmocka
           key: ${{ runner.os }}-${{ steps.env.outputs.arch }}-cmocka-${{ hashFiles('contrib/Makefile', 'contrib/cmocka/**') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.env.outputs.arch }}-cmocka-
           upload-chunk-size: 1000000
 
       # Cache the funchook build. Use a key based on a hash of all the files
@@ -215,8 +209,6 @@ jobs:
         with:
           path: contrib/build/funchook
           key: ${{ runner.os }}-${{ steps.env.outputs.arch }}-funchook-${{ hashFiles('contrib/Makefile', 'contrib/funchook/**') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.env.outputs.arch }}-funchook-
           upload-chunk-size: 1000000
 
       # Cache the funchook build. Use a key based on a hash of all the files
@@ -226,8 +218,6 @@ jobs:
         with:
           path: contrib/build/pcre2
           key: ${{ runner.os }}-${{ steps.env.outputs.arch }}-pcre2-${{ hashFiles('contrib/Makefile', 'contrib/cpre2/**') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.env.outputs.arch }}-pcre2-
           upload-chunk-size: 1000000
 
       # Cache the openssl build. Use a key based on a hash of all the files
@@ -237,8 +227,6 @@ jobs:
         with:
           path: contrib/build/openssl
           key: ${{ runner.os }}-${{ steps.env.outputs.arch }}-openssl-${{ hashFiles('contrib/Makefile', 'contrib/openssl/**') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.env.outputs.arch }}-openssl-
           upload-chunk-size: 1000000
 
       # Build our `appscope-builder` image. This should only end up using the


### PR DESCRIPTION
See the write-up in #518 for why we need to remove the `restore-key`
entries.

The `releases/` -> `release/` change causes the integration tests to be
run for PRs targeting the release branches.

Closes #518.