### PR TITLE
[Minor] Optimize initState() function 

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -235,25 +235,15 @@ error:
 void
 initState()
 {
-    net_info *netinfoLocal;
-    fs_info *fsinfoLocal;
-    if ((netinfoLocal = (net_info *)malloc(sizeof(struct net_info_t) * NET_ENTRIES)) == NULL) {
-        scopeLog("ERROR: Constructor:Malloc", -1, CFG_LOG_ERROR);
-    }
-
-    if (netinfoLocal) memset(netinfoLocal, 0, sizeof(struct net_info_t) * NET_ENTRIES);
-
     // Per a Read Update & Change (RUC) model; now that the object is ready assign the global
-    g_netinfo = netinfoLocal;
-
-    if ((fsinfoLocal = (fs_info *)malloc(sizeof(struct fs_info_t) * FS_ENTRIES)) == NULL) {
-        scopeLog("ERROR: Constructor:Malloc", -1, CFG_LOG_ERROR);
+    if ((g_netinfo = (net_info *)calloc(1, sizeof(struct net_info_t) * NET_ENTRIES)) == NULL) {
+        scopeLog("ERROR: Constructor:Calloc", -1, CFG_LOG_ERROR);
     }
-
-    if (fsinfoLocal) memset(fsinfoLocal, 0, sizeof(struct fs_info_t) * FS_ENTRIES);
 
     // Per RUC...
-    g_fsinfo = fsinfoLocal;
+    if ((g_fsinfo = (fs_info *)calloc(1, sizeof(struct fs_info_t) * FS_ENTRIES)) == NULL) {
+        scopeLog("ERROR: Constructor:Calloc", -1, CFG_LOG_ERROR);
+    }
 
     initHttpState();
     // the http guard array is static while the net fs array is dynamically allocated


### PR DESCRIPTION
- use calloc instead of malloc + memset
Found during work on other PR.