### PR TITLE
Add PRINTF_FORMAT as compiler format attribute

### DIFF
--- a/src/dbg.h
+++ b/src/dbg.h
@@ -25,6 +25,8 @@ void                 dbgAddLine(const char* key, const char* fmt, ...);
 #define TOSTRING(x) STRINGIFY(x)
 #define DBG_FILE_AND_LINE __FILE__ ":" TOSTRING(__LINE__)
 
+#define PRINTF_FORMAT(fmt_id, arg_id) __attribute__((format(printf, (fmt_id), (arg_id))))
+
 //
 //  The DBG macro is used to keep track of unexpected/undesirable
 //  conditions as instrumented with DBG in the source code.  This is done

--- a/src/gocontext.h
+++ b/src/gocontext.h
@@ -46,7 +46,7 @@ extern uint64_t scope_stack;
 
 extern int arch_prctl(int, unsigned long);
 extern void initGoHook(elf_buf_t*);
-extern void sysprint(const char *, ...);
+extern void sysprint(const char *, ...) PRINTF_FORMAT(1, 2);
 extern void *getSymbol(const char *, char *);
 
 extern void go_hook_write(void);

--- a/src/wrap_go.c
+++ b/src/wrap_go.c
@@ -476,7 +476,7 @@ initGoHook(elf_buf_t *ebuf)
             return; // don't install our hooks
         }
         Elf64_Shdr* textSec = getElfSection(ebuf->buf, ".text");
-        sysprint("base %lx %lx %x\n", base, (uint64_t)ebuf->text_addr, textSec->sh_offset);
+        sysprint("base %lx %lx %lx\n", base, (uint64_t)ebuf->text_addr, textSec->sh_offset);
         base = base - (uint64_t)ebuf->text_addr + textSec->sh_offset;
     }
     
@@ -559,7 +559,7 @@ initGoHook(elf_buf_t *ebuf)
         asm_count = cs_disasm(disass_handle, orig_func, size,
                                  (uint64_t)orig_func, 0, &asm_inst);
         if (asm_count <= 0) {
-            sysprint("ERROR: disassembler fails: %s\n\tlen %d code %p result %d\n\ttext addr %p text len %d oinfotext %p\n",
+            sysprint("ERROR: disassembler fails: %s\n\tlen %" PRIu64 " code %p result %lu\n\ttext addr %p text len %zu oinfotext 0x%" PRIx64 "\n",
                      tap->func_name, size,
                      orig_func, sizeof(asm_inst), ebuf->text_addr, ebuf->text_len, offset_into_txt);
             continue;
@@ -1152,7 +1152,7 @@ c_http_server_read(char *stackaddr)
                 fd = *(int *)(pfd + g_go.pd_to_fd);
             }
 
-            funcprint("Scope: go_http_server_read of %ld\n", fd);
+            funcprint("Scope: go_http_server_read of %d\n", fd);
             doProtocol((uint64_t)0, fd, (void *)buf, rc, TLSRX, BUF);
         }
     }
@@ -1200,7 +1200,7 @@ c_http_server_write(char *stackaddr)
                 fd = *(int *)(pfd + g_go.pd_to_fd);
             }
 
-            funcprint("Scope: c_http_server_write of %ld\n", fd);
+            funcprint("Scope: c_http_server_write of %d\n", fd);
             doProtocol((uint64_t)0, fd, (void *)buf, rc, TLSTX, BUF);
         }
     }


### PR DESCRIPTION
 - add awareness to variadic functions about format specifier

Done while working on #514.
Changes from this patch will be included in another PR but the changes could be reviewed separately.
[Edit]
Example warnings, after adding compiler attribute: src/wrap_go.c:479:33: warning: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'Elf64_Off {aka long unsigned int}' [-Wformat=]
are presented https://github.com/criblio/appscope/pull/523/checks?check_run_id=3492739359 (with run which only enabled the compiler attribute.
Current patch includes fixes for warnings.
