### PR TITLE
Modify logging mechanism -  scopeLog

### DIFF
--- a/src/bashmem.c
+++ b/src/bashmem.c
@@ -167,18 +167,14 @@ bashMemFuncsFound()
         patch_info_t *func = &bash_mem_func[i];
         void *func_ptr = dlsym(exe_handle, func->name);
         if (!func_ptr) {
-            char buf[128];
-            snprintf(buf, sizeof(buf), "Couldn't find bash function %s", func->name);
-            scopeLog(buf, -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "Couldn't find bash function %s", func->name);
             continue;
         }
 
         const int DECODE_BYTES = 50;
         asm_count = cs_disasm(disass_handle, func_ptr, DECODE_BYTES, (uint64_t)func_ptr, 0, &asm_inst);
         if (asm_count <= 0) {
-            char buf[128];
-            snprintf(buf, sizeof(buf), "Couldn't disassemble bash function %s", func->name);
-            scopeLog(buf, -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "Couldn't disassemble bash function %s", func->name);
             continue;
         }
 
@@ -193,11 +189,9 @@ bashMemFuncsFound()
             }
         }
         if (j==asm_count) {
-            char buf[128];
-            snprintf(buf, sizeof(buf), "For bash function %s, couldn't find "
+            scopeLog(CFG_LOG_ERROR, "For bash function %s, couldn't find "
                 "a jmp instruction in the first %d instructions from 0x%p",
                 func->name, asm_count, func_ptr);
-            scopeLog(buf, -1, CFG_LOG_ERROR);
             continue;
         }
 
@@ -245,7 +239,7 @@ replaceBashMemFuncs()
 
     funchook_t *funchook = funchook_create();
     if (!funchook) {
-        scopeLog("funchook_create failed", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "funchook_create failed");
         return FALSE;
     }
 
@@ -264,10 +258,7 @@ replaceBashMemFuncs()
         void *addr_to_patch = func->internal_addr;
         rc = funchook_prepare(funchook, (void **)&addr_to_patch, (void *)func->fn_ptr);
         if (rc) {
-            char buf[128];
-            snprintf(buf, sizeof(buf), "funchook_prepare failed for %s at 0x%p",
-                func->name, func->internal_addr);
-            scopeLog(buf, -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR,"funchook_prepare failed for %s at 0x%p", func->name, func->internal_addr);
         } else {
             num_patched++;
         }
@@ -275,10 +266,7 @@ replaceBashMemFuncs()
 
     rc = funchook_install(funchook, 0);
     if (rc) {
-        char buf[128];
-        snprintf(buf, sizeof(buf), "ERROR: failed to install run_bash_mem_fix. (%s)\n",
-                 funchook_error_message(funchook));
-        scopeLog(buf, -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: failed to install run_bash_mem_fix. (%s)\n", funchook_error_message(funchook));
     }
 
     return !rc && (num_patched == bash_mem_func_count);
@@ -318,10 +306,7 @@ run_bash_mem_fix(void)
     successful = TRUE;
 out:
     {
-        char buf[128];
-        snprintf(buf, sizeof(buf), "run_bash_mem_fix was run %s",
-                 (successful) ? "successfully" : "but failed");
-        scopeLog(buf, -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "run_bash_mem_fix was run %s", (successful) ? "successfully" : "but failed");
     }
     return successful;
 }

--- a/src/cfgutils.c
+++ b/src/cfgutils.c
@@ -1564,11 +1564,9 @@ processProtocolPayload(config_t* config, yaml_document_t* doc, yaml_node_t* node
 static void
 processProtocolEntry(config_t* config, yaml_document_t* doc, yaml_node_t* node)
 {
-    char logBuf[256];
-
     // protocol entries must be key/value maps
     if (node->type != YAML_MAPPING_NODE) {
-        scopeLog("WARN: ignoring non-map protocol entry\n", -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "WARN: ignoring non-map protocol entry\n");
         return;
     }
 
@@ -1605,7 +1603,7 @@ processProtocolEntry(config_t* config, yaml_document_t* doc, yaml_node_t* node)
     if (!protocol_context->protname || !protocol_context->regex) {
         destroyProtEntry(protocol_context);
         protocol_context = NULL;
-        scopeLog("WARN: ignoring protocol entry missing name or regex\n", -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "WARN: ignoring protocol entry missing name or regex\n");
         return;
     }
 
@@ -1617,10 +1615,8 @@ processProtocolEntry(config_t* config, yaml_document_t* doc, yaml_node_t* node)
             PCRE2_ZERO_TERMINATED, 0,
             &errornumber, &erroroffset, NULL);
     if (!protocol_context->re) {
-        snprintf(logBuf, sizeof(logBuf),
-                 "WARN: invalid regex for \"%s\" protocol entry; %s\n",
+        scopeLog(CFG_LOG_WARN, "WARN: invalid regex for \"%s\" protocol entry; %s\n",
                  protocol_context->protname, protocol_context->regex);
-        scopeLog(logBuf, -1, CFG_LOG_WARN);
         destroyProtEntry(protocol_context);
         protocol_context = NULL;
         return;
@@ -1671,7 +1667,7 @@ static void
 processCustomFilterProcname(config_t* config, yaml_document_t* doc, yaml_node_t* node)
 {
     if (node->type != YAML_SCALAR_NODE) {
-        scopeLog("WARN: non-scalar procname value\n", -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "WARN: non-scalar procname value\n");
         custom_matched = FALSE;
         return;
     }
@@ -1692,7 +1688,7 @@ static void
 processCustomFilterArg(config_t* config, yaml_document_t* doc, yaml_node_t* node)
 {
     if (node->type != YAML_SCALAR_NODE) {
-        scopeLog("WARN: non-scalar arg value\n", -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "WARN: non-scalar arg value\n");
         custom_matched = FALSE;
         return;
     }
@@ -1712,7 +1708,7 @@ static void
 processCustomFilterHostname(config_t* config, yaml_document_t* doc, yaml_node_t* node)
 {
     if (node->type != YAML_SCALAR_NODE) {
-        scopeLog("WARN: non-scalar hostname value\n", -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "WARN: non-scalar hostname value\n");
         custom_matched = FALSE;
         return;
     }
@@ -1732,7 +1728,7 @@ static void
 processCustomFilterUsername(config_t* config, yaml_document_t* doc, yaml_node_t* node)
 {
     if (node->type != YAML_SCALAR_NODE) {
-        scopeLog("WARN: non-scalar username value\n", -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "WARN: non-scalar username value\n");
         custom_matched = FALSE;
         return;
     }
@@ -1753,7 +1749,7 @@ static void
 processCustomFilterEnv(config_t* config, yaml_document_t* doc, yaml_node_t* node)
 {
     if (node->type != YAML_SCALAR_NODE) {
-        scopeLog("WARN: non-scalar env value\n", -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "WARN: non-scalar env value\n");
         custom_matched = FALSE;
         return;
     }
@@ -1788,7 +1784,7 @@ static void
 processCustomFilterAncestor(config_t* config, yaml_document_t* doc, yaml_node_t* node)
 {
     if (node->type != YAML_SCALAR_NODE) {
-        scopeLog("WARN: non-scalar ancestor value\n", -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "WARN: non-scalar ancestor value\n");
         custom_matched = FALSE;
         return;
     }
@@ -1879,7 +1875,7 @@ processCustomConfig(config_t* config, yaml_document_t* doc, yaml_node_t* node)
 {
     // All filters have to match and there must be more than one filter
     if (!custom_matched || !custom_match_count) {
-        scopeLog("INFO: skipping custom config\n", -1, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "INFO: skipping custom config\n");
         return;
     }
 
@@ -1893,7 +1889,7 @@ processCustomEntry(config_t* config, yaml_document_t* doc, yaml_node_pair_t* pai
     yaml_node_t* node = yaml_document_get_node(doc, pair->value);
 
     if (node->type != YAML_MAPPING_NODE) {
-        scopeLog("WARN: ignoring non-map custom entry\n", -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "WARN: ignoring non-map custom entry\n");
         return;
     }
 
@@ -2681,7 +2677,7 @@ singleChannelSet(ctl_t *ctl, mtc_t *mtc)
 
     // if any logs created during cfg send now
     if (g_logmsg[0] != '\0') {
-        scopeLog(g_logmsg, -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "%s", g_logmsg);
     }
 
     transport_t *trans = ctlTransport(ctl, CFG_CTL);

--- a/src/com.c
+++ b/src/com.c
@@ -93,12 +93,8 @@ reportProcessStart(ctl_t *ctl, bool init, which_transport_t who)
     // only emit metric and log msgs at init time
     if (init) {
         // 3) Log it at startup, provided the loglevel is set to allow it
-        scopeLog("Constructor (Scope Version: " SCOPE_VER ")", -1, CFG_LOG_INFO);
-        char *cmd_w_args = NULL;
-        if (asprintf(&cmd_w_args, "command w/args: %s", g_proc.cmd) != -1) {
-            scopeLog(cmd_w_args, -1, CFG_LOG_INFO);
-            if (cmd_w_args) free(cmd_w_args);
-        }
+        scopeLog(CFG_LOG_INFO, "Constructor (Scope Version: " SCOPE_VER ")");
+        scopeLog(CFG_LOG_INFO, "command w/args: %s", g_proc.cmd);
 
         msgLogConfig(g_cfg.staticfg);
 
@@ -242,7 +238,7 @@ msgLogConfig(config_t *cfg)
     char *cfg_text = cJSON_PrintUnformatted(json);
 
     if (cfg_text) {
-        scopeLog(cfg_text, -1, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "%s", cfg_text);
         free(cfg_text);
     }
 
@@ -311,7 +307,7 @@ pcre2_match_wrapper(pcre2_code *re, PCRE2_SPTR data, PCRE2_SIZE size,
     int rc, arc;
     char *pcre_stack, *tstack, *gstack;
     if ((pcre_stack = malloc(PCRE_STACK_SIZE)) == NULL) {
-        scopeLog("ERROR; pcre2_match_wrapper: malloc", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR; pcre2_match_wrapper: malloc");
         return -1;
     }
 
@@ -357,7 +353,7 @@ regexec_wrapper(const regex_t *preg, const char *string, size_t nmatch,
     char *pcre_stack = NULL, *tstack = NULL, *gstack = NULL;
 
      if ((pcre_stack = malloc(PCRE_STACK_SIZE)) == NULL) {
-        scopeLog("ERROR; regexec_wrapper: malloc", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR; regexec_wrapper: malloc");
         return -1;
     }
 

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -525,7 +525,7 @@ prepMessage(upload_t *upld)
     char *temp = realloc(streamMsg, strsize+2); // room for "\n\0"
     if (!temp) {
         DBG(NULL);
-        scopeLog("CTL realloc error", -1, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "CTL realloc error");
         free(streamMsg);
         return NULL;
     }

--- a/src/dbg.c
+++ b/src/dbg.c
@@ -32,7 +32,7 @@ struct _dbg_t {
 dbg_t *g_dbg = NULL;
 log_t *g_log = NULL;
 proc_id_t g_proc = {0};
-
+bool g_constructor_debug_enabled;
 
 void
 dbgInit()
@@ -260,8 +260,7 @@ dbgAddLine(const char *key, const char *fmt, ...)
 // for unit tests and allows for a different definition for the
 // scope executable.
 void __attribute__((weak))
-scopeLog(const char *msg, int fd, cfg_log_level_t level)
+scopeLog(cfg_log_level_t level, const char *format, ...)
 {
     return;
 }
-

--- a/src/dbg.h
+++ b/src/dbg.h
@@ -63,7 +63,8 @@ void                 dbgAddLine(const char* key, const char* fmt, ...);
 
 extern log_t *g_log;
 extern proc_id_t g_proc;
+extern bool g_constructor_debug_enabled;
 
-void scopeLog(const char *, int, cfg_log_level_t);
+void scopeLog(cfg_log_level_t, const char *, ...) PRINTF_FORMAT(2,3);
 
 #endif // __DBG_H__

--- a/src/javaagent.c
+++ b/src/javaagent.c
@@ -49,11 +49,9 @@ static java_global_t g_java = {0};
 static void 
 logJvmtiError(jvmtiEnv *jvmti, jvmtiError errnum, const char *str) 
 {
-    char buf[1024];
     char *errnum_str = NULL;
     (*jvmti)->GetErrorName(jvmti, errnum, &errnum_str);
-    snprintf(buf, sizeof(buf), "ERROR: JVMTI: [%d] %s - %s\n", errnum, (errnum_str == NULL ? "Unknown": errnum_str), (str == NULL? "" : str));
-    scopeLog(buf, -1, CFG_LOG_ERROR);
+    scopeLog(CFG_LOG_ERROR, "ERROR: JVMTI: [%d] %s - %s\n", errnum, (errnum_str == NULL ? "Unknown": errnum_str), (str == NULL? "" : str));
 }
 
 static void 
@@ -140,7 +138,7 @@ initAppOutputStreamGlobals(JNIEnv *jni)
         g_java.fid_AppOutputStream_socket = (*jni)->GetFieldID(jni, appOutputStreamClass, "this$0", "Lsun/security/ssl/SSLSocketImpl;");
     }
     if (g_java.fid_AppOutputStream_socket == NULL) {
-        scopeLog("unable to find an SSLSocket field in AppOutputStream class", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "unable to find an SSLSocket field in AppOutputStream class");
     }
     clearJniException(jni);
 }
@@ -180,7 +178,7 @@ initAppInputStreamGlobals(JNIEnv *jni)
         g_java.fid_AppInputStream_socket = (*jni)->GetFieldID(jni, appInputStreamClass, "this$0", "Lsun/security/ssl/SSLSocketImpl;");
     }
     if (g_java.fid_AppInputStream_socket == NULL) {
-        scopeLog("unable to find an SSLSocket field in AppInputStream class", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "unable to find an SSLSocket field in AppInputStream class");
     }
     clearJniException(jni);
 }
@@ -244,14 +242,14 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env,
         strcmp(name, "com/sun/net/ssl/internal/ssl/AppOutputStream") == 0 ||
         strcmp(name, "sun/security/ssl/SSLSocketImpl$AppOutputStream") == 0) {
 
-        scopeLog("installing Java SSL hooks for AppOutputStream class...", -1, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "installing Java SSL hooks for AppOutputStream class...");
 
         java_class_t *classInfo = javaReadClass(class_data);
 
         int methodIndex = javaFindMethodIndex(classInfo, "write", "([BII)V");
         if (methodIndex == -1) {
             javaDestroy(&classInfo);
-            scopeLog("ERROR: 'write' method not found in AppOutputStream class\n", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: 'write' method not found in AppOutputStream class\n");
             return;
         }
         javaCopyMethod(classInfo, classInfo->methods[methodIndex], "__write");
@@ -270,14 +268,14 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env,
         strcmp(name, "com/sun/net/ssl/internal/ssl/AppInputStream") == 0 ||
         strcmp(name, "sun/security/ssl/SSLSocketImpl$AppInputStream") == 0) {
 
-        scopeLog("installing Java SSL hooks for AppInputStream class...", -1, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "installing Java SSL hooks for AppInputStream class...");
 
         java_class_t *classInfo = javaReadClass(class_data);
 
         int methodIndex = javaFindMethodIndex(classInfo, "read", "([BII)I");
         if (methodIndex == -1) {
             javaDestroy(&classInfo);
-            scopeLog("ERROR: 'read' method not found in AppInputStream class\n", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: 'read' method not found in AppInputStream class\n");
             return;
         }
         javaCopyMethod(classInfo, classInfo->methods[methodIndex], "__read");
@@ -295,14 +293,14 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env,
     if (strcmp(name, "sun/security/ssl/SSLEngineImpl") == 0 || 
         strcmp(name, "com/sun/net/ssl/internal/ssl/SSLEngineImpl") == 0) {
         
-        scopeLog("installing Java SSL hooks for SSLEngineImpl class...", -1, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "installing Java SSL hooks for SSLEngineImpl class...");
 
         java_class_t *classInfo = javaReadClass(class_data);
 
         int methodIndex = javaFindMethodIndex(classInfo, "wrap", "([Ljava/nio/ByteBuffer;IILjava/nio/ByteBuffer;)Ljavax/net/ssl/SSLEngineResult;");
         if (methodIndex == -1) {
             javaDestroy(&classInfo);
-            scopeLog("ERROR: 'wrap' method not found in SSLEngineImpl class\n", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: 'wrap' method not found in SSLEngineImpl class\n");
             return;
         }
         javaCopyMethod(classInfo, classInfo->methods[methodIndex], "__wrap");
@@ -311,7 +309,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env,
         methodIndex = javaFindMethodIndex(classInfo, "unwrap", "(Ljava/nio/ByteBuffer;[Ljava/nio/ByteBuffer;II)Ljavax/net/ssl/SSLEngineResult;");
          if (methodIndex == -1) {
             javaDestroy(&classInfo);
-            scopeLog("ERROR: 'unwrap' method not found in SSLEngineImpl class\n", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: 'unwrap' method not found in SSLEngineImpl class\n");
             return;
         }
         javaCopyMethod(classInfo, classInfo->methods[methodIndex], "__unwrap");
@@ -328,13 +326,13 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env,
 
     if (strcmp(name, "sun/nio/ch/SocketChannelImpl") == 0) {
 
-        scopeLog("installing Java SSL hooks for SocketChannelImpl class...", -1, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "installing Java SSL hooks for SocketChannelImpl class...");
         java_class_t *classInfo = javaReadClass(class_data);
 
         int methodIndex = javaFindMethodIndex(classInfo, "read", "(Ljava/nio/ByteBuffer;)I");
         if (methodIndex == -1) {
             javaDestroy(&classInfo);
-            scopeLog("ERROR: 'read' method not found in SocketChannelImpl class\n", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: 'read' method not found in SocketChannelImpl class\n");
             return;
         }
         javaCopyMethod(classInfo, classInfo->methods[methodIndex], "__read");
@@ -343,7 +341,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env,
         methodIndex = javaFindMethodIndex(classInfo, "write", "(Ljava/nio/ByteBuffer;)I");
         if (methodIndex == -1) {
             javaDestroy(&classInfo);
-            scopeLog("ERROR: 'write' method not found in SocketChannelImpl class\n", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: 'write' method not found in SocketChannelImpl class\n");
             return;
         }
         javaCopyMethod(classInfo, classInfo->methods[methodIndex], "__write");
@@ -361,7 +359,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env,
     if (strcmp(name, "java/nio/DirectByteBuffer") == 0 ||
         strcmp(name, "java/nio/DirectByteBufferR") == 0) {
 
-        scopeLog("installing Java SSL hooks for java.nio.DirectByteBuffer class...", -1, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "installing Java SSL hooks for java.nio.DirectByteBuffer class...");
         java_class_t *classInfo = javaReadClass(class_data);
 
         // add a private field which will hold the fd used to read/write data for that buffer
@@ -565,11 +563,11 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
     jvmtiError error;
     jvmtiEnv *env;
 
-    scopeLog("Initializing Java agent", -1, CFG_LOG_INFO);
+    scopeLog(CFG_LOG_INFO, "Initializing Java agent");
 
     jint result = (*jvm)->GetEnv(jvm, (void **) &env, JVMTI_VERSION_1_0);
     if (result != 0) {
-        scopeLog("ERROR: GetEnv failed\n", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: GetEnv failed\n");
         return JNI_ERR;
     }
 
@@ -629,7 +627,7 @@ initJavaAgent() {
 
         int result = fullSetenv("JAVA_TOOL_OPTIONS", buf, 1);
         if (result) {
-            scopeLog("ERROR: Could not set JAVA_TOOL_OPTIONS failed\n", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: Could not set JAVA_TOOL_OPTIONS failed\n");
         }
         free(buf);
     }

--- a/src/mtcformat.c
+++ b/src/mtcformat.c
@@ -293,7 +293,7 @@ mtcFormatEventForOutput(mtc_fmt_t *fmt, event_t *evt, regex_t *fieldFilter)
             char *temp = realloc(msg, strsize+2); // room for "\n\0"
             if (!temp) {
                 DBG(NULL);
-                scopeLog("mtcFormat realloc error", -1, CFG_LOG_INFO);
+                scopeLog(CFG_LOG_INFO, "mtcFormat realloc error");
                 free(msg);
                 msg = NULL;
             } else {

--- a/src/report.c
+++ b/src/report.c
@@ -147,7 +147,7 @@ sendEvent(mtc_t *mtc, event_t *event)
     cmdSendEvent(g_ctl, event, getTime(), &g_proc);
 
     if (cmdSendMetric(mtc, event) == -1) {
-        scopeLog("ERROR: sendEvent:cmdSendMetric", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: sendEvent:cmdSendMetric");
     }
 }
 
@@ -366,13 +366,13 @@ httpFields(event_field_t *fields, http_report *hreport, char *hdr,
         strncpy(hreport->hres, hdr, hdr_len);
         header = hreport->hres;
     } else {
-        scopeLog("WARN: httpFields: proto ptype is not req or resp", proto->fd, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "fd:%d WARN: httpFields: proto ptype is not req or resp", proto->fd);
         return FALSE;
     }
 
     char *thishdr = strtok_r(header, "\r\n", &savea);
     if (!thishdr) {
-        scopeLog("WARN: httpFields: parse an http header", proto->fd, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "fd:%d WARN: httpFields: parse an http header", proto->fd);
         return FALSE;
     }
 
@@ -513,7 +513,7 @@ doHttpHeader(protocol_info *proto)
     // we're either building a new req or we have a previous req
     if (map->req) {
         if ((hreport.hreq = calloc(1, map->req_len)) == NULL) {
-            scopeLog("ERROR: doHttpHeader: hreq memory allocation failure", proto->fd, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "fd:%d ERROR: doHttpHeader: hreq memory allocation failure", proto->fd);
             return;
         }
 
@@ -523,7 +523,7 @@ doHttpHeader(protocol_info *proto)
         char *headertok = strtok_r(header, "\r\n", &savea);
         if (!headertok) {
             free(hreport.hreq);
-            scopeLog("WARN: doHttpHeader: parse an http request header", proto->fd, CFG_LOG_WARN);
+            scopeLog(CFG_LOG_WARN, "fd:%d WARN: doHttpHeader: parse an http request header", proto->fd);
             return;
         }
 
@@ -533,7 +533,7 @@ doHttpHeader(protocol_info *proto)
             H_ATTRIB(fields[hreport.ix], "http_method", method_str, 1);
             HTTP_NEXT_FLD(hreport.ix);
         } else {
-            scopeLog("WARN: doHttpHeader: no method in an http request header", proto->fd, CFG_LOG_WARN);
+            scopeLog(CFG_LOG_WARN, "fd:%d WARN: doHttpHeader: no method in an http request header", proto->fd);
         }
 
         char *target_str = strtok_r(NULL, " ", &savea);
@@ -541,7 +541,7 @@ doHttpHeader(protocol_info *proto)
             H_ATTRIB(fields[hreport.ix], "http_target", target_str, 4);
             HTTP_NEXT_FLD(hreport.ix);
         } else {
-            scopeLog("WARN: doHttpHeader: no target in an http request header", proto->fd, CFG_LOG_WARN);
+            scopeLog(CFG_LOG_WARN, "fd:%d WARN: doHttpHeader: no target in an http request header", proto->fd);
         }
 
         char *flavor_str = strtok_r(NULL, " ", &savea);
@@ -553,7 +553,7 @@ doHttpHeader(protocol_info *proto)
                 HTTP_NEXT_FLD(hreport.ix);
             }
         } else {
-            scopeLog("WARN: doHttpHeader: no http version in an http request header", proto->fd, CFG_LOG_WARN);
+            scopeLog(CFG_LOG_WARN, "fd:%d WARN: doHttpHeader: no http version in an http request header", proto->fd);
         }
 
         H_ATTRIB(fields[hreport.ix], "http_scheme", ssl, 1);
@@ -593,7 +593,7 @@ doHttpHeader(protocol_info *proto)
     */
     if (proto->ptype == EVT_HRES) {
         if ((hreport.hres = calloc(1, proto->len)) == NULL) {
-            scopeLog("ERROR: doHttpHeader: hres memory allocation failure", proto->fd, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "fd:%d ERROR: doHttpHeader: hres memory allocation failure", proto->fd);
             return;
         }
 
@@ -631,7 +631,7 @@ doHttpHeader(protocol_info *proto)
             H_ATTRIB(fields[hreport.ix], "http_flavor", flavor_str, 1);
             HTTP_NEXT_FLD(hreport.ix);
         } else {
-            scopeLog("WARN: doHttpHeader: no version string in an http request header", proto->fd, CFG_LOG_WARN);
+            scopeLog(CFG_LOG_WARN, "fd:%d WARN: doHttpHeader: no version string in an http request header", proto->fd);
         }
 
         H_VALUE(fields[hreport.ix], "http_status_code", status, 1);
@@ -839,7 +839,7 @@ doErrorMetric(metric_t type, control_type_t source,
 
         event_t netErrMetric = INT_EVENT("net.error", value->mtc, DELTA, fields);
         if (cmdSendMetric(g_mtc, &netErrMetric)) {
-            scopeLog("ERROR: doErrorMetric:NET:cmdSendMetric", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: doErrorMetric:NET:cmdSendMetric");
         }
         atomicSwapU64(&value->mtc, 0);
         break;
@@ -919,14 +919,14 @@ doErrorMetric(metric_t type, control_type_t source,
 
         event_t fsErrMetric = INT_EVENT(metric, value->mtc, DELTA, fields);
         if (cmdSendMetric(g_mtc, &fsErrMetric)) {
-            scopeLog("ERROR: doErrorMetric:FS_ERR:cmdSendMetric", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: doErrorMetric:FS_ERR:cmdSendMetric");
         }
         atomicSwapU64(&value->mtc, 0);
         break;
     }
 
     default:
-        scopeLog("ERROR: doErrorMetric:metric type", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: doErrorMetric:metric type");
     }
 }
 
@@ -1009,7 +1009,7 @@ doDNSMetricName(metric_t type, net_info *net)
         };
         event_t dnsMetric = INT_EVENT("net.dns", ctrs->numDNS.mtc, DELTA, fields);
         if (cmdSendMetric(g_mtc, &dnsMetric)) {
-            scopeLog("ERROR: doDNSMetricName:DNS:cmdSendMetric", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: doDNSMetricName:DNS:cmdSendMetric");
         }
         break;
     }
@@ -1075,7 +1075,7 @@ doDNSMetricName(metric_t type, net_info *net)
         };
         event_t dnsDurMetric = INT_EVENT("net.dns.duration", dur, DELTA_MS, fields);
         if (cmdSendMetric(g_mtc, &dnsDurMetric)) {
-            scopeLog("ERROR: doDNSMetricName:DNS_DURATION:cmdSendMetric", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: doDNSMetricName:DNS_DURATION:cmdSendMetric");
         }
         atomicSwapU64(&ctrs->dnsDurationNum.mtc, 0);
         atomicSwapU64(&ctrs->dnsDurationTotal.mtc, 0);
@@ -1083,7 +1083,7 @@ doDNSMetricName(metric_t type, net_info *net)
     }
 
     default:
-        scopeLog("ERROR: doDNSMetric:metric type", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: doDNSMetric:metric type");
     }
 }
 
@@ -1185,7 +1185,7 @@ doProcMetric(metric_t type, long long measurement)
     }
 
     default:
-        scopeLog("ERROR: doProcMetric:metric type", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: doProcMetric:metric type");
     }
 }
 
@@ -1220,7 +1220,7 @@ doStatMetric(const char *op, const char *pathname, void* ctr)
 
     event_t evt = INT_EVENT("fs.op.stat", ctrs->numStat.mtc, DELTA, fields);
     if (cmdSendMetric(g_mtc, &evt)) {
-        scopeLog("doStatMetric", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "doStatMetric");
     }
 }
 
@@ -1570,7 +1570,7 @@ doFSMetric(metric_t type, fs_info *fs, control_type_t source,
         };
         event_t evt = INT_EVENT("fs.duration", dur, HISTOGRAM, fields);
         if (cmdSendMetric(g_mtc, &evt)) {
-            scopeLog("ERROR: doFSMetric:FS_DURATION:cmdSendMetric", fs->fd, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "fd:%d ERROR: doFSMetric:FS_DURATION:cmdSendMetric", fs->fd);
         }
 
         // Reset the info if we tried to report
@@ -1653,7 +1653,7 @@ doFSMetric(metric_t type, fs_info *fs, control_type_t source,
         event_t rwMetric = INT_EVENT(metric, sizebytes->mtc, HISTOGRAM, fields);
 
         if (cmdSendMetric(g_mtc, &rwMetric)) {
-            scopeLog(err_str, fs->fd, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "fd:%d %s", fs->fd, err_str);
         }
         subFromInterfaceCounts(global_counter, sizebytes->mtc);
         atomicSwapU64(&numops->mtc, 0);
@@ -1744,7 +1744,7 @@ doFSMetric(metric_t type, fs_info *fs, control_type_t source,
 
         event_t evt = INT_EVENT(metric, numops->mtc, DELTA, fields);
         if (cmdSendMetric(g_mtc, &evt)) {
-            scopeLog(err_str, fs->fd, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "fd:%d %s", fs->fd, err_str);
         }
         subFromInterfaceCounts(global_counter, numops->mtc);
         atomicSwapU64(&numops->mtc, 0);
@@ -1806,7 +1806,7 @@ doTotalNetRxTx(metric_t type)
             };
             event_t evt = INT_EVENT(metric, (*value)[bucket].mtc, DELTA, fields);
             if (cmdSendMetric(g_mtc, &evt)) {
-                scopeLog(err_str, -1, CFG_LOG_ERROR);
+                scopeLog(CFG_LOG_ERROR, "%s", err_str);
             }
         }
 
@@ -1914,7 +1914,7 @@ doTotal(metric_t type)
     };
     event_t evt = INT_EVENT(metric, value->mtc, aggregation_type, fields);
     if (cmdSendMetric(g_mtc, &evt)) {
-        scopeLog(err_str, -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "%s", err_str);
     }
 
     // Reset the info we tried to report (if it's not a gauge)
@@ -1984,7 +1984,7 @@ doTotalDuration(metric_t type)
     };
     event_t evt = INT_EVENT(metric, dur, aggregation_type, fields);
     if (cmdSendMetric(g_mtc, &evt)) {
-        scopeLog(err_str, -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "%s", err_str);
     }
 
     // Reset the info we tried to report
@@ -2064,7 +2064,7 @@ doNetMetric(metric_t type, net_info *net, control_type_t source, ssize_t size)
 
         event_t evt = INT_EVENT(metric, value->mtc, CURRENT, fields);
         if (cmdSendMetric(g_mtc, &evt)) {
-            scopeLog(err_str, net->fd, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "fd:%d %s", net->fd, err_str);
         }
         // Don't reset the info if we tried to report.  It's a gauge.
         // atomicSwapU64(value, 0);
@@ -2138,7 +2138,7 @@ doNetMetric(metric_t type, net_info *net, control_type_t source, ssize_t size)
         };
         event_t evt = INT_EVENT("net.conn_duration", dur, DELTA_MS, fields);
         if (cmdSendMetric(g_mtc, &evt)) {
-            scopeLog("ERROR: doNetMetric:CONNECTION_DURATION:cmdSendMetric", net->fd, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "fd:%d ERROR: doNetMetric:CONNECTION_DURATION:cmdSendMetric", net->fd);
         }
         atomicSwapU64(&net->numDuration.mtc, 0);
         atomicSwapU64(&net->totalDuration.mtc, 0);
@@ -2267,7 +2267,7 @@ doNetMetric(metric_t type, net_info *net, control_type_t source, ssize_t size)
         event_t rxNetMetric = INT_EVENT("net.rx", net->rxBytes.mtc, DELTA, rxFields);
         memmove(&rxMetric, &rxNetMetric, sizeof(event_t));
         if (cmdSendMetric(g_mtc, &rxMetric)) {
-            scopeLog("ERROR: doNetMetric:NETRX:cmdSendMetric", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: doNetMetric:NETRX:cmdSendMetric");
         }
 
         // Reset the info if we tried to report
@@ -2394,7 +2394,7 @@ doNetMetric(metric_t type, net_info *net, control_type_t source, ssize_t size)
         event_t txNetMetric = INT_EVENT("net.tx", net->txBytes.mtc, DELTA, txFields);
         memmove(&txMetric, &txNetMetric, sizeof(event_t));
         if (cmdSendMetric(g_mtc, &txMetric)) {
-            scopeLog("ERROR: doNetMetric:NETTX:cmdSendMetric", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: doNetMetric:NETTX:cmdSendMetric");
         }
 
         // Reset the info if we tried to report
@@ -2421,7 +2421,7 @@ doNetMetric(metric_t type, net_info *net, control_type_t source, ssize_t size)
     }
 
     default:
-        scopeLog("ERROR: doNetMetric:metric type", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: doNetMetric:metric type");
     }
 }
 
@@ -2601,7 +2601,7 @@ doPayload()
                 hlen = rc + 1;
             } else {
                 hlen--;
-                scopeLog("WARN: payload header was truncated", pinfo->sockfd, CFG_LOG_WARN);
+                scopeLog(CFG_LOG_WARN, "fd:%d WARN: payload header was truncated", pinfo->sockfd);
             }
 
             char *bdata = NULL;

--- a/src/scopetypes.h
+++ b/src/scopetypes.h
@@ -173,6 +173,7 @@ typedef unsigned int bool;
 //    SCOPE_PID                      provided by library
 //    SCOPE_PAYLOAD_HEADER           write payload headers to files
 //    SCOPE_ALLOW_MUSL_ATTACH        allows attach for musl processes
+//    SCOPE_ALLOW_CONSTRUCT_DBG      allows debug inside the constructor
 
 #define SCOPE_PID_ENV "SCOPE_PID"
 #define PRESERVE_PERF_REPORTING "SCOPE_PERF_PRESERVE"

--- a/src/state.c
+++ b/src/state.c
@@ -237,12 +237,12 @@ initState()
 {
     // Per a Read Update & Change (RUC) model; now that the object is ready assign the global
     if ((g_netinfo = (net_info *)calloc(1, sizeof(struct net_info_t) * NET_ENTRIES)) == NULL) {
-        scopeLog("ERROR: Constructor:Calloc", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: Constructor:Calloc");
     }
 
     // Per RUC...
     if ((g_fsinfo = (fs_info *)calloc(1, sizeof(struct fs_info_t) * FS_ENTRIES)) == NULL) {
-        scopeLog("ERROR: Constructor:Calloc", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: Constructor:Calloc");
     }
 
     initHttpState();
@@ -277,24 +277,21 @@ dumpAddrs(int sd)
 {
     in_port_t port;
     char ip[INET6_ADDRSTRLEN];
-    char buf[1024];
 
     inet_ntop(AF_INET,
               &((struct sockaddr_in *)&g_netinfo[sd].localConn)->sin_addr,
               ip, sizeof(ip));
     port = get_port(sd, g_netinfo[sd].localConn.ss_family, LOCAL);
-    snprintf(buf, sizeof(buf), "%s:%d LOCAL: %s:%d", __FUNCTION__, __LINE__, ip, port);
-    scopeLog(buf, sd, CFG_LOG_DEBUG);
+    scopeLog(CFG_LOG_DEBUG, "fd:%d %s:%d LOCAL: %s:%d", sd, __FUNCTION__, __LINE__, ip, port);
 
     inet_ntop(AF_INET,
               &((struct sockaddr_in *)&g_netinfo[sd].remoteConn)->sin_addr,
               ip, sizeof(ip));
     port = get_port(sd, g_netinfo[sd].remoteConn.ss_family, REMOTE);
-    snprintf(buf, sizeof(buf), "%s:%d REMOTE:%s:%d", __FUNCTION__, __LINE__, ip, port);
-    scopeLog(buf, sd, CFG_LOG_DEBUG);
+    scopeLog(CFG_LOG_DEBUG, "fd:%d %s:%d REMOTE:%s:%d", sd, __FUNCTION__, __LINE__, ip, port);
 
     if (get_port(sd, g_netinfo[sd].localConn.ss_family, REMOTE) == DNS_PORT) {
-        scopeLog("DNS", sd, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "fd:%d DNS", sd);
     }
 }
 #endif
@@ -883,7 +880,7 @@ setProtocol(int sockfd, protocol_def_t *protoDef, net_info *net, char *buf, size
     match_data = pcre2_match_data_create_from_pattern(protoDef->re, NULL);
     if (pcre2_match_wrapper(protoDef->re, (PCRE2_SPTR)data, (PCRE2_SIZE)cvlen, 0, 0,
                             match_data, NULL) > 0) {
-        scopeLog("protocol detected", sockfd, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "fd:%d protocol detected", sockfd);
 
         if (net) {
             net->protoDetect = DETECT_TRUE;
@@ -1035,7 +1032,7 @@ extractPayload(int sockfd, net_info *net, void *buf, size_t len, metric_t src, s
     pinfo->sockfd = sockfd;
     pinfo->len = len;
 
-    scopeLog("posting payload", sockfd, CFG_LOG_DEBUG);
+    scopeLog(CFG_LOG_DEBUG, "fd:%d posting payload", sockfd);
 
     if (cmdPostPayload(g_ctl, (char *)pinfo) == -1) {
         if (pinfo->data) free(pinfo->data);
@@ -1090,8 +1087,7 @@ detectTLS(int sockfd, net_info *net, void *buf, size_t len, metric_t src, src_da
         // matched, set the detect-state to TRUE
         net->tlsDetect = DETECT_TRUE;
         net->tlsProtoDef = tls_proto_def;
-
-        scopeLog("detected TLS", sockfd, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "fd:%d detected TLS", sockfd);
         if (tls_proto_def->detect) {
             // TODO send TLS protocol-detect event
         }
@@ -1103,7 +1099,7 @@ detectTLS(int sockfd, net_info *net, void *buf, size_t len, metric_t src, src_da
         if (rc != PCRE2_ERROR_NOMATCH)
         {
             DBG(NULL);
-            scopeLog("doProtocol: TLS regex failed", sockfd, CFG_LOG_DEBUG);
+            scopeLog(CFG_LOG_DEBUG, "fd:%d doProtocol: TLS regex failed", sockfd);
         }
     }
     pcre2_match_data_free(match_data);
@@ -1337,7 +1333,7 @@ addSock(int fd, int type, int family)
 
             // Need to realloc
             if ((temp = realloc(g_netinfo, sizeof(struct net_info_t) * increase)) == NULL) {
-                scopeLog("ERROR: addSock:realloc", fd, CFG_LOG_ERROR);
+                scopeLog(CFG_LOG_ERROR, "fd:%d ERROR: addSock:realloc", fd);
                 DBG("re-alloc on Net table failed");
             } else {
                 memset(&temp[g_numNinfo], 0, sizeof(struct net_info_t) * (increase - g_numNinfo));
@@ -1388,7 +1384,7 @@ doBlockConnection(int fd, const struct sockaddr *addr_arg)
     }
 
     if (g_cfg.blockconn == htons(port)) {
-        scopeLog("doBlockConnection: blocked connection", fd, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "fd:%d doBlockConnection: blocked connection", fd);
         return 1;
     }
 
@@ -1492,7 +1488,7 @@ doAddNewSock(int sockfd)
                 addSock(sockfd, type, addr.ss_family);
             } else {
                 // Really can't add the socket at this point
-                scopeLog("ERROR: doAddNewSock:getsockopt", sockfd, CFG_LOG_ERROR);
+                scopeLog(CFG_LOG_ERROR, "fd:%d ERROR: doAddNewSock:getsockopt", sockfd);
             }
         } else {
             // is RAW a viable default?
@@ -1676,8 +1672,8 @@ getNSFuncs(void)
 
     void *handle = g_fn.dlopen("libresolv.so", RTLD_LAZY | RTLD_NODELETE);
     if (handle == NULL) {
-        scopeLog("WARNING: could not locate libresolv, DNS events will be affected",
-                 -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN,
+                    "WARNING: could not locate libresolv, DNS events will be affected");
         return FALSE;
     }
 
@@ -1686,8 +1682,8 @@ getNSFuncs(void)
     dlclose(handle);
 
     if (!g_fn.ns_initparse || !g_fn.ns_parserr) {
-        scopeLog("WARNING: could not locate name server functions, DNS events will be affected",
-                 -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN,
+                    "WARNING: could not locate name server functions, DNS events will be affected");
         return FALSE;
     }
 
@@ -1709,7 +1705,7 @@ parseDNSAnswer(char *buf, size_t len, cJSON *json, cJSON *addrs, int first)
 
     // init ns lib
     if (g_fn.ns_initparse((const unsigned char *)buf, len, &handle) == -1) {
-        scopeLog("ERROR:init parse", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR:init parse");
         return FALSE;
     }
 
@@ -1721,7 +1717,7 @@ parseDNSAnswer(char *buf, size_t len, cJSON *json, cJSON *addrs, int first)
             //char dispbuf[4096];
 
             if (g_fn.ns_parserr(&handle, ns_s_an, i, &rr) == -1) {
-                scopeLog("ERROR:parse rr", -1, CFG_LOG_ERROR);
+                scopeLog(CFG_LOG_ERROR, "ERROR:parse rr");
                 return FALSE;
             }
 
@@ -1734,7 +1730,7 @@ parseDNSAnswer(char *buf, size_t len, cJSON *json, cJSON *addrs, int first)
             }
 
             //ns_sprintrr(&handle, &rr, NULL, NULL, dispbuf, sizeof (dispbuf));
-            //scopeLog(dispbuf, -1, CFG_LOG_DEBUG);
+            //scopeLog(CFG_LOG_DEBUG, "%s", dispbuf);
 
             // type A is IPv4, AAA is IPv6
             if (ns_rr_type(rr) == ns_t_a) {
@@ -1753,7 +1749,7 @@ parseDNSAnswer(char *buf, size_t len, cJSON *json, cJSON *addrs, int first)
             }
 
             //snprintf(dispbuf, sizeof(dispbuf), "resolved addr is %s\n", ipaddr);
-            //scopeLog(dispbuf, -1, CFG_LOG_DEBUG);
+            //scopeLog(CFG_LOG_DEBUG, "%s", dispbuf);
 
             if (!cJSON_AddStringToObjLN(addrs, "addr", ipaddr)) {
                 continue;
@@ -1946,7 +1942,7 @@ doSend(int sockfd, ssize_t rc, const void *buf, size_t len, src_data_t src)
 void
 doAccept(int sd, struct sockaddr *addr, socklen_t *addrlen, char *func)
 {
-    scopeLog(func, sd, CFG_LOG_DEBUG);
+    scopeLog(CFG_LOG_DEBUG, "fd:%d %s", sd, func);
     if (addr) {
         addSock(sd, SOCK_STREAM, addr->sa_family);
     } else {
@@ -2016,7 +2012,7 @@ doRead(int fd, uint64_t initialTime, int success, const void *buf, ssize_t bytes
     struct net_info_t *net = getNetEntry(fd);
 
     if (success) {
-        scopeLog(func, fd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d %s", fd, func);
         if (net) {
             // This is a network descriptor
             doSetAddrs(fd);
@@ -2050,7 +2046,7 @@ doWrite(int fd, uint64_t initialTime, int success, const void *buf, ssize_t byte
     struct net_info_t *net = getNetEntry(fd);
 
     if (success) {
-        scopeLog(func, fd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d %s", fd, func);
         if (net) {
             // This is a network descriptor
             doSetAddrs(fd);
@@ -2096,7 +2092,7 @@ doSeek(int fd, int success, const char *func)
 {
     struct fs_info_t *fs = getFSEntry(fd);
     if (success) {
-        scopeLog(func, fd, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "fd:%d %s", fd, func);
         if (fs) {
             doUpdateState(FS_SEEK, fd, 0, func, NULL);
         }
@@ -2112,7 +2108,7 @@ void
 doStatPath(const char *path, int rc, const char *func)
 {
     if (rc != -1) {
-        scopeLog(func, -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "%s", func);
         doUpdateState(FS_STAT, -1, 0, func, path);
     } else {
         doUpdateState(FS_ERR_STAT, -1, (size_t)0, func, path);
@@ -2125,7 +2121,7 @@ doStatFd(int fd, int rc, const char* func)
     struct fs_info_t *fs = getFSEntry(fd);
 
     if (rc != -1) {
-        scopeLog(func, fd, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "fd:%d %s", fd, func);
         if (fs) {
             doUpdateState(FS_STAT, fd, 0, func, fs->path);
         }
@@ -2177,7 +2173,7 @@ doDup(int fd, int rc, const char *func, int copyNet)
     if (rc != -1) {
         if (net) {
             // This is a network descriptor
-            scopeLog(func, rc, CFG_LOG_DEBUG);
+            scopeLog(CFG_LOG_DEBUG, "fd:%d %s", rc, func);
             if (copyNet) {
                 doDupSock(fd, rc);
             } else {
@@ -2202,7 +2198,7 @@ doDup2(int oldfd, int newfd, int rc, const char *func)
     struct net_info_t *net = getNetEntry(oldfd);
 
     if ((rc != -1) && (oldfd != newfd)) {
-        scopeLog(func, rc, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "fd:%d %s", rc, func);
         if (net) {
             if (getNetEntry(newfd)) {
                 doClose(newfd, func);
@@ -2261,7 +2257,7 @@ doOpen(int fd, const char *path, fs_type_t type, const char *func)
 {
     if (checkFSEntry(fd) == TRUE) {
         if (g_fsinfo[fd].active) {
-            scopeLog("doOpen: duplicate", fd, CFG_LOG_DEBUG);
+            scopeLog(CFG_LOG_DEBUG, "fd:%d doOpen: duplicate", fd);
             DBG(NULL);
             doClose(fd, func);
         }
@@ -2284,7 +2280,7 @@ doOpen(int fd, const char *path, fs_type_t type, const char *func)
 
             // Need to realloc
             if ((temp = realloc(g_fsinfo, sizeof(struct fs_info_t) * increase)) == NULL) {
-                scopeLog("ERROR: doOpen:realloc", fd, CFG_LOG_ERROR);
+                scopeLog(CFG_LOG_ERROR, "fd:%d ERROR: doOpen:realloc", fd);
                 DBG("re-alloc on FS table failed");
             } else {
                 memset(&temp[g_numFSinfo], 0, sizeof(struct fs_info_t) * (increase - g_numFSinfo));
@@ -2312,7 +2308,7 @@ doOpen(int fd, const char *path, fs_type_t type, const char *func)
         }
 
         doUpdateState(FS_OPEN, fd, 0, func, path);
-        scopeLog(func, fd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d %s", fd, func);
     }
 }
 
@@ -2323,7 +2319,7 @@ doSendFile(int out_fd, int in_fd, uint64_t initialTime, int rc, const char *func
     struct net_info_t *nettx = getNetEntry(out_fd);
 
     if (rc != -1) {
-        scopeLog(func, in_fd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d %s", in_fd, func);
         if (nettx) {
             doSetAddrs(out_fd);
             doSend(out_fd, rc, NULL, 0, NONE);

--- a/src/sysexec.c
+++ b/src/sysexec.c
@@ -58,7 +58,7 @@ sysprint(const char* fmt, ...)
 #if SYSPRINT_CONSOLE > 0
     printf("%s", str);
 #endif
-    scopeLog(str, -1, CFG_LOG_DEBUG);
+    scopeLog(CFG_LOG_DEBUG, "%s", str);
 }
 
 static int
@@ -68,17 +68,17 @@ get_file_size(const char *path)
     struct stat sbuf;
 
     if (g_fn.open && (fd = g_fn.open(path, O_RDONLY)) == -1) {
-        scopeLog("ERROR: get_file_size:open", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: get_file_size:open");
         return -1;
     }
 
     if (fstat(fd, &sbuf) == -1) {
-        scopeLog("ERROR: get_file_size:fstat", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: get_file_size:fstat");
         return -1;
     }
 
     if (g_fn.close && g_fn.close(fd) == -1) {
-        scopeLog("ERROR: get_file_size:close", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: get_file_size:close");
         return -1;        
     }
 
@@ -151,19 +151,19 @@ map_segment(char *buf, Elf64_Phdr *phead)
                      prot | PROT_WRITE,
                      MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
                      -1, (off_t)NULL)) == MAP_FAILED) {
-        scopeLog("ERROR: load_segment:mmap", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: load_segment:mmap");
         return -1;
     }
 
     if (laddr != addr) {
-        scopeLog("ERROR: load_segment:mmap:laddr mismatch", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: load_segment:mmap:laddr mismatch");
         return -1;
     }
 
     load_sections(buf, (char *)phead->p_vaddr, (size_t)lsize);
 
     if (((prot & PROT_WRITE) == 0) && (mprotect(laddr, lsize, prot) == -1)) {
-        scopeLog("ERROR: load_segment:mprotect", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: load_segment:mprotect");
         return -1;
     }
 
@@ -186,7 +186,7 @@ load_elf(char *buf)
                           PROT_READ | PROT_WRITE,
                           MAP_PRIVATE | MAP_ANONYMOUS,
                           -1, (off_t)NULL)) == MAP_FAILED) {
-        scopeLog("ERROR: load_elf:mmap", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: load_elf:mmap");
         return (Elf64_Addr)NULL;
     }
 
@@ -207,7 +207,7 @@ unmap_all(char *buf, const char **argv)
 
     int flen;
     if ((flen = get_file_size(argv[1])) == -1) {
-        scopeLog("ERROR:unmap_all: file size", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR:unmap_all: file size");
         return -1;
     }
 
@@ -238,7 +238,7 @@ copy_strings(char *buf, uint64_t sp, int argc, const char **argv, const char **e
         if (&argv[i] && spp) {
             *spp++ = (char *)argv[i];
         } else {
-            scopeLog("ERROR:copy_strings: arg entry is not correct", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR:copy_strings: arg entry is not correct");
             return -1;
         }
     }
@@ -267,7 +267,7 @@ copy_strings(char *buf, uint64_t sp, int argc, const char **argv, const char **e
         if ((&environ[i]) && spp) {
             *spp++ = (char *)environ[i];
         } else {
-            scopeLog("ERROR:copy_strings: environ string is not correct", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR:copy_strings: environ string is not correct");
             return -1;
         }
     }
@@ -341,7 +341,7 @@ set_go(char *buf, int argc, const char **argv, const char **env, Elf64_Addr phad
                    PROT_READ | PROT_WRITE,
                    MAP_PRIVATE | MAP_ANONYMOUS | MAP_GROWSDOWN,
                    -1, (off_t)NULL)) == MAP_FAILED) {
-        scopeLog("set_go:mmap", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "set_go:mmap");
         return -1;
     }
 
@@ -350,7 +350,7 @@ set_go(char *buf, int argc, const char **argv, const char **env, Elf64_Addr phad
     start = ehdr->e_entry;
 
     if (arch_prctl(ARCH_GET_FS, (unsigned long)&scope_fs) == -1) {
-        scopeLog("set_go:arch_prctl", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "set_go:arch_prctl");
         return -1;
     }
 
@@ -379,7 +379,7 @@ sys_exec(elf_buf_t *ebuf, const char *path, int argc, const char **argv, const c
 
     if (!ebuf || !path || !argv || (argc < 1)) return -1;
 
-    scopeLog("sys_exec type:", ehdr->e_type, CFG_LOG_DEBUG);
+    scopeLog(CFG_LOG_DEBUG, "fd:%d sys_exec type:", ehdr->e_type);
 
     phaddr = load_elf((char *)ebuf->buf);
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -214,11 +214,11 @@ transportNeedsConnection(transport_t *trans)
             if ((trans->net.sock == -1) ||
                 (trans->net.tls.enable && !trans->net.tls.ssl)) return TRUE;
             if (osNeedsConnect(trans->net.sock)) {
-                DBG("fd: %d, tls:%d", trans->net.sock, trans->net.tls.enable);
+                DBG("fd:%d, tls:%d", trans->net.sock, trans->net.tls.enable);
                 if (trans->net.tls.enable) {
-                    scopeLog("tls session closed remotely", trans->net.sock, CFG_LOG_INFO);
+                    scopeLog(CFG_LOG_INFO, "fd:%d tls session closed remotely", trans->net.sock);
                 } else {
-                    scopeLog("tcp connection closed remotely", trans->net.sock, CFG_LOG_INFO);
+                    scopeLog(CFG_LOG_INFO, "fd:%d tcp connection closed remotely", trans->net.sock);
                 }
                 transportDisconnect(trans);
                 return TRUE;
@@ -237,7 +237,7 @@ transportNeedsConnection(transport_t *trans)
         case CFG_UNIX:
             if (trans->local.sock == -1) return TRUE;
             if (osNeedsConnect(trans->local.sock)) {
-                DBG("fd: %d", trans->local.sock);
+                DBG("fd:%d", trans->local.sock);
                 transportDisconnect(trans);
                 return TRUE;
             }
@@ -284,13 +284,7 @@ shutdownTlsSession(transport_t *trans)
         if (ret < 0) {
             // protocol error occurred
             int ssl_err = SSL_get_error(trans->net.tls.ssl, ret);
-            char *logmsg = NULL;
-            if (asprintf(&logmsg, "Client SSL_shutdown failed: ssl_err=%d\n",
-                     ssl_err)) {
-                scopeLog(logmsg, -1, CFG_LOG_INFO);
-                if (logmsg) free(logmsg);
-            }
-
+            scopeLog(CFG_LOG_INFO, "Client SSL_shutdown failed: ssl_err=%d\n", ssl_err);
         } else if (ret == 0) {
             // shutdown not complete, call again
             char buf[4096];
@@ -305,12 +299,7 @@ shutdownTlsSession(transport_t *trans)
             if (ret != 1) {
                 // second shutdown not successful
                 int ssl_err = SSL_get_error(trans->net.tls.ssl, ret);
-                char *logmsg = NULL;
-                if (asprintf(&logmsg, "Waiting for server shutdown using SSL_shutdown failed: "
-                            "ssl_err=%d\n", ssl_err)) {
-                    scopeLog(logmsg, -1, CFG_LOG_INFO);
-                    if (logmsg) free(logmsg);
-                }
+                scopeLog(CFG_LOG_INFO, "Waiting for server shutdown using SSL_shutdown failed: ssl_err=%d\n", ssl_err);
             }
         }
     }
@@ -333,7 +322,7 @@ shutdownTlsSession(transport_t *trans)
 static void
 handle_tls_destroy(void)
 {
-    scopeLog("detected beginning of process exit sequence", -1, CFG_LOG_INFO);
+    scopeLog(CFG_LOG_INFO, "detected beginning of process exit sequence");
 
     if (handleExit_fn) handleExit_fn();
 }
@@ -358,7 +347,7 @@ static int
 establishTlsSession(transport_t *trans)
 {
     if (!trans || trans->net.sock == -1) return FALSE;
-    scopeLog("establishing tls session", trans->net.sock, CFG_LOG_INFO);
+    scopeLog(CFG_LOG_INFO, "fd:%d establishing tls session", trans->net.sock);
 
     static int init_called = FALSE;
     if (!init_called) {
@@ -368,11 +357,9 @@ establishTlsSession(transport_t *trans)
 
     trans->net.tls.ctx = SSL_CTX_new(TLS_method());
     if (!trans->net.tls.ctx) {
-        char msg[512] = {0};
         char err[256] = {0};
         ERR_error_string_n(ERR_peek_last_error() , err, sizeof(err));
-        snprintf(msg, sizeof(msg), "error creating tls context: %s", err);
-        scopeLog(msg, trans->net.sock, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "fd:%d error creating tls context: %s", trans->net.sock, err);
         goto err;
     }
 
@@ -383,11 +370,9 @@ establishTlsSession(transport_t *trans)
 
     long loc_rv = SSL_CTX_load_verify_locations(trans->net.tls.ctx, cafile, NULL);
     if (trans->net.tls.validateserver && !loc_rv) {
-        char msg[512] = {0};
         char err[256] = {0};
         ERR_error_string_n(ERR_peek_last_error() , err, sizeof(err));
-        snprintf(msg, sizeof(msg), "error setting tls cacertpath: \"%s\" : %s", cafile, err);
-        scopeLog(msg, trans->net.sock, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "fd:%d error setting tls cacertpath: \"%s\" : %s", trans->net.sock, cafile, err);
         // We're not treating this as a hard error at this point.
         // Let the process proceed; validation below will likely fail
         // and might provide more meaningful info.
@@ -395,36 +380,29 @@ establishTlsSession(transport_t *trans)
 
     trans->net.tls.ssl = SSL_new(trans->net.tls.ctx);
     if (!trans->net.tls.ssl) {
-        char msg[512] = {0};
         char err[256] = {0};
         ERR_error_string_n(ERR_peek_last_error() , err, sizeof(err));
-        snprintf(msg, sizeof(msg), "error creating tls session: %s", err);
-        scopeLog(msg, trans->net.sock, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "fd:%d error creating tls session: %s", trans->net.sock, err);
         goto err;
     }
 
     if (!SSL_set_fd(trans->net.tls.ssl, trans->net.sock)) {
-        char msg[512] = {0};
         char err[256] = {0};
         ERR_error_string_n(ERR_peek_last_error() , err, sizeof(err));
-        snprintf(msg, sizeof(msg), "error setting tls on socket: %d : %s", trans->net.sock, err);
-        scopeLog(msg, trans->net.sock, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "fd:%d error setting tls on socket: %d : %s", trans->net.sock, trans->net.sock, err);
         goto err;
     }
 
     ERR_clear_error(); // to make SSL_get_error reliable
     int con_rv = SSL_connect(trans->net.tls.ssl);
     if (con_rv != 1) {
-        char msg[512] = {0};
         char err[256] = {0};
         int ssl_err = SSL_get_error(trans->net.tls.ssl, con_rv);
         ERR_error_string_n(ssl_err, err, sizeof(err));
-        snprintf(msg, sizeof(msg), "error establishing tls connection: %s", err);
-        scopeLog(msg, trans->net.sock, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "fd:%d error establishing tls connection: %s", trans->net.sock, err);
         if (ssl_err == SSL_ERROR_SSL || ssl_err == SSL_ERROR_SYSCALL) {
             ERR_error_string_n(ERR_peek_last_error() , err, sizeof(err));
-            snprintf(msg, sizeof(msg), "error establishing tls connection: %s %d", err, errno);
-            scopeLog(msg, trans->net.sock, CFG_LOG_INFO);
+            scopeLog(CFG_LOG_INFO, "fd:%d error establishing tls connection: %s %d", trans->net.sock, err, errno);
         }
         goto err;
     }
@@ -435,22 +413,20 @@ establishTlsSession(transport_t *trans)
         if (cert) {
             X509_free(cert);  // Looks good.  Free it immediately
         } else {
-            scopeLog("error accessing peer certificate for tls server validation",
-                                                  trans->net.sock, CFG_LOG_INFO);
+            scopeLog(CFG_LOG_INFO, "fd:%d error accessing peer certificate for tls server validation",
+                                                  trans->net.sock);
             goto err;
         }
 
         long ver_rc = SSL_get_verify_result(trans->net.tls.ssl);
         if (ver_rc != X509_V_OK) {
-            char msg[512] = {0};
             const char *err = X509_verify_cert_error_string(ver_rc);
-            snprintf(msg, sizeof(msg), "tls server validation failed : \"%s\"", err);
-            scopeLog(msg, trans->net.sock, CFG_LOG_INFO);
+            scopeLog(CFG_LOG_INFO, "fd:%d tls server validation failed : \"%s\"", trans->net.sock, err);
             goto err;
         }
     }
 
-    scopeLog("tls session established", trans->net.sock, CFG_LOG_INFO);
+    scopeLog(CFG_LOG_INFO, "fd:%d tls session established", trans->net.sock);
     return TRUE;
 err:
     shutdownTlsSession(trans);
@@ -679,7 +655,7 @@ checkPendingSocketStatus(transport_t *trans)
     socklen_t optlen = sizeof(opt);
     if ((getsockopt(trans->net.pending_connect, SOL_SOCKET, SO_ERROR, (void*)(&opt), &optlen) < 0)
             || opt) {
-        scopeLog("connect failed", trans->net.pending_connect, CFG_LOG_INFO);
+        scopeLog(CFG_LOG_INFO, "fd:%d connect failed", trans->net.pending_connect);
 
         g_fn.close(trans->net.pending_connect);
         trans->net.pending_connect = -1;
@@ -687,7 +663,7 @@ checkPendingSocketStatus(transport_t *trans)
     }
 
     // We have a connection
-    scopeLog("connect successful", trans->net.pending_connect, CFG_LOG_INFO);
+    scopeLog(CFG_LOG_INFO, "fd:%d connect successful", trans->net.pending_connect);
 
     // Move this descriptor up out of the way
     trans->net.sock = placeDescriptor(trans->net.pending_connect, trans);
@@ -749,13 +725,8 @@ getAddressList(transport_t *trans)
             return 0;
     }
 
-    char *logmsg = NULL;
     char *type = (trans->type == CFG_UDP) ? "udp" : "tcp";
-    if (asprintf(&logmsg, "getting DNS info for %s %s:%s",
-             type, trans->net.host, trans->net.port) != -1) {
-        scopeLog(logmsg, -1, CFG_LOG_INFO);
-        if (logmsg) free(logmsg);
-    }
+    scopeLog(CFG_LOG_INFO, "getting DNS info for %s %s:%s", type, trans->net.host, trans->net.port);
 
     if (trans->getaddrinfo(trans->net.host,
                            trans->net.port,
@@ -844,22 +815,14 @@ socketConnectionStart(transport_t *trans)
                          addr->ai_addrlen) == -1) {
 
             if (errno != EINPROGRESS) {
-                char *logmsg = NULL;
-                if (asprintf(&logmsg, "connect to %s:%d failed", addrstr, port) != -1) {
-                    scopeLog(logmsg, sock, CFG_LOG_INFO);
-                    if (logmsg) free(logmsg);
-                }
+                scopeLog(CFG_LOG_INFO, "fd:%d connect to %s:%d failed", sock, addrstr, port);
 
                 // We could create a sock, but not connect.  Clean up.
                 g_fn.close(sock);
                 continue;
             }
 
-            char *logmsg = NULL;
-            if (asprintf(&logmsg, "connect to %s:%d is pending", addrstr, port) != -1) {
-                scopeLog(logmsg, sock, CFG_LOG_INFO);
-                if (logmsg) free(logmsg);
-            }
+            scopeLog(CFG_LOG_INFO, "fd:%d connect to %s:%d is pending", sock, addrstr, port);
 
             trans->net.pending_connect = sock;
             break;  // replace w/continue for a shotgun start.
@@ -867,11 +830,7 @@ socketConnectionStart(transport_t *trans)
 
 
         if (trans->type == CFG_UDP) {
-            char *logmsg = NULL;
-            if (asprintf(&logmsg, "connect to %s:%d was successful", addrstr, port) != -1) {
-                scopeLog(logmsg, sock, CFG_LOG_INFO);
-                if (logmsg) free(logmsg);
-            }
+            scopeLog(CFG_LOG_INFO, "fd:%d connect to %s:%d was successful", sock, addrstr, port);
 
             // connect on udp sockets normally succeeds immediately.
             trans->net.sock = placeDescriptor(sock, trans);
@@ -983,7 +942,7 @@ transportConnect(transport_t *trans)
             }
 
             // We have a connection
-            scopeLog("connect successful", trans->local.sock, CFG_LOG_INFO);
+            scopeLog(CFG_LOG_INFO, "fd:%d connect successful", trans->local.sock);
 
             // Move this descriptor up out of the way
             trans->local.sock = placeDescriptor(trans->local.sock, trans);

--- a/src/utils.c
+++ b/src/utils.c
@@ -76,9 +76,7 @@ setPidEnv(int pid)
     }
 
     if (fullSetenv(SCOPE_PID_ENV, val, 1) == -1) {
-        char dbmsg[PATH_MAX];
-        snprintf(dbmsg, sizeof(dbmsg), "setPidEnv: %s:%s", SCOPE_PID_ENV, val);
-        scopeLog(dbmsg, -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "setPidEnv: %s:%s", SCOPE_PID_ENV, val);
     }
 }
 

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -2667,9 +2667,16 @@ scope_write(int fd, const void* buf, size_t size)
 static int
 scope_open(const char* pathname)
 {
-    int fd = g_fn.open(pathname, O_WRONLY | O_APPEND);
+    // This implementation is largely based on transportConnectFile().
+    int fd = g_fn.open(pathname, O_CREAT|O_WRONLY|O_APPEND|O_CLOEXEC, 0666);
     if (fd == -1) {
-        fd = g_fn.open(pathname, O_CREAT | O_WRONLY, 0666);
+        DBG("%s", pathname);
+        return fd;
+    }
+
+    // Since umask affects open permissions above...
+    if (fchmod(fd, 0666) == -1) {
+        DBG("%d %s", fd, pathname);
     }
     return fd;
 }

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -270,14 +270,14 @@ findSymbol(struct dl_phdr_info *info, size_t size, void *data)
     if (g_fn.func == NULL ) {                                          \
        if (!g_ctl) {                                                   \
          if ((g_fn.func = scope_dlsym(RTLD_NEXT, #func, func)) == NULL) {  \
-             scopeLog("ERROR: "#func":NULL\n", -1, CFG_LOG_ERROR);     \
+             scopeLog(CFG_LOG_ERROR, "ERROR: "#func":NULL\n");         \
              return rc;                                                \
          }                                                             \
        } else {                                                        \
         param_t param = {.in_symbol = #func, .out_addr = NULL,         \
                          .after_scope = FALSE};                        \
         if (!dl_iterate_phdr(findSymbol, &param)) {                    \
-            scopeLog("ERROR: "#func":NULL\n", -1, CFG_LOG_ERROR);      \
+            scopeLog(CFG_LOG_ERROR, "ERROR: "#func":NULL\n");          \
             return rc;                                                 \
         }                                                              \
         g_fn.func = param.out_addr;                                    \
@@ -289,14 +289,14 @@ findSymbol(struct dl_phdr_info *info, size_t size, void *data)
     if (g_fn.func == NULL ) {                                          \
        if (!g_ctl) {                                                   \
          if ((g_fn.func = scope_dlsym(RTLD_NEXT, #func, func)) == NULL) {  \
-             scopeLog("ERROR: "#func":NULL\n", -1, CFG_LOG_ERROR);     \
+             scopeLog(CFG_LOG_ERROR, "ERROR: "#func":NULL\n");         \
              return;                                                   \
          }                                                             \
        } else {                                                        \
         param_t param = {.in_symbol = #func, .out_addr = NULL,         \
                          .after_scope = FALSE};                        \
         if (!dl_iterate_phdr(findSymbol, &param)) {                    \
-            scopeLog("ERROR: "#func":NULL\n", -1, CFG_LOG_ERROR);      \
+            scopeLog(CFG_LOG_ERROR, "ERROR: "#func":NULL\n");          \
             return;                                                    \
         }                                                              \
         g_fn.func = param.out_addr;                                    \
@@ -322,7 +322,7 @@ findSymbol(struct dl_phdr_info *info, size_t size, void *data)
 #define WRAP_CHECK(func, rc)                                           \
     if (g_fn.func == NULL ) {                                          \
         if ((g_fn.func = dlsym(RTLD_NEXT, #func)) == NULL) {           \
-            scopeLog("ERROR: "#func":NULL\n", -1, CFG_LOG_ERROR);      \
+            scopeLog(CFG_LOG_ERROR, "ERROR: "#func":NULL\n");          \
             return rc;                                                 \
        }                                                               \
     }                                                                  \
@@ -331,7 +331,7 @@ findSymbol(struct dl_phdr_info *info, size_t size, void *data)
 #define WRAP_CHECK_VOID(func)                                          \
     if (g_fn.func == NULL ) {                                          \
         if ((g_fn.func = dlsym(RTLD_NEXT, #func)) == NULL) {           \
-            scopeLog("ERROR: "#func":NULL\n", -1, CFG_LOG_ERROR);      \
+            scopeLog(CFG_LOG_ERROR, "ERROR: "#func":NULL\n");          \
             return;                                                    \
        }                                                               \
     }                                                                  \
@@ -436,7 +436,7 @@ remoteConfig()
     snprintf(path, sizeof(path), "/tmp/cfg.%d", g_proc.pid);
     if ((fs = g_fn.fopen(path, "a+")) == NULL) {
         DBG(NULL);
-        scopeLog("ERROR: remoteConfig:fopen", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: remoteConfig:fopen");
         return;
     }
 
@@ -671,7 +671,7 @@ threadNow(int sig)
 
     if (g_fn.pthread_create &&
         (g_fn.pthread_create(&g_thread.periodicTID, NULL, periodic, NULL) != 0)) {
-        scopeLog("ERROR: threadNow:pthread_create", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: threadNow:pthread_create");
         if (!atomicCasU64(&serialize, 1ULL, 0ULL)) DBG(NULL);
         return;
     }
@@ -741,7 +741,7 @@ threadInit()
     if (getenv("SCOPE_NO_SIGNAL")) return;
 
     if (osThreadInit(threadNow, g_thread.interval) == FALSE) {
-        scopeLog("ERROR: threadInit:osThreadInit", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: threadInit:osThreadInit");
     }
 }
 
@@ -805,7 +805,7 @@ setProcId(proc_id_t *proc)
     proc->pid = getpid();
     proc->ppid = getppid();
     if (gethostname(proc->hostname, sizeof(proc->hostname)) != 0) {
-        scopeLog("ERROR: gethostname", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: gethostname");
     }
     osGetProcname(proc->procname, sizeof(proc->procname));
 
@@ -1039,7 +1039,7 @@ ssl_read_hook(SSL *ssl, void *buf, int num)
 {
     int rc;
 
-    scopeLog("ssl_read_hook", -1, CFG_LOG_TRACE);
+    scopeLog(CFG_LOG_TRACE, "ssl_read_hook");
     WRAP_CHECK(SSL_read, -1);
     rc = g_fn.SSL_read(ssl, buf, num);
     if (rc > 0) {
@@ -1059,7 +1059,7 @@ ssl_write_hook(SSL *ssl, void *buf, int num)
 {
     int rc;
 
-    scopeLog("ssl_write_hook", -1, CFG_LOG_TRACE);
+    scopeLog(CFG_LOG_TRACE, "ssl_write_hook");
     WRAP_CHECK(SSL_write, -1);
     rc = g_fn.SSL_write(ssl, buf, num);
     if (rc > 0) {
@@ -1078,12 +1078,10 @@ static void *
 load_func(const char *module, const char *func)
 {
     void *addr;
-    char buf[128];
     
     void *handle = g_fn.dlopen(module, RTLD_LAZY | RTLD_NOLOAD);
     if (handle == NULL) {
-        snprintf(buf, sizeof(buf), "ERROR: Could not open file %s.\n", module ? module : "(null)");
-        scopeLog(buf, -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: Could not open file %s.\n", module ? module : "(null)");
         return NULL;
     }
 
@@ -1091,13 +1089,11 @@ load_func(const char *module, const char *func)
     dlclose(handle);
 
     if (addr == NULL) {
-        snprintf(buf, sizeof(buf), "ERROR: Could not get function address of %s.\n", func);
-        scopeLog(buf, -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: Could not get function address of %s.\n", func);
         return NULL;
     }
 
-    snprintf(buf, sizeof(buf), "%s:%d %s found at %p\n", __FUNCTION__, __LINE__, func, addr);
-    scopeLog(buf, -1, CFG_LOG_ERROR);
+    scopeLog(CFG_LOG_ERROR, "%s:%d %s found at %p\n", __FUNCTION__, __LINE__, func, addr);
     return addr;
 }
 
@@ -1188,7 +1184,6 @@ hookInject()
     char *str = NULL;
     int rsz = 0;
     struct link_map *lm;
-    char buf[512];
 
     if (dl_iterate_phdr(findLibscopePath, &full_path)) {
         void *libscopeHandle = g_fn.dlopen(full_path, RTLD_NOW);
@@ -1212,8 +1207,7 @@ hookInject()
                 inject_hook_list[i].func = addr;
                 if ((dlsym(handle, inject_hook_list[i].symbol)) &&
                     (doGotcha(lm, (got_list_t *)&inject_hook_list[i], rel, sym, str, rsz, 1) != -1)) {
-                    snprintf(buf, sizeof(buf), "\tGOT patched %s", inject_hook_list[i].symbol);
-                    scopeLog(buf, -1, CFG_LOG_DEBUG);
+                    scopeLog(CFG_LOG_DEBUG, "\tGOT patched %s", inject_hook_list[i].symbol);
                 }
             }
         }
@@ -1244,7 +1238,7 @@ initHook(int attachedFlag)
         initGoHook(ebuf);
         threadNow(0);
         if (arch_prctl(ARCH_GET_FS, (unsigned long)&scope_fs) == -1) {
-            scopeLog("initHook:arch_prctl", -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "initHook:arch_prctl");
         }
 
         __asm__ volatile (
@@ -1391,10 +1385,8 @@ initHook(int attachedFlag)
         // hook 'em
         rc = funchook_install(funchook, 0);
         if (rc != 0) {
-            char buf[128];
-            snprintf(buf, sizeof(buf), "ERROR: failed to install SSL_read hook. (%s)\n",
-                     funchook_error_message(funchook));
-            scopeLog(buf, -1, CFG_LOG_ERROR);
+            scopeLog(CFG_LOG_ERROR, "ERROR: failed to install SSL_read hook. (%s)\n",
+                        funchook_error_message(funchook));
             return;
         }
     }
@@ -1409,7 +1401,7 @@ initEnv(int *attachedFlag)
 
     if (!g_fn.fopen || !g_fn.fgets || !g_fn.fclose || !g_fn.setenv) {
         // these log statements use debug level so they can be used with constructor debug
-        scopeLog("ERROR: missing g_fn's for initEnv()", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "ERROR: missing g_fn's for initEnv()");
         return;
     }
 
@@ -1417,14 +1409,14 @@ initEnv(int *attachedFlag)
     char path[128];
     int  pathLen = snprintf(path, sizeof(path), "/dev/shm/scope_attach_%d.env", getpid());
     if (pathLen < 0 || pathLen >= sizeof(path)) {
-        scopeLog("ERROR: snprintf(scope_attach_PID.env) failed", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "ERROR: snprintf(scope_attach_PID.env) failed");
         return;
     }
 
     // open it
     FILE *fd = g_fn.fopen(path, "r");
     if (fd == NULL) {
-        scopeLog("ERROR: fopen(scope_attach_PID.env) failed", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "ERROR: fopen(scope_attach_PID.env) failed");
         return;
     }
 
@@ -1442,10 +1434,10 @@ initEnv(int *attachedFlag)
             if (val) {
                 fullSetenv(key, val, 1);
             } else {
-                scopeLog("ERROR: strtok(val) failed", -1, CFG_LOG_DEBUG);
+                scopeLog(CFG_LOG_DEBUG, "ERROR: strtok(val) failed");
             }
         } else {
-            scopeLog("ERROR: strtok(key) failed", -1, CFG_LOG_DEBUG);
+            scopeLog(CFG_LOG_DEBUG, "ERROR: strtok(key) failed");
         }
     }
 
@@ -2357,7 +2349,7 @@ gethostbyname_r(const char *name, struct hostent *ret, char *buf, size_t buflen,
     time.duration = getDuration(time.initial);
 
     if ((rc == 0) && (result != NULL)) {
-        scopeLog("gethostbyname_r", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "gethostbyname_r");
         doUpdateState(DNS, -1, time.duration, NULL, name);
         doUpdateState(DNS_DURATION, -1, time.duration, NULL, name);
     }  else {
@@ -2381,7 +2373,7 @@ gethostbyname2_r(const char *name, int af, struct hostent *ret, char *buf,
     time.duration = getDuration(time.initial);
 
     if ((rc == 0) && (result != NULL)) {
-        scopeLog("gethostbyname2_r", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "gethostbyname2_r");
         doUpdateState(DNS, -1, time.duration, NULL, name);
         doUpdateState(DNS_DURATION, -1, time.duration, NULL, name);
     }  else {
@@ -2493,11 +2485,9 @@ execve(const char *pathname, char *const argv[], char *const envp[])
     scopexec = getenv("SCOPE_EXEC_PATH");
     if (((scopexec = getpath(scopexec)) == NULL) &&
         ((scopexec = getpath("ldscope")) == NULL)) {
-        char msg[64];
 
         // can't find the scope executable
-        snprintf(msg, sizeof(msg), "execve: can't find a scope executable for %s", pathname);
-        scopeLog(msg, -1, CFG_LOG_WARN);
+        scopeLog(CFG_LOG_WARN, "execve: can't find a scope executable for %s", pathname);
         return g_fn.execve(pathname, argv, envp);
     }
 
@@ -2741,7 +2731,7 @@ SSL_read(SSL *ssl, void *buf, int num)
 {
     int rc;
     
-    //scopeLog("SSL_read", -1, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "SSL_read");
     WRAP_CHECK(SSL_read, -1);
     rc = g_fn.SSL_read(ssl, buf, num);
 
@@ -2761,7 +2751,7 @@ SSL_write(SSL *ssl, const void *buf, int num)
 {
     int rc;
     
-    //scopeLog("SSL_write", -1, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "SSL_write");
     WRAP_CHECK(SSL_write, -1);
 
     rc = g_fn.SSL_write(ssl, buf, num);
@@ -2816,7 +2806,7 @@ gnutls_record_recv(gnutls_session_t session, void *data, size_t data_size)
 {
     ssize_t rc;
 
-    //scopeLog("gnutls_record_recv", -1, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "gnutls_record_recv");
     WRAP_CHECK(gnutls_record_recv, -1);
     rc = g_fn.gnutls_record_recv(session, data, data_size);
 
@@ -2832,7 +2822,7 @@ gnutls_record_recv_early_data(gnutls_session_t session, void *data, size_t data_
 {
     ssize_t rc;
 
-    //scopeLog("gnutls_record_recv_early_data", -1, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "gnutls_record_recv_early_data");
     WRAP_CHECK(gnutls_record_recv_early_data, -1);
     rc = g_fn.gnutls_record_recv_early_data(session, data, data_size);
 
@@ -2848,7 +2838,7 @@ gnutls_record_recv_packet(gnutls_session_t session, gnutls_packet_t *packet)
 {
     ssize_t rc;
 
-    //scopeLog("gnutls_record_recv_packet", -1, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "gnutls_record_recv_packet");
     WRAP_CHECK(gnutls_record_recv_packet, -1);
     rc = g_fn.gnutls_record_recv_packet(session, packet);
 
@@ -2863,7 +2853,7 @@ gnutls_record_recv_seq(gnutls_session_t session, void *data, size_t data_size, u
 {
     ssize_t rc;
 
-    //scopeLog("gnutls_record_recv_seq", -1, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "gnutls_record_recv_seq");
     WRAP_CHECK(gnutls_record_recv_seq, -1);
     rc = g_fn.gnutls_record_recv_seq(session, data, data_size, seq);
 
@@ -2879,7 +2869,7 @@ gnutls_record_send(gnutls_session_t session, const void *data, size_t data_size)
 {
     ssize_t rc;
 
-    //scopeLog("gnutls_record_send", -1, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "gnutls_record_send");
     WRAP_CHECK(gnutls_record_send, -1);
     rc = g_fn.gnutls_record_send(session, data, data_size);
 
@@ -2896,7 +2886,7 @@ gnutls_record_send2(gnutls_session_t session, const void *data, size_t data_size
 {
     ssize_t rc;
 
-    //scopeLog("gnutls_record_send2", -1, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "gnutls_record_send2");
     WRAP_CHECK(gnutls_record_send2, -1);
     rc = g_fn.gnutls_record_send2(session, data, data_size, pad, flags);
 
@@ -2912,7 +2902,7 @@ gnutls_record_send_early_data(gnutls_session_t session, const void *data, size_t
 {
     ssize_t rc;
 
-    //scopeLog("gnutls_record_send_early_data", -1, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "gnutls_record_send_early_data");
     WRAP_CHECK(gnutls_record_send_early_data, -1);
     rc = g_fn.gnutls_record_send_early_data(session, data, data_size);
 
@@ -2929,7 +2919,7 @@ gnutls_record_send_range(gnutls_session_t session, const void *data, size_t data
 {
     ssize_t rc;
 
-    //scopeLog("gnutls_record_send_range", -1, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "gnutls_record_send_range");
     WRAP_CHECK(gnutls_record_send_range, -1);
     rc = g_fn.gnutls_record_send_range(session, data, data_size, range);
 
@@ -2949,13 +2939,13 @@ nss_close(PRFileDesc *fd)
     // Note: NSS docs don't define that PR_GetError should be called on failure
     if (!fd) return PR_FAILURE;
 
-    //scopeLog("nss_close", (uint64_t)fd->methods, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "fd:%d nss_close", (uint64_t)fd->methods);
     if ((nssentry = lstFind(g_nsslist, (uint64_t)fd->methods)) != NULL) {
         rc = nssentry->ssl_methods->close(fd);
     } else {
         rc = PR_FAILURE;
         DBG(NULL);
-        scopeLog("ERROR: nss_close no list entry", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: nss_close no list entry");
         return rc;
     }
 
@@ -2984,13 +2974,13 @@ nss_send(PRFileDesc *fd, const void *buf, PRInt32 amount, PRIntn flags, PRInterv
         return -1;
     }
 
-    //scopeLog("nss_send", (uint64_t)fd->methods, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "fd:%d nss_send", (uint64_t)fd->methods);
     if ((nssentry = lstFind(g_nsslist, (uint64_t)fd->methods)) != NULL) {
         rc = nssentry->ssl_methods->send(fd, buf, amount, flags, timeout);
     } else {
         rc = -1;
         DBG(NULL);
-        scopeLog("ERROR: nss_send no list entry", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: nss_send no list entry");
     }
 
     if (rc > 0) {
@@ -3020,13 +3010,13 @@ nss_recv(PRFileDesc *fd, void *buf, PRInt32 amount, PRIntn flags, PRIntervalTime
         return -1;
     }
 
-    //scopeLog("nss_recv", (uint64_t)fd->methods, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "fd:%d nss_recv", (uint64_t)fd->methods);
     if ((nssentry = lstFind(g_nsslist, (uint64_t)fd->methods)) != NULL) {
         rc = nssentry->ssl_methods->recv(fd, buf, amount, flags, timeout);
     } else {
         rc = -1;
         DBG(NULL);
-        scopeLog("ERROR: nss_recv no list entry", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: nss_recv no list entry");
     }
 
     if (rc > 0) {
@@ -3056,13 +3046,13 @@ nss_read(PRFileDesc *fd, void *buf, PRInt32 amount)
         return -1;
     }
 
-    //scopeLog("nss_read", (uint64_t)fd->methods, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "fd:%d nss_read", (uint64_t)fd->methods);
     if ((nssentry = lstFind(g_nsslist, (uint64_t)fd->methods)) != NULL) {
         rc = nssentry->ssl_methods->read(fd, buf, amount);
     } else {
         rc = -1;
         DBG(NULL);
-        scopeLog("ERROR: nss_read no list entry", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: nss_read no list entry");
     }
 
     if (rc > 0) {
@@ -3092,13 +3082,13 @@ nss_write(PRFileDesc *fd, const void *buf, PRInt32 amount)
         return -1;
     }
 
-    //scopeLog("nss_write", fd->methods, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "fd:%d nss_write", fd->methods);
     if ((nssentry = lstFind(g_nsslist, (uint64_t)fd->methods)) != NULL) {
         rc = nssentry->ssl_methods->write(fd, buf, amount);
     } else {
         rc = -1;
         DBG(NULL);
-        scopeLog("ERROR: nss_write no list entry", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: nss_write no list entry");
     }
 
     if (rc > 0) {
@@ -3128,13 +3118,13 @@ nss_writev(PRFileDesc *fd, const PRIOVec *iov, PRInt32 iov_size, PRIntervalTime 
         return -1;
     }
 
-    //scopeLog("nss_writev", fd->methods, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "fd:%d nss_writev", fd->methods);
     if ((nssentry = lstFind(g_nsslist, (uint64_t)fd->methods)) != NULL) {
         rc = nssentry->ssl_methods->writev(fd, iov, iov_size, timeout);
     } else {
         rc = -1;
         DBG(NULL);
-        scopeLog("ERROR: nss_writev no list entry", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: nss_writev no list entry");
     }
 
     if (rc > 0) {
@@ -3165,13 +3155,13 @@ nss_sendto(PRFileDesc *fd, const void *buf, PRInt32 amount, PRIntn flags,
         return -1;
     }
 
-    //scopeLog("nss_sendto", fd->methods, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "fd:%d nss_sendto", fd->methods);
     if ((nssentry = lstFind(g_nsslist, (uint64_t)fd->methods)) != NULL) {
         rc = nssentry->ssl_methods->sendto(fd, (void *)buf, amount, flags, addr, timeout);
     } else {
         rc = -1;
         DBG(NULL);
-        scopeLog("ERROR: nss_sendto no list entry", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: nss_sendto no list entry");
     }
 
     if (rc > 0) {
@@ -3202,13 +3192,13 @@ nss_recvfrom(PRFileDesc *fd, void *buf, PRInt32 amount, PRIntn flags,
         return -1;
     }
 
-    //scopeLog("nss_recvfrom", fd->methods, CFG_LOG_ERROR);
+    //scopeLog(CFG_LOG_ERROR, "fd:%d nss_recvfrom", fd->methods);
     if ((nssentry = lstFind(g_nsslist, (uint64_t)fd->methods)) != NULL) {
         rc = nssentry->ssl_methods->recvfrom(fd, buf, amount, flags, addr, timeout);
     } else {
         rc = -1;
         DBG(NULL);
-        scopeLog("ERROR: nss_recvfrom no list entry", -1, CFG_LOG_ERROR);
+        scopeLog(CFG_LOG_ERROR, "ERROR: nss_recvfrom no list entry");
     }
 
     if (rc > 0) {
@@ -3242,7 +3232,7 @@ SSL_ImportFD(PRFileDesc *model, PRFileDesc *currFd)
             memmove(nssentry->ssl_methods, result->methods, sizeof(PRIOMethods));
             memmove(nssentry->ssl_int_methods, result->methods, sizeof(PRIOMethods));
             nssentry->id = (uint64_t)nssentry->ssl_int_methods;
-            //scopeLog("SSL_ImportFD", (uint64_t)nssentry->id, CFG_LOG_INFO);
+            //scopeLog(CFG_LOG_INFO, "fd:%d SSL_ImportFD", (uint64_t)nssentry->id);
 
             // ref contrib/tls/nss/prio.h struct PRIOMethods
             // read ... todo? read, recvfrom, acceptread
@@ -3277,7 +3267,6 @@ dlopen(const char *filename, int flags)
 {
     void *handle;
     struct link_map *lm;
-    char buf[1024];
     char fbuf[256];
 
     fbuf[0] = '\0';
@@ -3288,8 +3277,7 @@ dlopen(const char *filename, int flags)
     if (flags & RTLD_NODELETE) strcat(fbuf, "RTLD_NODELETE|");
     if (flags & RTLD_NOLOAD) strcat(fbuf, "RTLD_NOLOAD|");
     if (flags & RTLD_DEEPBIND) strcat(fbuf, "RTLD_DEEPBIND|");
-    snprintf(buf, sizeof(buf), "dlopen called for %s with %s", filename, fbuf);
-    scopeLog(buf, -1, CFG_LOG_DEBUG);
+    scopeLog(CFG_LOG_DEBUG, "dlopen called for %s with %s", filename, fbuf);
 
     WRAP_CHECK(dlopen, NULL);
 
@@ -3309,15 +3297,13 @@ dlopen(const char *filename, int flags)
         // Get the link map and ELF sections in advance of something matching
         if ((dlinfo(handle, RTLD_DI_LINKMAP, (void *)&lm) != -1) &&
             (getElfEntries(lm, &rel, &sym, &str, &rsz) != -1)) {
-            snprintf(buf, sizeof(buf), "\tlibrary:  %s", lm->l_name);
-            scopeLog(buf, -1, CFG_LOG_DEBUG);
+            scopeLog(CFG_LOG_DEBUG, "\tlibrary:  %s", lm->l_name);
 
             // for each symbol in the list try to hook
             for (i=0; hook_list[i].symbol; i++) {
                 if ((dlsym(handle, hook_list[i].symbol)) &&
                     (doGotcha(lm, (got_list_t *)&hook_list[i], rel, sym, str, rsz, 0) != -1)) {
-                    snprintf(buf, sizeof(buf), "\tdlopen interposed  %s", hook_list[i].symbol);
-                    scopeLog(buf, -1, CFG_LOG_DEBUG);
+                    scopeLog(CFG_LOG_DEBUG, "\tdlopen interposed  %s", hook_list[i].symbol);
                 }
             }
         }
@@ -3451,7 +3437,7 @@ __sendto_nocancel(int sockfd, const void *buf, size_t len, int flags,
     WRAP_CHECK(__sendto_nocancel, -1);
     rc = g_fn.__sendto_nocancel(sockfd, buf, len, flags, dest_addr, addrlen);
     if (rc != -1) {
-        scopeLog("__sendto_nocancel", sockfd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d __sendto_nocancel", sockfd);
         doSetAddrs(sockfd);
 
         if (remotePortIsDNS(sockfd)) {
@@ -3482,7 +3468,7 @@ DNSServiceQueryRecord(void *sdRef, uint32_t flags, uint32_t interfaceIndex,
     time.duration = getDuration(time.initial);
 
     if (rc == 0) {
-        scopeLog("DNSServiceQueryRecord", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "DNSServiceQueryRecord");
         doUpdateState(DNS, -1, time.duration, NULL, fullname);
         doUpdateState(DNS_DURATION, -1, time.duration, NULL, fullname);
     } else {
@@ -4117,7 +4103,7 @@ EXPORTOFF void
 vsyslog(int priority, const char *format, va_list ap)
 {
     WRAP_CHECK_VOID(vsyslog);
-    scopeLog("vsyslog", -1, CFG_LOG_DEBUG);
+    scopeLog(CFG_LOG_DEBUG, "vsyslog");
     g_fn.vsyslog(priority, format, ap);
     return;
 }
@@ -4128,7 +4114,7 @@ fork()
     pid_t rc;
 
     WRAP_CHECK(fork, -1);
-    scopeLog("fork", -1, CFG_LOG_DEBUG);
+    scopeLog(CFG_LOG_DEBUG, "fork");
     rc = g_fn.fork();
     if (rc == 0) {
         // We are the child proc
@@ -4146,7 +4132,7 @@ socket(int socket_family, int socket_type, int protocol)
     WRAP_CHECK(socket, -1);
     sd = g_fn.socket(socket_family, socket_type, protocol);
     if (sd != -1) {
-        scopeLog("socket", sd, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "fd:%d socket", sd);
         addSock(sd, socket_type, socket_family);
 
         if ((socket_family == AF_INET) || (socket_family == AF_INET6)) {
@@ -4191,7 +4177,7 @@ listen(int sockfd, int backlog)
     WRAP_CHECK(listen, -1);
     rc = g_fn.listen(sockfd, backlog);
     if (rc != -1) {
-        scopeLog("listen", sockfd, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "fd:%d listen", sockfd);
 
         doUpdateState(OPEN_PORTS, sockfd, 1, "listen", NULL);
         doUpdateState(NET_CONNECTIONS, sockfd, 1, "listen", NULL);
@@ -4257,7 +4243,7 @@ bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
     rc = g_fn.bind(sockfd, addr, addrlen);
     if (rc != -1) { 
         doSetConnection(sockfd, addr, addrlen, LOCAL);
-        scopeLog("bind", sockfd, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "fd:%d bind", sockfd);
     } else {
         doUpdateState(NET_ERR_CONN, sockfd, (ssize_t)0, "bind", "nopath");
     }
@@ -4281,7 +4267,7 @@ connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
         doSetConnection(sockfd, addr, addrlen, REMOTE);
         doUpdateState(NET_CONNECTIONS, sockfd, 1, "connect", NULL);
 
-        scopeLog("connect", sockfd, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "fd:%d connect", sockfd);
     } else {
         doUpdateState(NET_ERR_CONN, sockfd, (ssize_t)0, "connect", "nopath");
     }
@@ -4297,7 +4283,7 @@ send(int sockfd, const void *buf, size_t len, int flags)
     doURL(sockfd, buf, len, NETTX);
     rc = g_fn.send(sockfd, buf, len, flags);
     if (rc != -1) {
-        scopeLog("send", sockfd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d send", sockfd);
         if (remotePortIsDNS(sockfd)) {
             getDNSName(sockfd, (void *)buf, len);
         }
@@ -4319,7 +4305,7 @@ internal_sendto(int sockfd, const void *buf, size_t len, int flags,
     WRAP_CHECK(sendto, -1);
     rc = g_fn.sendto(sockfd, buf, len, flags, dest_addr, addrlen);
     if (rc != -1) {
-        scopeLog("sendto", sockfd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d sendto", sockfd);
         doSetConnection(sockfd, dest_addr, addrlen, REMOTE);
 
         if (remotePortIsDNS(sockfd)) {
@@ -4350,7 +4336,7 @@ sendmsg(int sockfd, const struct msghdr *msg, int flags)
     WRAP_CHECK(sendmsg, -1);
     rc = g_fn.sendmsg(sockfd, msg, flags);
     if (rc != -1) {
-        scopeLog("sendmsg", sockfd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d sendmsg", sockfd);
 
         // For UDP connections the msg is a remote addr
         if (msg && !sockIsTCP(sockfd)) {
@@ -4385,7 +4371,7 @@ internal_sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int fla
     WRAP_CHECK(sendmmsg, -1);
     rc = g_fn.sendmmsg(sockfd, msgvec, vlen, flags);
     if (rc != -1) {
-        scopeLog("sendmmsg", sockfd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d sendmmsg", sockfd);
 
         // For UDP connections the msg is a remote addr
         if (!sockIsTCP(sockfd)) {
@@ -4425,7 +4411,7 @@ recv(int sockfd, void *buf, size_t len, int flags)
     ssize_t rc;
 
     WRAP_CHECK(recv, -1);
-    scopeLog("recv", sockfd, CFG_LOG_TRACE);
+    scopeLog(CFG_LOG_TRACE, "fd:%d recv", sockfd);
     if ((rc = doURL(sockfd, buf, len, NETRX)) == 0) {
         rc = g_fn.recv(sockfd, buf, len, flags);
     }
@@ -4453,7 +4439,7 @@ internal_recvfrom(int sockfd, void *buf, size_t len, int flags,
     WRAP_CHECK(recvfrom, -1);
     rc = g_fn.recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
     if (rc != -1) {
-        scopeLog("recvfrom", sockfd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d recvfrom", sockfd);
 
         if (remotePortIsDNS(sockfd)) {
             getDNSAnswer(sockfd, buf, rc, BUF);
@@ -4519,7 +4505,7 @@ recvmsg(int sockfd, struct msghdr *msg, int flags)
     WRAP_CHECK(recvmsg, -1);
     rc = g_fn.recvmsg(sockfd, msg, flags);
     if (rc != -1) {
-        scopeLog("recvmsg", sockfd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d recvmsg", sockfd);
 
         // For UDP connections the msg is a remote addr
         if (msg) {
@@ -4555,7 +4541,7 @@ recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
     WRAP_CHECK(recvmmsg, -1);
     rc = g_fn.recvmmsg(sockfd, msgvec, vlen, flags, timeout);
     if (rc != -1) {
-        scopeLog("recvmmsg", sockfd, CFG_LOG_TRACE);
+        scopeLog(CFG_LOG_TRACE, "fd:%d recvmmsg", sockfd);
 
         // For UDP connections the msg is a remote addr
         if (msgvec) {
@@ -4595,7 +4581,7 @@ gethostbyname(const char *name)
     time.duration = getDuration(time.initial);
 
     if (rc != NULL) {
-        scopeLog("gethostbyname", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "gethostbyname");
         doUpdateState(DNS, -1, time.duration, NULL, name);
         doUpdateState(DNS_DURATION, -1, time.duration, NULL, name);
     } else {
@@ -4619,7 +4605,7 @@ gethostbyname2(const char *name, int af)
     time.duration = getDuration(time.initial);
 
     if (rc != NULL) {
-        scopeLog("gethostbyname2", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "gethostbyname2");
         doUpdateState(DNS, -1, time.duration, NULL, name);
         doUpdateState(DNS_DURATION, -1, time.duration, NULL, name);
     } else {
@@ -4651,7 +4637,7 @@ getaddrinfo(const char *node, const char *service,
     time.duration = getDuration(time.initial);
 
     if (rc == 0) {
-        scopeLog("getaddrinfo", -1, CFG_LOG_DEBUG);
+        scopeLog(CFG_LOG_DEBUG, "getaddrinfo");
         doUpdateState(DNS, -1, time.duration, NULL, node);
         doUpdateState(DNS_DURATION, -1, time.duration, NULL, node);
     } else {

--- a/test/testContainers/go/unsupported/Dockerfile
+++ b/test/testContainers/go/unsupported/Dockerfile
@@ -56,7 +56,8 @@ ENV SCOPE_EVENT_METRIC=true
 ENV SCOPE_EVENT_HTTP=true
 ENV SCOPE_EVENT_DEST=file:///go/events.log
 ENV SCOPE_LOG_LEVEL=warning
-ENV SCOPE_LOG_DEST=file:///go/logs.txt
+ENV SCOPE_LOG_DEST=file:///tmp/scope.log
+ENV SCOPE_ALLOW_CONSTRUCT_DBG=true
 
 RUN echo "export PATH=/usr/local/scope:/usr/local/scope/bin:${PATH}" >/etc/profile.d/path.sh
 COPY scope-profile.sh /etc/profile.d/scope.sh

--- a/test/testContainers/go/unsupported/test_go.sh
+++ b/test/testContainers/go/unsupported/test_go.sh
@@ -5,7 +5,7 @@ DEBUG=0  # set this to 1 to capture the LOG_FILE for each test
 FAILED_TEST_LIST=""
 FAILED_TEST_COUNT=0
 
-LOG_FILE="/go/logs.txt"
+LOG_FILE="/tmp/scope.log"
 touch $LOG_FILE
 
 starttest(){


### PR DESCRIPTION
Modify scopeLog logging mechanism : 
- modify handling scopeLog parameters  - use variadic function with format specifier as parameter to move message composition in scopeLog
- Enable logging mechanism inside constructor using SCOPE_ALLOW_CONSTRUCT_DBG=true
- ~~Buffer the logging before initialization of configuration~~
- Highly recommend to review this commit by commit
- Fixes: #514