### PR TITLE
case-insentive hostname filter

### DIFF
--- a/src/cfgutils.c
+++ b/src/cfgutils.c
@@ -1713,8 +1713,10 @@ processCustomFilterHostname(config_t* config, yaml_document_t* doc, yaml_node_t*
         return;
     }
 
+    // Note hostname are not case sensitive so unlike other filters, this is a
+    // case-insensitive comparison.
     char *valueStr = stringVal(node);
-    if (valueStr && !strcmp(valueStr, g_proc.hostname)) {
+    if (valueStr && !strcasecmp(valueStr, g_proc.hostname)) {
         ++custom_match_count;
         free(valueStr);
         return;

--- a/test/cfgutilstest.c
+++ b/test/cfgutilstest.c
@@ -2140,7 +2140,7 @@ cfgReadCustomHostnameFilter(void **state)
         // this should match and enable payloads
         "  eg2:\n"
         "    filter:\n"
-        "      hostname: myhost\n"
+        "      hostname: MyHost\n" // note case change
         "    config:\n"
         "      payload:\n"
         "        enable: true\n"

--- a/test/testContainers/go/net/plainClient.go
+++ b/test/testContainers/go/net/plainClient.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 
-    resp, err := http.Get("http://cribl.com")
+    resp, err := http.Get("http://cribl.io")
     if err != nil {
         panic(err)
     }

--- a/test/testContainers/go/net/tlsClient.go
+++ b/test/testContainers/go/net/tlsClient.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 
-    resp, err := http.Get("https://cribl.com")
+    resp, err := http.Get("https://cribl.io")
     if err != nil {
         panic(err)
     }

--- a/test/testContainers/gogen/Dockerfile
+++ b/test/testContainers/gogen/Dockerfile
@@ -37,6 +37,7 @@ RUN  mkdir /usr/local/scope && \
      ln -s /opt/appscope/lib/linux/$(uname -m)/libscope.so /usr/local/scope/lib/libscope.so
 
 COPY gogen/scope-test /usr/local/scope/scope-test
+COPY gogen/weblog.yml /gogen/weblog.yml
 
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/test/testContainers/gogen/scope-test
+++ b/test/testContainers/gogen/scope-test
@@ -58,7 +58,7 @@ RX_FILE="/gogen/receive.log"
 tcpserver 12345 > $RX_FILE &
 
 # Run gogen
-ldscope ./gogen -c coccyx/weblog -ot json -o tcp --url localhost:12345 -g 10 --os 10 -v gen -c 10 -ei 10000 -i 60
+ldscope ./gogen -c /gogen/weblog.yml -ot json -o tcp --url localhost:12345 -g 10 --os 10 -v gen -c 10 -ei 10000 -i 60
 ERR+=$?
 evaltest
 

--- a/test/testContainers/gogen/weblog.yml
+++ b/test/testContainers/gogen/weblog.yml
@@ -1,0 +1,410 @@
+global:
+  rotInterval: 1
+  samplesDir:
+  - $GOGEN_HOME/examples/common
+  - examples/weblog
+samples:
+- name: weblog
+  description: Weblog data in Apache common format
+  notes: |
+    Easily customizable for your own needs.  If you want your IP ranges, edit external_ips.sample.   To modify server hostnames and client IPs, modify webhosts.csv.  Useragents.sample is also pretty dated, so feel free to replace with a more modern list of user agents.
+  disabled: false
+  generator: sample
+  rater: default
+  interval: 1
+  count: 10
+  earliest: now
+  latest: now
+  begin: -1s
+  end: now
+  endIntervals: 1
+  tokens:
+  - name: ts-dmyhmsms-template
+    format: template
+    token: $ts$
+    type: gotimestamp
+    replacement: 02/Jan/2006:15:04:05 +0000
+    field: _raw
+  - name: host
+    format: template
+    token: $host$
+    type: fieldChoice
+    group: 1
+    sample: webhosts.csv
+    field: host
+    srcField: host
+    fieldChoice:
+    - host: web-01.bar.com
+      ip: 10.2.1.33
+    - host: web-02.bar.com
+      ip: 10.2.1.34
+    - host: web-03.bar.com
+      ip: 10.2.1.35
+  - name: clientip
+    format: template
+    token: $clientip$
+    type: choice
+    sample: external_ips.sample
+    field: _raw
+    choice:
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 12.130.60.4
+    - 12.130.60.5
+    - 125.17.14.100
+    - 128.241.220.82
+    - 130.253.37.97
+    - 131.178.233.243
+    - 141.146.8.66
+    - 142.162.221.28
+    - 142.233.200.21
+    - 194.215.205.19
+    - 201.122.42.235
+    - 201.28.109.162
+    - 201.3.120.132
+    - 201.42.223.29
+    - 203.92.58.136
+    - 212.235.92.150
+    - 212.27.63.151
+    - 217.132.169.69
+    - 59.162.167.100
+    - 74.125.19.106
+    - 81.11.191.113
+    - 82.245.228.36
+    - 84.34.159.23
+    - 86.212.199.60
+    - 86.9.190.90
+    - 87.194.216.51
+    - 89.167.143.32
+    - 90.205.111.169
+    - 92.1.170.135
+    - 1.16.0.0
+    - 1.19.11.11
+    - 27.1.0.0
+    - 27.1.11.11
+    - 27.35.0.0
+    - 27.35.11.11
+    - 27.96.128.0
+    - 27.96.191.11
+    - 27.101.0.0
+    - 27.101.11.11
+    - 27.102.0.0
+    - 27.102.11.11
+    - 27.160.0.0
+    - 27.175.11.11
+    - 27.176.0.0
+    - 193.33.170.23
+    - 194.146.236.22
+    - 194.8.74.23
+    - 195.216.243.24
+    - 195.69.160.22
+    - 195.69.252.22
+    - 195.80.144.22
+    - 200.6.134.23
+    - 202.164.25.24
+    - 203.223.0.20
+    - 217.197.192.20
+    - 62.216.64.19
+    - 64.66.0.20
+    - 69.80.0.18
+    - 87.240.128.18
+    - 89.11.192.18
+    - 91.199.80.24
+    - 91.205.40.22
+    - 91.208.184.24
+    - 91.214.92.22
+    - 94.229.0.20
+    - 94.229.0.21
+  - name: status
+    format: template
+    token: $status$
+    type: weightedChoice
+    field: _raw
+    weightedChoice:
+    - weight: 10
+      choice: "200"
+    - weight: 4
+      choice: "301"
+    - weight: 3
+      choice: "404"
+    - weight: 2
+      choice: "503"
+  - name: useragent
+    format: template
+    token: $useragent$
+    type: choice
+    sample: useragents.sample
+    field: _raw
+    choice:
+    - Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; Nexus S Build/GRK39F) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPad; U; CPU OS 4_3_1 like Mac OS X; en-us) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8G4 Safari/6533.18.5
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0_1 like Mac OS X; en_US) AppleWebKit
+      (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.3;FBBV/4030.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone
+      OS;FBSV/5.0.1;FBSS/2; FBCR/Pelephone;FBID/phone;FBLC/en_US;FBSF/2.0]
+    - Mozilla/5.0 (Linux; U; Android 2.3.3; nb-no; HTC_DesireHD_A9191 Build/GRI40)
+      AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; MI-ONE Plus Build/GINGERBREAD)
+      AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; DROID BIONIC Build/5.5.1_84_DBN-62_MR-11)
+      AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0_1 like Mac OS X; en_US) AppleWebKit
+      (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.3;FBBV/4030.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone
+      OS;FBSV/5.0.1;FBSS/2; FBCR/vodafoneUK;FBID/phone;FBLC/en_US;FBSF/2.0]
+    - Mozilla/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like
+      Gecko) 1Password/3.6.1/361009 (like Mobile/8C148 Safari/6533.18.5)
+    - Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML,
+      like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3
+    - Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; ADR6400L Build/FRG83D) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like
+      Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; ADR6350 Build/GRJ22) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0_1 like Mac OS X; en_US) AppleWebKit
+      (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone
+      OS;FBSV/5.0.1;FBSS/2; FBCR/AT&T;FBID/phone;FBLC/en_US;FBSF/2.0]
+    - Mozilla/5.0 (Linux; U; Android 2.2.3; en-us; Droid Build/FRK76) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like
+      Gecko) Mobile/9A405
+    - Mozilla/5.0 (iPad; U; CPU OS 4_3_5 like Mac OS X; en-us) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8L1 Safari/6533.18.5
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/528.18
+      (KHTML, like Gecko) Version/4.0 Mobile/7A341 Safari/528.16
+    - BlackBerry9300/5.0.0.955 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/102
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; en-us) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8C148 Safari/6533.18.5
+    - Mozilla/5.0 (Linux; U; Android 3.1; de-de; GT-P7510 Build/HMJ37) AppleWebKit/534.13
+      (KHTML, like Gecko) Version/4.0 Safari/534.13
+    - Mozilla/5.0 (iPad; U; CPU OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8J3 Safari/6533.18.5
+    - Mozilla/5.0 (iPad; U; CPU OS 4_2_1 like Mac OS X; en-us) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8C148 Safari/6533.18.5
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_6 like Mac OS X; en-us) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8E200 Safari/6533.18.5
+    - Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; Nexus One Build/GRK39F) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPad; U; CPU iPhone OS 5_0_1 like Mac OS X; en_US) AppleWebKit
+      (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.3;FBBV/4030.0;FBDV/iPad1,1;FBMD/iPad;FBSN/iPhone
+      OS;FBSV/5.0.1;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]
+    - Mozilla/5.0 (Linux; U; Android 2.3.3; en-ca; SAMSUNG-SGH-I997R Build/GINGERBREAD)
+      AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML,
+      like Gecko) Version/7.0.0.261 Mobile Safari/534.11+
+    - Mozilla/5.0 (iPad; U; CPU OS 4_3_3 like Mac OS X; de-de) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5
+    - Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like
+      Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3
+    - Mozilla/5.0 (iPod; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML,
+      like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; es-es) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5
+    - Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML,
+      like Gecko) Mobile/9A405
+    - Mozilla/5.0 (iPad; U; CPU OS 4_3_3 like Mac OS X; en-gb) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5
+    - Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; HUAWEI-M860 Build/ERE27)
+      AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+    - Mozilla/5.0 (Android; Linux armv7l; rv:8.0) Gecko/20111104 Firefox/8.0 Fennec/8.0
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; DROID3 Build/5.5.1_84_D3G-55) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 3.2.1; en-us; Transformer TF101 Build/HTK75)
+      AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_7 like Mac OS X; en-us) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8E303 Safari/6533.18.5
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18
+      (KHTML, like Gecko) Mobile/7E18
+    - Mozilla/5.0 (BlackBerry; U; BlackBerry 9850; en-US) AppleWebKit/534.11+ (KHTML,
+      like Gecko) Version/7.0.0.374 Mobile Safari/534.11+
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; T-Mobile G2 Build/GRJ22) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; DROIDX Build/4.5.1_57_DX5-35) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; Sprint APA9292KT Build/GRI40) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_10 like Mac OS X; en-us) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8E600 Safari/6533.18.5
+    - Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; LG-MS690 Build/FRG83) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; ADR6300 Build/GRJ22) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Incredible 2 Build/GRI40) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (BlackBerry; U; BlackBerry 9700; en-US) AppleWebKit/534.8+ (KHTML,
+      like Gecko) Version/6.0.0.526 Mobile Safari/534.8+
+    - Mozilla/5.0 (Linux; U; Android 2.3.3; ro-ro; GT-I9000 Build/GINGERBREAD) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18
+      (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16
+    - Mozilla/5.0 (Linux; U; Android 2.2; en-us; Comet Build/FRF91) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; DROID BIONIC 4G Build/5.5.1_84_DBN-55)
+      AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; SPH-M930BST Build/GINGERBREAD)
+      AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - BlackBerry9000/4.6.0.297 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/102
+    - Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; SAMSUNG-SGH-I927 Build/GINGERBREAD)
+      AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML,
+      like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3
+    - Mozilla/5.0 (iPad; U; CPU iPhone OS 5_0_1 like Mac OS X; zh_TW) AppleWebKit
+      (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.3;FBBV/4030.0;FBDV/iPad2,1;FBMD/iPad;FBSN/iPhone
+      OS;FBSV/5.0.1;FBSS/1; FBCR/;FBID/tablet;FBLC/zh_TW;FBSF/1.0]
+    - BlackBerry9650/5.0.0.1006 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/105
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0_1 like Mac OS X; ja_JP) AppleWebKit
+      (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.3;FBBV/4030.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone
+      OS;FBSV/5.0.1;FBSS/2; FBCR/
+    - Mozilla/5.0 (iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10
+      (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10
+    - Mozilla/5.0 (BlackBerry; U; BlackBerry 9300; en-GB) AppleWebKit/534.8+ (KHTML,
+      like Gecko) Version/6.0.0.600 Mobile Safari/534.8+
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Mobile/8J2
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0_1 like Mac OS X; ja_JP) AppleWebKit
+      (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone
+      OS;FBSV/5.0.1;FBSS/2; FBCR/
+    - Mozilla/5.0 (Linux; U; Android 2.3.3; nl-nl; HTC_DesireHD_A9191 Build/GRI40)
+      AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPad; U; CPU OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5
+    - Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10
+      (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; SonyEricssonLT15i Build/4.0.2.A.0.42)
+      AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Sprint APX515CKT Build/GRJ22) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Opera/9.80 (Android; Opera Mini/6.5.27452/26.1235; U; en) Presto/2.8.119 Version/10.54
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; ja-jp; SonyEricssonSO-03C Build/4.0.1.C.1.9)
+      AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; GT-I9100 Build/GRJ22) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en-gb) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8L1 Safari/6533.18.5
+    - Mozilla/5.0 (Linux; U; Android 2.1-update1; en-gb; Milestone Build/SHOLS_U2_02.36.0)
+      AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+    - Mozilla/5.0 (Linux; U; Android 2.2; en-gb; GT-I9000 Build/FROYO) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.5; ja-jp; SC-02C Build/GINGERBREAD) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 2.3.4; ko-kr; HTC_X515E Build/GRJ22) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9
+      (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7 (compatible;
+      Googlebot-Mobile/2.1; +http://www.google.com/bot.html)
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; ja_JP) AppleWebKit
+      (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.3;FBBV/4030.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone
+      OS;FBSV/4.3.3;FBSS/1; FBCR/??????????;FBID/phone;FBLC/ja_JP;FBSF/1.0]
+    - Mozilla/5.0 (Linux; U; Android 2.3.6; en-gb; Nexus One Build/GRK39F) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/528.18
+      (KHTML, like Gecko) Mobile/7E18
+    - Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; GT-I9100 Build/GINGERBREAD) AppleWebKit/533.1
+      (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+    - Mozilla/5.0 (Linux; U; Android 3.2.1; en-us; Xoom Build/HTK75D) AppleWebKit/534.13
+      (KHTML, like Gecko) Version/4.0 Safari/534.13
+    - BlackBerry8520/5.0.0.681 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/120
+    - Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_4 like Mac OS X; fr-fr) AppleWebKit/533.17.9
+      (KHTML, like Gecko) Version/5.0.2 Mobile/8K2 Safari/6533.18.5
+  - name: size
+    format: template
+    token: $size$
+    type: random
+    replacement: int
+    field: _raw
+    lower: 200
+    upper: 4000
+  lines:
+  - _raw: $clientip$ - - [$ts$] "GET /product.screen?product_id=HolyGouda&JSESSIONID=SD3SL1FF7ADFF8
+      HTTP/1.1" $status$ $size$ "http://shop.buttercupgames.com/cart.do?action=view&itemId=HolyGouda"
+      "$useragent$"
+    host: $host$
+    index: main
+    source: /var/log/httpd/access_log
+    sourcetype: access_combined
+  field: _raw
+  singlepass: true
+mix: []


### PR DESCRIPTION
Changed the hostname filter for custom configs to be case-insensitive
since that's how they are in DNS and elsewhere. We checked and username
are not case-insensitive so leaving that filter as is.

Closes #579