### PR TITLE
Add a user config option to scope

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -32,7 +32,7 @@ debug:
 	$(MAKE) scope BUILD_OPTS="-gcflags=all=\"-N -l\""
 
 ## all: build and compress \`scope\`
-all: scope compressscope
+all: scope #compressscope
 
 ## clean: remove the built binary
 clean:

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -32,7 +32,7 @@ debug:
 	$(MAKE) scope BUILD_OPTS="-gcflags=all=\"-N -l\""
 
 ## all: build and compress \`scope\`
-all: scope #compressscope
+all: scope compressscope
 
 ## clean: remove the built binary
 clean:

--- a/cli/cmd/dash.go
+++ b/cli/cmd/dash.go
@@ -63,10 +63,11 @@ func init() {
 
 func readMetrics(workDir string, w *widgets) {
 	metricsPath := filepath.Join(workDir, "metrics.json")
+	metricsDestPath := filepath.Join(workDir, "metric_dest")
 	file, err := os.Open(metricsPath)
 	if err != nil && strings.Contains(err.Error(), "metrics.json: no such file or directory") {
-		if util.CheckFileExists(metricsPath) {
-			dest, _ := ioutil.ReadFile(metricsPath)
+		if util.CheckFileExists(metricsDestPath) {
+			dest, _ := ioutil.ReadFile(metricsDestPath)
 			fmt.Printf("Cannot run dash: Metrics were output to %s\n", dest)
 			os.Exit(0)
 		}
@@ -175,8 +176,18 @@ func readMetrics(workDir string, w *widgets) {
 
 func readEvents(workDir string, w *widgets) {
 	eventsPath := filepath.Join(workDir, "events.json")
+	eventsDestPath := filepath.Join(workDir, "event_dest")
 	file, err := os.Open(eventsPath)
-	util.CheckErrSprintf(err, "%v", err)
+	if err != nil && strings.Contains(err.Error(), "events.json: no such file or directory") {
+		if util.CheckFileExists(eventsDestPath) {
+			dest, _ := ioutil.ReadFile(eventsDestPath)
+			fmt.Printf("Cannot run dash: Events were output to %s\n", dest)
+			os.Exit(0)
+		}
+	} else {
+		util.CheckErrSprintf(err, "error opening events file: %v", err)
+	}
+
 	tr := util.NewTailReader(file)
 	in := make(chan map[string]interface{})
 	eventCount, _ := util.CountLines(eventsPath)

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -57,5 +57,6 @@ func runCmdFlags(cmd *cobra.Command, rc *run.Config) {
 	cmd.Flags().BoolVarP(&rc.Payloads, "payloads", "p", false, "Capture payloads of network transactions")
 	cmd.Flags().StringVar(&rc.Loglevel, "loglevel", "", "Set ldscope log level (debug, warning, info, error, none)")
 	cmd.Flags().StringVarP(&rc.LibraryPath, "librarypath", "l", "", "Set path for dynamic libraries")
+	cmd.Flags().StringVarP(&rc.UserConfig, "userconfig", "u", "", "Run ldscope with a user specified config file.")
 	metricAndEventDestFlags(cmd, rc)
 }

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -57,6 +57,6 @@ func runCmdFlags(cmd *cobra.Command, rc *run.Config) {
 	cmd.Flags().BoolVarP(&rc.Payloads, "payloads", "p", false, "Capture payloads of network transactions")
 	cmd.Flags().StringVar(&rc.Loglevel, "loglevel", "", "Set ldscope log level (debug, warning, info, error, none)")
 	cmd.Flags().StringVarP(&rc.LibraryPath, "librarypath", "l", "", "Set path for dynamic libraries")
-	cmd.Flags().StringVarP(&rc.UserConfig, "userconfig", "u", "", "Run ldscope with a user specified config file.")
+	cmd.Flags().StringVarP(&rc.UserConfig, "userconfig", "u", "", "Run ldscope with a user specified config file. Overrides all other settings.")
 	metricAndEventDestFlags(cmd, rc)
 }

--- a/cli/history/sessions.go
+++ b/cli/history/sessions.go
@@ -54,7 +54,6 @@ func GetSessions() (ret SessionList) {
 		id, _ := strconv.Atoi(vals[2])
 		pid, _ := strconv.Atoi(vals[3])
 		ts, _ := strconv.ParseInt(vals[4], 10, 64)
-
 		workDir := filepath.Join(histDir, f.Name())
 
 		ret = append(ret, Session{

--- a/cli/run/run.go
+++ b/cli/run/run.go
@@ -26,6 +26,7 @@ type Config struct {
 	LibraryPath   string
 	NoBreaker     bool
 	AuthToken     string
+	UserConfig    string
 
 	now func() time.Time
 	sc  *ScopeConfig

--- a/cli/run/run_test.go
+++ b/cli/run/run_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 	case "createWorkDir":
 		internal.InitConfig()
 		rc := Config{}
-		rc.createWorkDir("foo", false)
+		rc.createWorkDir([]string{"foo"}, false)
 	case "run":
 		internal.InitConfig()
 		rc := Config{}

--- a/cli/run/scopeconfig.go
+++ b/cli/run/scopeconfig.go
@@ -191,15 +191,15 @@ func (c *Config) SetDefault() error {
 // configFromFile loads a configuration from a yml file
 func (c *Config) configFromFile() error {
 	c.sc = &ScopeConfig{}
-	/*
-		yamlFile, err := ioutil.ReadFile(c.UserConfig)
-		if err != nil {
-			return err
-		}
-		if err = yaml.Unmarshal(yamlFile, c.sc); err != nil {
-				return err
-			}
-	*/
+
+	yamlFile, err := ioutil.ReadFile(c.UserConfig)
+	if err != nil {
+		return err
+	}
+	if err = yaml.Unmarshal(yamlFile, c.sc); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/cli/run/scopeconfig.go
+++ b/cli/run/scopeconfig.go
@@ -188,7 +188,22 @@ func (c *Config) SetDefault() error {
 	return nil
 }
 
-// configFromRunOpts writes the scope configuration to the workdir
+// configFromFile loads a configuration from a yml file
+func (c *Config) configFromFile() error {
+	c.sc = &ScopeConfig{}
+	/*
+		yamlFile, err := ioutil.ReadFile(c.UserConfig)
+		if err != nil {
+			return err
+		}
+		if err = yaml.Unmarshal(yamlFile, c.sc); err != nil {
+				return err
+			}
+	*/
+	return nil
+}
+
+// configFromRunOpts creates a configuration from run options
 func (c *Config) configFromRunOpts() error {
 	err := c.SetDefault()
 	if err != nil {

--- a/cli/run/scopeconfig.go
+++ b/cli/run/scopeconfig.go
@@ -188,8 +188,8 @@ func (c *Config) SetDefault() error {
 	return nil
 }
 
-// configFromFile loads a configuration from a yml file
-func (c *Config) configFromFile() error {
+// ConfigFromFile loads a configuration from a yml file
+func (c *Config) ConfigFromFile() error {
 	c.sc = &ScopeConfig{}
 
 	yamlFile, err := ioutil.ReadFile(c.UserConfig)

--- a/cli/run/setup.go
+++ b/cli/run/setup.go
@@ -154,7 +154,7 @@ func (rc *Config) createWorkDir(cmd string, attach bool) {
 	internal.CreateLogFile(filepath.Join(rc.WorkDir, "scope.log"), filePerms)
 
 	// Metrics file
-	if rc.MetricsDest != "" || rc.CriblDest != "" {
+	if rc.UserConfig == "" && (rc.MetricsDest != "" || rc.CriblDest != "") {
 		metricsDest := rc.MetricsDest
 		if metricsDest == "" {
 			metricsDest = rc.CriblDest
@@ -162,13 +162,13 @@ func (rc *Config) createWorkDir(cmd string, attach bool) {
 		err = ioutil.WriteFile(filepath.Join(rc.WorkDir, "metric_dest"), []byte(metricsDest), filePerms)
 		util.CheckErrSprintf(err, "error writing metric_dest: %v", err)
 	}
-	if rc.MetricsFormat != "" {
+	if rc.UserConfig == "" && rc.MetricsFormat != "" {
 		err = ioutil.WriteFile(filepath.Join(rc.WorkDir, "metric_format"), []byte(rc.MetricsFormat), filePerms)
 		util.CheckErrSprintf(err, "error writing metric_format: %v", err)
 	}
 
 	// Events file
-	if rc.EventsDest != "" || rc.CriblDest != "" {
+	if rc.UserConfig == "" && (rc.EventsDest != "" || rc.CriblDest != "") {
 		eventsDest := rc.EventsDest
 		if eventsDest == "" {
 			eventsDest = rc.CriblDest

--- a/cli/run/setup.go
+++ b/cli/run/setup.go
@@ -83,7 +83,7 @@ func CreateAll(path string) error {
 }
 
 // createWorkDir creates a working directory
-func (rc *Config) createWorkDir(cmd string, attach bool) {
+func (rc *Config) createWorkDir(args []string, attach bool) {
 	filePerms := os.FileMode(0644)
 	dirPerms := os.FileMode(0755)
 	if attach {
@@ -106,9 +106,9 @@ func (rc *Config) createWorkDir(cmd string, attach bool) {
 	ts := strconv.FormatInt(rc.now().UTC().UnixNano(), 10)
 	pid := strconv.Itoa(os.Getpid())
 	sessionID := getSessionID()
-	tmpDirName := path.Base(cmd) + "_" + sessionID + "_" + pid + "_" + ts
+	tmpDirName := path.Base(args[0]) + "_" + sessionID + "_" + pid + "_" + ts
 
-	// History directory
+	// Create History directory
 	histDir := HistoryDir()
 	err := os.MkdirAll(histDir, 0755)
 	util.CheckErrSprintf(err, "error creating history dir: %v", err)
@@ -118,7 +118,7 @@ func (rc *Config) createWorkDir(cmd string, attach bool) {
 		fmt.Printf("WARNING: Session history will be stored in %s and owned by root\n", histDir)
 	}
 
-	// Working directory
+	// Create Working directory
 	if attach {
 		// Validate /tmp exists
 		if !util.CheckDirExists("/tmp") {
@@ -140,28 +140,44 @@ func (rc *Config) createWorkDir(cmd string, attach bool) {
 		util.CheckErrSprintf(err, "error creating workdir dir: %v", err)
 	}
 
-	// Cmd directory
+	// Create Cmd directory
 	cmdDir := filepath.Join(rc.WorkDir, "cmd")
 	err = os.Mkdir(cmdDir, dirPerms)
 	util.CheckErrSprintf(err, "error creating cmd dir: %v", err)
 
-	// Payloads directory
+	// Create Payloads directory
 	payloadsDir := filepath.Join(rc.WorkDir, "payloads")
 	err = os.MkdirAll(payloadsDir, dirPerms)
 	util.CheckErrSprintf(err, "error creating payloads dir: %v", err)
 
-	// Log file
+	// Create Log file
 	internal.CreateLogFile(filepath.Join(rc.WorkDir, "scope.log"), filePerms)
 
-	// Create metrics_dest file
-	if rc.MetricsDest != "" || rc.CriblDest != "" {
-		metricsDest := rc.MetricsDest
-		if metricsDest == "" {
-			metricsDest = rc.CriblDest
+	// Create Metrics file
+	if rc.sc.Metric.Transport.TransportType == "file" {
+		f, err := os.OpenFile(rc.sc.Metric.Transport.Path, os.O_CREATE, filePerms)
+		if err != nil && !os.IsExist(err) {
+			util.ErrAndExit("cannot create metric file %s: %v", rc.sc.Metric.Transport.Path, err)
 		}
-		err = ioutil.WriteFile(filepath.Join(rc.WorkDir, "metric_dest"), []byte(metricsDest), filePerms)
-		util.CheckErrSprintf(err, "error writing metric_dest: %v", err)
+		f.Close()
 	}
+
+	// Create Events file
+	if rc.sc.Event.Transport.TransportType == "file" {
+		f, err := os.OpenFile(rc.sc.Event.Transport.Path, os.O_CREATE, filePerms)
+		if err != nil && !os.IsExist(err) {
+			util.ErrAndExit("cannot create metric file %s: %v", rc.sc.Event.Transport.Path, err)
+		}
+		f.Close()
+	}
+
+	// Create event_dest file
+	err = ioutil.WriteFile(filepath.Join(rc.WorkDir, "event_dest"), []byte(rc.buildEventsDest()), filePerms)
+	util.CheckErrSprintf(err, "error writing event_dest: %v", err)
+
+	// Create metrics_dest file
+	err = ioutil.WriteFile(filepath.Join(rc.WorkDir, "metric_dest"), []byte(rc.buildMetricsDest()), filePerms)
+	util.CheckErrSprintf(err, "error writing metric_dest: %v", err)
 
 	// Create metrics_format file
 	if rc.MetricsFormat != "" {
@@ -169,15 +185,26 @@ func (rc *Config) createWorkDir(cmd string, attach bool) {
 		util.CheckErrSprintf(err, "error writing metric_format: %v", err)
 	}
 
-	// Create event_dest file
-	if rc.EventsDest != "" || rc.CriblDest != "" {
-		eventsDest := rc.EventsDest
-		if eventsDest == "" {
-			eventsDest = rc.CriblDest
+	// Create config file
+	scYamlPath := filepath.Join(rc.WorkDir, "scope.yml")
+	if rc.UserConfig == "" {
+		err := rc.WriteScopeConfig(scYamlPath, filePerms)
+		util.CheckErrSprintf(err, "%v", err)
+	} else {
+		input, err := ioutil.ReadFile(rc.UserConfig)
+		if err != nil {
+			util.ErrAndExit("cannot read file %s: %v", rc.UserConfig, err)
 		}
-		err = ioutil.WriteFile(filepath.Join(rc.WorkDir, "event_dest"), []byte(eventsDest), filePerms)
-		util.CheckErrSprintf(err, "error writing event_dest: %v", err)
+		if err = ioutil.WriteFile(scYamlPath, input, 0644); err != nil {
+			util.ErrAndExit("failed to write file to %s: %v", scYamlPath, err)
+		}
 	}
+
+	// Create args.json file
+	argsJSONPath := filepath.Join(rc.WorkDir, "args.json")
+	argsBytes, err := json.Marshal(args)
+	util.CheckErrSprintf(err, "error marshaling JSON: %v", err)
+	err = ioutil.WriteFile(argsJSONPath, argsBytes, filePerms)
 
 	log.Info().Str("workDir", rc.WorkDir).Msg("created working directory")
 }
@@ -206,14 +233,13 @@ func HistoryDir() string {
 
 // setupWorkDir sets up a working directory for a given set of args
 func (rc *Config) setupWorkDir(args []string, attach bool) {
-	filePerms := os.FileMode(0644)
-	if attach {
-		filePerms = 0777
-		oldmask := syscall.Umask(0)
-		defer syscall.Umask(oldmask)
-	}
 
 	if rc.UserConfig == "" {
+		// Override to CriblDest if specified
+		if rc.CriblDest != "" {
+			rc.EventsDest = rc.CriblDest
+			rc.MetricsDest = rc.CriblDest
+		}
 		err := rc.configFromRunOpts()
 		util.CheckErrSprintf(err, "%v", err)
 	} else {
@@ -221,49 +247,53 @@ func (rc *Config) setupWorkDir(args []string, attach bool) {
 		util.CheckErrSprintf(err, "%v", err)
 	}
 
+	// Update paths to absolute for file transports
 	if rc.sc.Metric.Transport.TransportType == "file" {
 		newPath, err := filepath.Abs(rc.sc.Metric.Transport.Path)
 		util.CheckErrSprintf(err, "error getting absolute path for %s: %v", rc.sc.Metric.Transport.Path, err)
 		rc.sc.Metric.Transport.Path = newPath
-		rc.MetricsDest = newPath
-		f, err := os.OpenFile(rc.sc.Metric.Transport.Path, os.O_CREATE, filePerms)
-		if err != nil && !os.IsExist(err) {
-			util.ErrAndExit("cannot create metric file %s: %v", rc.sc.Metric.Transport.Path, err)
-		}
-		f.Close()
 	}
-
 	if rc.sc.Event.Transport.TransportType == "file" {
 		newPath, err := filepath.Abs(rc.sc.Event.Transport.Path)
 		util.CheckErrSprintf(err, "error getting absolute path for %s: %v", rc.sc.Event.Transport.Path, err)
 		rc.sc.Event.Transport.Path = newPath
-		rc.EventsDest = newPath
-		f, err := os.OpenFile(rc.sc.Event.Transport.Path, os.O_CREATE, filePerms)
-		if err != nil && !os.IsExist(err) {
-			util.ErrAndExit("cannot create metric file %s: %v", rc.sc.Event.Transport.Path, err)
-		}
-		f.Close()
 	}
 
-	cmd := path.Base(args[0])
-	rc.createWorkDir(cmd, attach)
+	rc.createWorkDir(args, attach)
+}
 
-	scYamlPath := filepath.Join(rc.WorkDir, "scope.yml")
-	if rc.UserConfig == "" {
-		err := rc.WriteScopeConfig(scYamlPath, filePerms)
-		util.CheckErrSprintf(err, "%v", err)
+func (rc *Config) buildMetricsDest() string {
+	var dest string
+	if rc.sc.Cribl.Enable == true {
+		if rc.sc.Cribl.Transport.TransportType == "unix" || rc.sc.Cribl.Transport.TransportType == "file" {
+			dest = rc.sc.Cribl.Transport.TransportType + "://" + rc.sc.Cribl.Transport.Path
+		} else {
+			dest = rc.sc.Cribl.Transport.TransportType + "://" + rc.sc.Cribl.Transport.Host + ":" + fmt.Sprint(rc.sc.Cribl.Transport.Port)
+		}
 	} else {
-		input, err := ioutil.ReadFile(rc.UserConfig)
-		if err != nil {
-			util.ErrAndExit("cannot read file %s: %v", rc.UserConfig, err)
-		}
-		if err = ioutil.WriteFile(scYamlPath, input, 0644); err != nil {
-			util.ErrAndExit("failed to write file to %s: %v", scYamlPath, err)
+		if rc.sc.Metric.Transport.TransportType == "unix" || rc.sc.Metric.Transport.TransportType == "file" {
+			dest = rc.sc.Metric.Transport.TransportType + "://" + rc.sc.Metric.Transport.Path
+		} else {
+			dest = rc.sc.Metric.Transport.TransportType + "://" + rc.sc.Metric.Transport.Host + ":" + fmt.Sprint(rc.sc.Metric.Transport.Port)
 		}
 	}
+	return dest
+}
 
-	argsJSONPath := filepath.Join(rc.WorkDir, "args.json")
-	argsBytes, err := json.Marshal(args)
-	util.CheckErrSprintf(err, "error marshaling JSON: %v", err)
-	err = ioutil.WriteFile(argsJSONPath, argsBytes, filePerms)
+func (rc *Config) buildEventsDest() string {
+	var dest string
+	if rc.sc.Cribl.Enable == true {
+		if rc.sc.Cribl.Transport.TransportType == "unix" || rc.sc.Cribl.Transport.TransportType == "file" {
+			dest = rc.sc.Cribl.Transport.TransportType + "://" + rc.sc.Cribl.Transport.Path
+		} else {
+			dest = rc.sc.Cribl.Transport.TransportType + "://" + rc.sc.Cribl.Transport.Host + ":" + fmt.Sprint(rc.sc.Cribl.Transport.Port)
+		}
+	} else {
+		if rc.sc.Event.Transport.TransportType == "unix" || rc.sc.Event.Transport.TransportType == "file" {
+			dest = rc.sc.Event.Transport.TransportType + "://" + rc.sc.Event.Transport.Path
+		} else {
+			dest = rc.sc.Event.Transport.TransportType + "://" + rc.sc.Event.Transport.Host + ":" + fmt.Sprint(rc.sc.Event.Transport.Port)
+		}
+	}
+	return dest
 }

--- a/cli/util/proc_test.go
+++ b/cli/util/proc_test.go
@@ -34,12 +34,12 @@ func TestProcessesByName(t *testing.T) {
 // - The expected user value is returned
 func TestPidUser(t *testing.T) {
 	/*
-	 * Disabled since we run as "builder" for `make docker-build`.
-	 * 
-	// Process 1 owner
-	pid := 1
-	result := PidUser(pid)
-	assert.Equal(t, "root", result)
+		 * Disabled since we run as "builder" for `make docker-build`.
+		 *
+		// Process 1 owner
+		pid := 1
+		result := PidUser(pid)
+		assert.Equal(t, "root", result)
 	*/
 
 	// Current process owner


### PR DESCRIPTION
This PR provides the user with the option to configure scope with a file, like so:

`scope run -u ~/scope.yml -- top`
`scope run --userconfig ~/scope.yml -- top`

Scope will create a session directory for the session, and the config file will be copied to that directory.

**Design Decision 1**
This config file is parsed at some point, in order to validate _some of_ the contents ; and to create metric and event files in the right places (explained later), but the config file is copied to the session directory directly using file io from the user specified file. By design, there is no intervention by scope. The config you pass scope is the config that will be loaded by ldscope.

**Design Decision 2**
All runtime options that modify the config will be ignored, essentially overridden by the contents of this config file. For example, if you were to execute `scope run -u ~/scope.yml -c 127.0.0.1:9000 -- top`, the -c argument would be ignored.

**Design Decision 3**
The file you pass into `-u` can have any name. When it is copied to the session directory, it is always renamed to `scope.yml`. This allows the user to have more than one yml configuration file locally. This decision also allows for less validation being required.

**Discovered Work**
After running a `-u` command, the user might want to run follow-up scope commands that utilize historical session data, these being `scope flows`, `scope dash`, `scope metrics`, `scope events`.

Initially, after the work was done to copy the config, some of these commands could fail with a "corrupt session" error or a seg fault. They would expect metrics/events data to exist in the sessions directory, or `_dest` files to exist (When a remote file/network destination is specified with `-e`, `-m`, or `-c` on the command line, the application creates files `event_dest`, `metric_dest`, `metric_format` files in the session directory specifying the location/format of those remote destinations).

When follow-up commands `scope flows`, `scope dash`, `scope metrics`, `scope events` are issued, metrics and events files aren't available in the session directory, so those commands report a clean message to the user stating that those commands cannot be run because it knows from the `_dest` files that the data was sent elsewhere.

When a remote file/network destination is specified in a user config file, I realized that I needed to create those three files.
I needed to also observe the override of a cribl destination if enabled in config, over event and metric destinations, in line with scope's original convention when using command line destination arguments.

This led me to...

**Design Decision 4**
I decided to always output `metrics_dest`, `metrics_format`, `events_dest` regardless of the destination. For consistency's sake; and to allow the `scope flows`, `scope dash`, `scope metrics`, and `scope events` commands to know where the data went, when configured by a file.

**Design Decision 5**
I added string builders "buildEventsDest()" and "buildMetricsDest()" to take transport information from the default config or from our configuration file, and build a path like "unix://path/to/file" or "tcp://some.network:0000". These paths are used in the `_dest` files, maintaining a consistent format.

**Design Decision 6**
I improved error messaging in `scope flows` and `scope dash` commands by informing the user where the data went.

Closes #572 