### PR TITLE
Use operating system compiler Macros

### DIFF
--- a/os/linux/Makefile
+++ b/os/linux/Makefile
@@ -3,9 +3,9 @@
 CWD = $(shell pwd)
 OS=linux
 CC=gcc
-CFLAGS=-fPIC -g -Wall -Wno-nonnull -Wno-deprecated-declarations -D__LINUX__
+CFLAGS=-fPIC -g -Wall -Wno-nonnull -Wno-deprecated-declarations
 SCOPE_VER:="$(shell git --no-pager describe --abbrev=12 --dirty=+ --always --tags)"
-TEST_CFLAGS=-g -Wall -Wno-nonnull -O0 -coverage -D__LINUX__
+TEST_CFLAGS=-g -Wall -Wno-nonnull -O0 -coverage
 TEST_CFLAGS+=-DSCOPE_VER=\"$(SCOPE_VER)\"
 YAML_DEFINES=-DYAML_VERSION_MAJOR="0" -DYAML_VERSION_MINOR="2" -DYAML_VERSION_PATCH="2" -DYAML_VERSION_STRING="\"0.2.2\""
 CJSON_DEFINES=-DENABLE_LOCALES
@@ -42,7 +42,7 @@ $(PCRE2_AR):
 
 $(LDSCOPEDYN): src/fn.c os/$(OS)/os.c src/dbg.c src/scopeelf.c src/scope.c src/utils.c src/inject.c
 	@echo "$${CI:+::group::}Building $@"
-	gcc -Wall -g -D__LINUX__ $(ARCH_CFLAGS) $(DISTRO_FLAGS) \
+	gcc -Wall -g $(ARCH_CFLAGS) $(DISTRO_FLAGS) \
 		-DSCOPE_VER=\"$(SCOPE_VER)\" \
 		src/fn.c os/$(OS)/os.c src/dbg.c src/scopeelf.c src/scope.c src/utils.c src/inject.c \
 		-ldl -lrt -o $@ -I./os/$(OS) $(INCLUDES)
@@ -56,7 +56,7 @@ $(LDSCOPE): src/scope_static.c src/libdir.c $(LDSCOPEDYN) $(LIBSCOPE)
 	cd $(dir $(LIBSCOPE)) && objcopy \
 		-I binary -O $(ARCH_BINARY) -B $(ARCH_OBJ) \
 		$(notdir $(LIBSCOPE)) $(notdir $(LIBSCOPE:.so=.o))
-	gcc -Wall -static -g -D__LINUX__ $(ARCH_CFLAGS) $(DISTRO_FLAGS) \
+	gcc -Wall -static -g $(ARCH_CFLAGS) $(DISTRO_FLAGS) \
 		-DSCOPE_VER=\"$(SCOPE_VER)\" \
 		src/scope_static.c src/libdir.c \
 		$(INCLUDES) \

--- a/os/macOS/Makefile
+++ b/os/macOS/Makefile
@@ -1,10 +1,9 @@
 OS=macOS
 CC=gcc
-CFLAGS=-fPIC -g -Wall -Wno-nonnull -D__MACOS__
+CFLAGS=-fPIC -g -Wall -Wno-nonnull
 SCOPE_VER:="$(shell git --no-pager describe --abbrev=12 --dirty=+ --always --tags)"
-TEST_CFLAGS=-g -Wall -Wno-nonnull -O0 -coverage -D__MACOS__
+TEST_CFLAGS=-g -Wall -Wno-nonnull -O0 -coverage
 TEST_CFLAGS+=-DSCOPE_VER=\"$(SCOPE_VER)\"
-TEST_CFLAGS +=-D__MACOS__
 LD_FLAGS=$(PCRE2_AR) -Wl, -ldl -lpthread -lresolv
 INCLUDES=-I./contrib/libyaml/include -I./contrib/cJSON -I./os/$(OS) -I./contrib/pcre2/src -I./contrib/pcre2/build -I./contrib/funchook/distorm/include
 YAML_DEFINES=-DYAML_VERSION_MAJOR="0" -DYAML_VERSION_MINOR="2" -DYAML_VERSION_PATCH="2" -DYAML_VERSION_STRING="\"0.2.2\""

--- a/src/dns.h
+++ b/src/dns.h
@@ -79,10 +79,10 @@ typedef struct dns_query_t {
     unsigned char name[];
 } dns_query;
 
-#ifdef __LINUX__
+#ifdef __linux__
 struct response {
     HEADER hdr;
     u_char buf[NS_PACKETSZ];      /* defined in arpa/nameser.h */
 };
-#endif // __LINUX__
+#endif // __linux__
 #endif // _DNS_H_

--- a/src/evtformat.c
+++ b/src/evtformat.c
@@ -17,7 +17,7 @@
 // This voodoo avoids creating binaries which would require a glibc
 // that's 2.31 or newer, even if built on new ubuntu 20.04.
 // This is tested by test/glibcvertest.c.
-//#ifdef __LINUX__
+//#ifdef __linux__
 //__asm__(".symver clock_gettime,clock_gettime@GLIBC_2.2.5");
 //#endif
 

--- a/src/fn.h
+++ b/src/fn.h
@@ -4,14 +4,14 @@
 #include <wchar.h>
 #include <sys/statvfs.h>
 #include <netdb.h>
-#ifdef __LINUX__
+#ifdef __linux__
 #include <sys/epoll.h>
 #include <poll.h>
 #include <sys/vfs.h>
 #include <linux/aio_abi.h>
 #include <sys/ipc.h>
 #include <sys/sem.h>
-#endif // __LINUX__
+#endif // __linux__
 #include <signal.h>
 #include "../contrib/tls/tls.h"
 #include <stdarg.h>
@@ -20,13 +20,13 @@
 #include <unistd.h>
 #include <arpa/nameser.h>
 
-#ifdef __LINUX__
+#ifdef __linux__
 #ifndef io_context_t
 #define io_context_t unsigned long
 #endif
 #endif
 
-#ifdef __MACOS__
+#ifdef __APPLE__
 #include <sys/mount.h>
 
 #ifndef off64_t
@@ -39,7 +39,7 @@ typedef uint64_t fpos64_t;
 #ifndef nfds_t
 typedef unsigned int nfds_t;
 #endif
-#endif // __MACOS__
+#endif // __APPLE__
 
 
 typedef struct {
@@ -204,7 +204,7 @@ typedef struct {
     void *(*__memcpy_chk)(void *, const void *, size_t, size_t);
     int (*__sprintf_chk)(char *, int, size_t, const char *, ...);
     long int (*__fdelt_chk)(long int);
-#ifdef __LINUX__
+#ifdef __linux__
     // Couldn't easily get struct definitions for these on mac
     int (*statvfs64)(const char *, struct statvfs64 *);
     int (*fstatvfs64)(int, struct statvfs64 *);
@@ -233,13 +233,13 @@ typedef struct {
     int (*getentropy)(void *, size_t);
     void (*__ctype_init)(void);
     int (*__register_atfork)(void (*) (void), void (*) (void), void (*) (void), void *);
-#endif // __LINUX__
+#endif // __linux__
 
-#if defined(__LINUX__) && defined(__STATX__)
+#if defined(__linux__) && defined(__STATX__)
     int (*statx)(int, const char *, int, unsigned int, struct statx *);
-#endif // __LINUX__ && __STATX__
+#endif // __linux__ && __STATX__
 
-#ifdef __MACOS__
+#ifdef __APPLE__
     int (*accept$NOCANCEL)(int, struct sockaddr *, socklen_t *);
     int (*close$NOCANCEL)(int);
     int (*close_nocancel)(int);
@@ -248,7 +248,7 @@ typedef struct {
                                  const struct sockaddr *, socklen_t);
     int32_t (*DNSServiceQueryRecord)(void *, uint32_t, uint32_t, const char *,
                                       uint16_t, uint16_t, void *, void *);
-#endif // __MACOS__
+#endif // __APPLE__
 
     // These functions are not interposed.  They're here because
     // we've seen applications override the weak glibc implementation,

--- a/src/scopeelf.h
+++ b/src/scopeelf.h
@@ -1,7 +1,7 @@
 #ifndef __SCOPEELF_H__
 #define __SCOPEELF_H__
 
-#ifdef __LINUX__
+#ifdef __linux__
 
 #include <elf.h>
 #include <link.h>
@@ -32,6 +32,6 @@ bool is_static(char *);
 bool is_go(char *);
 bool is_musl(char *);
 
-#endif // __LINUX__
+#endif // __linux__
 
 #endif // __SCOPEELF_H__

--- a/src/state.c
+++ b/src/state.c
@@ -1347,11 +1347,11 @@ addSock(int fd, int type, int family)
         g_netinfo[fd].type = type;
         g_netinfo[fd].localConn.ss_family = family;
         g_netinfo[fd].uid = getTime();
-#ifdef __LINUX__
+#ifdef __linux__
         // Clear these bits so comparisons of type will work
         g_netinfo[fd].type &= ~SOCK_CLOEXEC;
         g_netinfo[fd].type &= ~SOCK_NONBLOCK;
-#endif // __LINUX__
+#endif // __linux__
     }
 }
 
@@ -2103,7 +2103,7 @@ doSeek(int fd, int success, const char *func)
     }
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 void
 doStatPath(const char *path, int rc, const char *func)
 {
@@ -2131,7 +2131,7 @@ doStatFd(int fd, int rc, const char* func)
         }
     }
 }
-#endif // __LINUX__
+#endif // __linux__
 
 int
 doDupFile(int oldfd, int newfd, const char *func)

--- a/src/state.h
+++ b/src/state.h
@@ -9,11 +9,11 @@
 #include "report.h"
 #include "../contrib/tls/tls.h"
 
-#ifdef __MACOS__
+#ifdef __APPLE__
 #ifndef AF_NETLINK
 #define AF_NETLINK 16
 #endif
-#endif // __MACOS__
+#endif // __APPLE__
 
 
 /**

--- a/src/transport.c
+++ b/src/transport.c
@@ -1151,7 +1151,7 @@ tcpSendPlain(transport_t *trans, const char *msg, size_t len)
     if (!trans || transportNeedsConnection(trans)) return -1;
 
     int flags = 0;
-#ifdef __LINUX__
+#ifdef __linux__
     flags |= MSG_NOSIGNAL;
 #endif
 
@@ -1275,7 +1275,7 @@ transportSend(transport_t *trans, const char *msg, size_t len)
         case CFG_UNIX:
             if (trans->local.sock != -1) {
                 int flags = 0;
-#ifdef __LINUX__
+#ifdef __linux__
                 flags |= MSG_NOSIGNAL;
 #endif
                 int rc = g_fn.send(trans->local.sock, msg, len, flags);

--- a/src/utils.c
+++ b/src/utils.c
@@ -80,7 +80,7 @@ setPidEnv(int pid)
     }
 }
 
-#ifdef __MACOS__
+#ifdef __APPLE__
 char *
 getpath(const char *cmd)
 {
@@ -172,7 +172,7 @@ out:
     if (path_env) free(path_env);
     return ret_val;
 }
-#endif //__MACOS__
+#endif //__APPLE__
 
 
 int

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -5,7 +5,7 @@
 #include <pthread.h>
 #include <sys/poll.h>
 
-#ifdef __LINUX__
+#ifdef __linux__
 #include <sys/prctl.h>
 #ifdef __GO__
 #include <asm/prctl.h>
@@ -64,7 +64,7 @@ static void *periodic(void *);
 static void doConfig(config_t *);
 static void threadNow(int);
 
-#ifdef __LINUX__
+#ifdef __linux__
 extern int arch_prctl(int, unsigned long);
 extern unsigned long scope_fs;
 
@@ -346,7 +346,7 @@ findSymbol(struct dl_phdr_info *info, size_t size, void *data)
     retval;                                                            \
 })
 
-#endif // __LINUX__
+#endif // __linux__
 
 
 static void
@@ -1628,7 +1628,7 @@ freopen(const char *pathname, const char *mode, FILE *orig_stream)
     return stream;
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 EXPORTON int
 nanosleep(const struct timespec *req, struct timespec *rem)
 {
@@ -3331,7 +3331,7 @@ _exit(int status)
     __builtin_unreachable();
 }
 
-#endif // __LINUX__
+#endif // __linux__
 
 EXPORTON int
 close(int fd)
@@ -3377,7 +3377,7 @@ fcloseall(void)
     return rc;
 }
 
-#ifdef __MACOS__
+#ifdef __APPLE__
 EXPORTON int
 close$NOCANCEL(int fd)
 {
@@ -3486,7 +3486,7 @@ DNSServiceQueryRecord(void *sdRef, uint32_t flags, uint32_t interfaceIndex,
     return rc;
 }
 
-#endif // __MACOS__
+#endif // __APPLE__
 
 EXPORTON off_t
 lseek(int fd, off_t offset, int whence)
@@ -4369,7 +4369,7 @@ sendmsg(int sockfd, const struct msghdr *msg, int flags)
     return rc;
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 static int
 internal_sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags)
 {
@@ -4410,7 +4410,7 @@ sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags)
 {
     return internal_sendmmsg(sockfd, msgvec, vlen, flags);
 }
-#endif // __LINUX__
+#endif // __linux__
 
 EXPORTON ssize_t
 recv(int sockfd, void *buf, size_t len, int flags)
@@ -4538,7 +4538,7 @@ recvmsg(int sockfd, struct msghdr *msg, int flags)
     return rc;
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 EXPORTON int
 recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
          int flags, struct timespec *timeout)
@@ -4573,7 +4573,7 @@ recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
 
     return rc;
 }
-#endif //__LINUX__
+#endif //__linux__
 
 EXPORTOFF struct hostent *
 gethostbyname(const char *name)

--- a/test/ctltest.c
+++ b/test/ctltest.c
@@ -36,13 +36,13 @@ void set_cbuf_data(char* val, unsigned long long new_size)
 }
 
 // These signatures satisfy --wrap=cbufGet in the Makefile
-#ifdef __LINUX__
+#ifdef __linux__
 int __real_cbufGet(cbuf_handle_t, uint64_t*);
 int __wrap_cbufGet(cbuf_handle_t cbuf, uint64_t *data)
-#endif // __LINUX__
-#ifdef __MACOS__
+#endif // __linux__
+#ifdef __APPLE__
 int cbufGet(cbuf_handle_t cbuf, uint64_t *data)
-#endif // __MACOS__
+#endif // __APPLE__
 {
     int res = __real_cbufGet(cbuf, data);
     if (enable_cbuf_data && res == 0) {

--- a/test/httpheadertest.c
+++ b/test/httpheadertest.c
@@ -38,13 +38,13 @@ needleTestSetup(void** state)
     return groupSetup(state);
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 int __real_cmdSendHttp(ctl_t *, event_t *, uint64_t, proc_id_t *);
 int __wrap_cmdSendHttp(ctl_t *ctl, event_t *event, uint64_t id, proc_id_t *proc)
-#endif // __LINUX__
-#ifdef __MACOS__
+#endif // __linux__
+#ifdef __APPLE__
 int cmdSendHttp(ctl_t *ctl, event_t *event, uint64_t id, proc_id_t *proc)
-#endif // __MACOS__
+#endif // __APPLE__
 {
     //printf("%s: %s\n", __FUNCTION__, event->name);
     if (!event || !proc) return -1;
@@ -60,13 +60,13 @@ int cmdSendHttp(ctl_t *ctl, event_t *event, uint64_t id, proc_id_t *proc)
     return 0;
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 int __real_cmdPostEvent(ctl_t *, char *);
 int __wrap_cmdPostEvent(ctl_t *ctl, char *event)
-#endif // __LINUX__
-#ifdef __MACOS__
+#endif // __linux__
+#ifdef __APPLE__
 int cmdPostEvent(ctl_t *ctl, char *event)
-#endif // __MACOS__
+#endif // __APPLE__
 {
     //printf("%s: data at: %p\n", __FUNCTION__, event);
     doProtocolMetric((protocol_info *)event);

--- a/test/reporttest.c
+++ b/test/reporttest.c
@@ -21,13 +21,13 @@ event_t mtcBuf[BUFSIZE] = {{0}};
 int mtcBufNext = 0;
 
 // These signatures satisfy --wrap=cmdSendEvent in the Makefile
-#ifdef __LINUX__
+#ifdef __linux__
 int __real_cmdSendEvent(ctl_t*, event_t*, uint64_t, proc_id_t*);
 int __wrap_cmdSendEvent(ctl_t* ctl, event_t* event, uint64_t uid, proc_id_t* proc)
-#endif // __LINUX__
-#ifdef __MACOS__
+#endif // __linux__
+#ifdef __APPLE__
 int cmdSendEvent(ctl_t* ctl, event_t* event, uint64_t uit, proc_id_t* proc)
-#endif // __MACOS__
+#endif // __APPLE__
 {
     // Store event for later inspection
     memcpy(&evtBuf[evtBufNext++], event, sizeof(*event));
@@ -37,13 +37,13 @@ int cmdSendEvent(ctl_t* ctl, event_t* event, uint64_t uit, proc_id_t* proc)
 }
 
 // These signatures satisfy --wrap=cmdSendMetric in the Makefile
-#ifdef __LINUX__
+#ifdef __linux__
 int __real_cmdSendMetric(mtc_t*, event_t*);
 int __wrap_cmdSendMetric(mtc_t* mtc, event_t* metric)
-#endif // __LINUX__
-#ifdef __MACOS__
+#endif // __linux__
+#ifdef __APPLE__
 int cmdSendMetric(mtc_t* mtc, event_t* metric)
-#endif // __MACOS__
+#endif // __APPLE__
 {
     // Store metric for later inspection
     memcpy(&mtcBuf[mtcBufNext++], metric, sizeof(*metric));
@@ -206,10 +206,10 @@ nothingCrashesBeforeAnyInit(void** state)
     doRead(16, 987, 1, NULL, 13, "readFunc", BUF, 0);
     doWrite(17, 876, 1, NULL, 0, "writeFunc", BUF, 0);
     doSeek(18, 1, "seekymcseekface");
-#ifdef __LINUX__
+#ifdef __linux__
     doStatPath("/pathy/path", 0, "statymcstatface");
     doStatFd(19, 0, "toomuchstat4u");
-#endif // __LINUX__
+#endif // __linux__
     doDupFile(20, 21, "dup");
     doDupSock(22, 23);
     doDup(24, 0, "dupFunc", 1);
@@ -975,7 +975,7 @@ doSeekSummarization(void** state)
     assert_int_equal(eventCalls(NULL), 0);
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 static void
 doStatPathNoSummarization(void** state)
 {
@@ -1111,7 +1111,7 @@ doStatFdSummarization(void** state)
      assert_int_equal(metricValues("fs.stat"), 2);
      assert_int_equal(eventCalls(NULL), 0);
 }
-#endif // __LINUX__
+#endif // __linux__
 
 static void
 doDNSSendNoDNSSummarization(void** state)
@@ -1521,7 +1521,7 @@ doNetRxTxErrorSummarization(void** state)
     doClose(16, "closeFunc");
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 static void
 doStatErrNoSummarization(void** state)
 {
@@ -1575,7 +1575,7 @@ doStatErrSummarization(void** state)
     assert_int_equal(metricValues("fs.error"), 2);
     assert_int_equal(eventCalls(NULL), 0);
 }
-#endif // __LINUX__
+#endif // __linux__
 
 static void
 doDNSErrNoSummarization(void** state)
@@ -1660,12 +1660,12 @@ main(int argc, char* argv[])
         cmocka_unit_test(doSendFullSummarization),
         cmocka_unit_test(doSeekNoSummarization),
         cmocka_unit_test(doSeekSummarization),
-#ifdef __LINUX__
+#ifdef __linux__
         cmocka_unit_test(doStatPathNoSummarization),
         cmocka_unit_test(doStatPathSummarization),
         cmocka_unit_test(doStatFdNoSummarization),
         cmocka_unit_test(doStatFdSummarization),
-#endif // __LINUX__
+#endif // __linux__
         cmocka_unit_test(doDNSSendNoDNSSummarization),
         cmocka_unit_test(doDNSSendDNSSummarization),
         cmocka_unit_test(doFSConnectionErrorNoSummarization),
@@ -1676,10 +1676,10 @@ main(int argc, char* argv[])
         cmocka_unit_test(doFSReadWriteErrorSummarization),
         cmocka_unit_test(doNetRxTxErrorNoSummarization),
         cmocka_unit_test(doNetRxTxErrorSummarization),
-#ifdef __LINUX__
+#ifdef __linux__
         cmocka_unit_test(doStatErrNoSummarization),
         cmocka_unit_test(doStatErrSummarization),
-#endif // __LINUX__
+#endif // __linux__
         cmocka_unit_test(doDNSErrNoSummarization),
         cmocka_unit_test(doDNSErrSummarization),
         cmocka_unit_test(dbgHasNoUnexpectedFailures),

--- a/test/selfinterposetest.c
+++ b/test/selfinterposetest.c
@@ -205,9 +205,9 @@ testNoInterposedSymbolIsUsed(void** state)
     // Get a list of all interposed functions
     char cmdbuf[1024];
     const char* os = "linux";
-#ifdef __MACOS__
+#ifdef __APPLE__
     os = "macOS";
-#endif // __MACOS__
+#endif // __APPLE__
 #if defined(__x86_64__)
     snprintf(cmdbuf, sizeof(cmdbuf), "nm ./lib/%s/x86_64/libscope.so", os);
 #elif defined(__aarch64__)

--- a/test/testContainers/syscalls/altp/include/common.h
+++ b/test/testContainers/syscalls/altp/include/common.h
@@ -1,7 +1,7 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
-#ifdef __MACOS__                                                                                                                                                                
+#ifdef __APPLE__                                                                                                                                                                
 #ifndef off64_t                                                                                                                                                                 
 typedef uint64_t off64_t;                                                                                                                                                       
 #endif                                                                                                                                                                          
@@ -13,7 +13,7 @@ struct statvfs64 {
     uint64_t x;                                                                                                                                                                 
 };                                                                                                                                                                              
 #endif                                                                                                                                                                          
-#endif // __MACOS__  
+#endif // __APPLE__  
 
 #define TEST_MSG "test"
 #define TEST_MSGW L"test"

--- a/test/wraptest.c
+++ b/test/wraptest.c
@@ -216,7 +216,7 @@ testTSCValue(void** state)
 
 /*
 
-This applies to __LINUX__ only.  And isn't like other tests in this file.
+This applies to __linux__ only.  And isn't like other tests in this file.
 Think about whether this adds enough value to run in conditionally only 
 for linux.
 


### PR DESCRIPTION
- replace the occurrence of "__LINUX__" and "__MACOS__"
- get information about the host operating system from the compiler itself
- ref: https://sourceforge.net/p/predef/wiki/OperatingSystems/