### PR TITLE
(499) run website workflow even without web tag

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -13,8 +13,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - web*
     paths:
       - 'website/**'
 jobs:


### PR DESCRIPTION
We want the workflow to run when we push changes under website/ so it can update staging without the web* tag.