### PR TITLE
Enable basic ldscope on aarch64/libmusl

### DIFF
--- a/cli/cmd/excrete.go
+++ b/cli/cmd/excrete.go
@@ -49,6 +49,7 @@ scope extract --metricdest tcp://some.host:8125 --eventdest tcp://other.host:100
 			err = rc.WriteScopeConfig(path.Join(outPath, "scope.yml"), 0644)
 			util.CheckErrSprintf(err, "error writing scope.yml: %v", err)
 		}
+		rc.Patch(outPath)
 		fmt.Printf("Successfully extracted to %s.\n", outPath)
 	},
 }

--- a/cli/run/excrete.go
+++ b/cli/run/excrete.go
@@ -1,0 +1,15 @@
+package run
+
+import (
+	"os"
+	"os/exec"
+	"path"
+)
+
+func (rc *Config) Patch(scope_path string) {
+	cmd := exec.Command(path.Join(scope_path, "ldscope"), "-p", path.Join(scope_path, "libscope.so"))
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+}

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -427,13 +427,13 @@ do_musl(char *exld, char *ldscope)
  * Returns 0 if musl was not detected and 1 if it was.
  */
 static int
-setup_loader(char *exe, char *ldscope)
+setup_loader(char *ldscope)
 {
     int ret = 0; // not musl
 
     char *ldso = NULL;
 
-    if (((ldso = get_loader(exe)) != NULL) &&
+    if (((ldso = get_loader(EXE_TEST_FILE)) != NULL) &&
         (strstr(ldso, LIBMUSL) != NULL)) {
             // we are using the musl ld.so
             do_musl(ldso, ldscope);
@@ -1034,7 +1034,7 @@ main(int argc, char **argv, char **env)
         fprintf(stderr, "error: failed to get a loader path\n");
         return EXIT_FAILURE;
     }
-    setup_loader(EXE_TEST_FILE, loader);
+    setup_loader(loader);
 
     // set SCOPE_EXEC_PATH to path to `ldscope` if not set already
     if (getenv("SCOPE_EXEC_PATH") == 0) {

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -150,6 +150,18 @@ set_library(const char* libpath)
 
     // get the elf header, section table and string table
     elf = (Elf64_Ehdr *)buf;
+
+    if (elf->e_ident[EI_MAG0] != ELFMAG0
+        || elf->e_ident[EI_MAG1] != ELFMAG1
+        || elf->e_ident[EI_MAG2] != ELFMAG2
+        || elf->e_ident[EI_MAG3] != ELFMAG3
+        || elf->e_ident[EI_VERSION] != EV_CURRENT) {
+        fprintf(stderr, "ERROR:%s: is not valid ELF file", libpath);
+        close(fd);
+        munmap(buf, sbuf.st_size);
+        return -1;
+    }
+
     sections = (Elf64_Shdr *)((char *)buf + elf->e_shoff);
     section_strtab = (char *)buf + sections[elf->e_shstrndx].sh_offset;
     found = name = 0;

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -172,7 +172,7 @@ set_library(const char* libpath)
     // locate the .dynamic section
     for (i = 0; i < elf->e_shnum; i++) {
         if (sections[i].sh_type == SHT_DYNAMIC) {
-            for (dyn = (Elf64_Dyn *)((char *)buf + sections[i].sh_offset); dyn != DT_NULL; dyn++) {
+            for (dyn = (Elf64_Dyn *)((char *)buf + sections[i].sh_offset); dyn != NULL && dyn->d_tag != DT_NULL; dyn++) {
                 if (dyn->d_tag == DT_NEEDED) {
                     char *depstr = (char *)(strtab + dyn->d_un.d_val);
                     if (depstr && strstr(depstr, "ld-linux")) {

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -55,8 +55,9 @@ get_dir(const char *path, char *fres, size_t len)
     DIR *dirp;
     struct dirent *entry;
     char *dcopy, *pcopy, *dname, *fname;
+    int res = -1;
 
-    if (!path || !fres || (len <= 0)) return -1;
+    if (!path || !fres || (len <= 0)) return res;
 
     pcopy = strdup(path);
     dname = dirname(pcopy);
@@ -64,7 +65,7 @@ get_dir(const char *path, char *fres, size_t len)
     if ((dirp = opendir(dname)) == NULL) {
         perror("get_dir:opendir");
         if (pcopy) free(pcopy);
-        return -1;
+        return res;
     }
 
     dcopy = strdup(path);
@@ -74,6 +75,7 @@ get_dir(const char *path, char *fres, size_t len)
         if ((entry->d_type != DT_DIR) &&
             (strstr(entry->d_name, fname))) {
             strncpy(fres, entry->d_name, len);
+            res = 0;
             break;
         }
     }
@@ -81,7 +83,7 @@ get_dir(const char *path, char *fres, size_t len)
     closedir(dirp);
     if (pcopy) free(pcopy);
     if (dcopy) free(dcopy);
-    return 0;
+    return res;
 }
 
 static void

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -220,8 +220,6 @@ set_library(const char* libpath)
         if (rc < sbuf.st_size) {
             perror("set_library:write");
         }
-    } else {
-        fprintf(stderr, "WARNING: can't locate or set the loader string in %s\n", libpath);
     }
 
     close(fd);

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -177,9 +177,11 @@ set_library(void)
                     char *depstr = (char *)(strtab + dyn->d_un.d_val);
                     if (depstr && strstr(depstr, "ld-linux")) {
                         char newdep[PATH_MAX];
+                        size_t newdep_len;
                         if (get_dir("/lib/ld-musl", newdep, sizeof(newdep)) == -1) break;
-                        if (strlen(depstr) >= (strlen(newdep) + 1)) {
-                            strncpy(depstr, newdep, strlen(newdep) + 1);
+                        newdep_len = strlen(newdep);
+                        if (strlen(depstr) >= newdep_len) {
+                            strncpy(depstr, newdep, newdep_len + 1);
                             found = 1;
                             break;
                         }
@@ -256,6 +258,7 @@ set_loader(char *exe)
             DIR *dirp;
             struct dirent *entry;
             char dir[PATH_MAX];
+            size_t dir_len;
 
             if (strstr(exld, "ld-musl") != NULL) {
                 close(fd);
@@ -279,10 +282,10 @@ set_loader(char *exe)
             }
 
             closedir(dirp);
-
-            if (name && (strlen(exld) > (strlen(dir) + 1))) {
+            dir_len = strlen(dir);
+            if (name && (strlen(exld) >= dir_len)) {
                 if (g_debug) printf("%s:%d exe ld.so: %s to %s\n", __FUNCTION__, __LINE__, exld, dir);
-                strncpy(exld, dir, strlen(dir) + 1);
+                strncpy(exld, dir, dir_len + 1);
                 found = 1;
                 break;
             }

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -402,10 +402,8 @@ do_musl(char *exld, char *ldscope)
         return;
     }
 
-#ifdef __x86_64__
     set_loader(ldscope);
     set_library();
-#endif
 
     if (ldso) free(ldso);
     if (lpath) free(lpath);

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -918,7 +918,6 @@ static struct option opts[] = {
 int
 main(int argc, char **argv, char **env)
 {
-    int is_musl;
     char *attachArg = 0;
     char path[PATH_MAX] = {0};
 
@@ -1002,12 +1001,11 @@ main(int argc, char **argv, char **env)
 
     // setup for musl libc if detected
     char *loader = (char *)libdirGetLoader();
-    if (loader) {
-        is_musl = setup_loader(EXE_TEST_FILE, loader);
-    } else {
+    if (!loader) {
         fprintf(stderr, "error: failed to get a loader path\n");
         return EXIT_FAILURE;
     }
+    setup_loader(EXE_TEST_FILE, loader);
 
     // set SCOPE_EXEC_PATH to path to `ldscope` if not set already
     if (getenv("SCOPE_EXEC_PATH") == 0) {
@@ -1096,17 +1094,7 @@ main(int argc, char **argv, char **env)
         return EXIT_FAILURE;
     }
 
-    if (is_musl && ubuf.machine && (strstr(ubuf.machine, "aarch64") != NULL)) {
-        strncpy(path, "/lib/", 8);
-        if (get_dir("/lib/ld-", path + strlen(path), sizeof(path) - strlen(path)) == -1) {
-            fprintf(stderr, "ERROR: can't get the path for ld-musl");
-            return EXIT_FAILURE;
-        }
-
-        execve(path, execArgv, environ);
-    } else {
-        execve(libdirGetLoader(), execArgv, environ);
-    }
+    execve(libdirGetLoader(), execArgv, environ);
 
     free(execArgv);
     perror("execve failed");

--- a/test/testContainers/README.md
+++ b/test/testContainers/README.md
@@ -60,7 +60,7 @@ AppScope Integration Test Runner
   `make (test)-shell` - run a shell in the test's container
   `make (test)-exec` - run a shell in the existing test's container
   `make (test)-build` - build the test's image
-Tests: alpine attach-glibc attach-musl bash cli console detect_proto elastic gogen go_2 go_3 go_4 go_5 go_6 go_7 go_8 go_9 go_10 go_11 go_12 go_13 go_14 go_15 go_16 go_17 http java7 java8 java9 java10 java11 java12 java13 java14 kafka logstream nginx oracle-java7 oracle-java8 oracle-java9 oracle-java10 oracle-java11 musl oracle-java12 oracle-java13 oracle-java14 service-initd service-systemd splunk syscalls tls transport
+Tests: alpine attach-glibc attach-musl bash cli console detect_proto elastic glibc gogen go_2 go_3 go_4 go_5 go_6 go_7 go_8 go_9 go_10 go_11 go_12 go_13 go_14 go_15 go_16 go_17 http java7 java8 java9 java10 java11 java12 java13 java14 kafka logstream nginx oracle-java7 oracle-java8 oracle-java9 oracle-java10 oracle-java11 musl oracle-java12 oracle-java13 oracle-java14 service-initd service-systemd splunk syscalls tls transport
 ```
 
 Developers can run tests locally pretty easily with this setup. We use it for

--- a/test/testContainers/docker-compose.x86_64.yml
+++ b/test/testContainers/docker-compose.x86_64.yml
@@ -425,12 +425,3 @@ services:
       context: .
       dockerfile: ./attach/Dockerfile.musl
     <<: *scope-common
-  # skipped on ARM - limit support for musl
-  musl:
-    image: ghcr.io/criblio/appscope-test-musl:${TAG:?Missing TAG environment variable}
-    build:
-      cache_from: 
-        - ghcr.io/criblio/appscope-test-musl:${TAG:?Missing TAG environment variable}
-      context: .
-      dockerfile: ./musl/Dockerfile
-    <<: *scope-common

--- a/test/testContainers/docker-compose.x86_64.yml
+++ b/test/testContainers/docker-compose.x86_64.yml
@@ -36,16 +36,6 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
     <<: *scope-common
 
-  # busted on ARM for now
-  alpine:
-    image: ghcr.io/criblio/appscope-test-alpine:${TAG:?Missing TAG environment variable}
-    build:
-      cache_from:
-        - ghcr.io/criblio/appscope-test-alpine:${TAG:?Missing TAG environment variable}
-      context: .
-      dockerfile: ./alpine/Dockerfile
-    <<: *scope-common
-
   # requires "privileged" on ARM but not on x86
   syscalls:
     image: ghcr.io/criblio/appscope-test-syscalls:${TAG:?Missing TAG environment variable}

--- a/test/testContainers/docker-compose.yml
+++ b/test/testContainers/docker-compose.yml
@@ -164,5 +164,14 @@ services:
       context: .
       dockerfile: ./console/Dockerfile
     <<: *scope-common
+    
+  musl:
+    image: ghcr.io/criblio/appscope-test-musl:${TAG:?Missing TAG environment variable}
+    build:
+      cache_from: 
+        - ghcr.io/criblio/appscope-test-musl:${TAG:?Missing TAG environment variable}
+      context: .
+      dockerfile: ./musl/Dockerfile
+    <<: *scope-common
 
 # vim: ts=2 sw=2 et :

--- a/test/testContainers/docker-compose.yml
+++ b/test/testContainers/docker-compose.yml
@@ -183,4 +183,13 @@ services:
       dockerfile: ./musl/Dockerfile
     <<: *scope-common
 
+  glibc:
+    image: ghcr.io/criblio/appscope-test-glibc:${TAG:?Missing TAG environment variable}
+    build:
+      cache_from: 
+        - ghcr.io/criblio/appscope-test-glibc:${TAG:?Missing TAG environment variable}
+      context: .
+      dockerfile: ./glibc/Dockerfile
+    <<: *scope-common
+
 # vim: ts=2 sw=2 et :

--- a/test/testContainers/docker-compose.yml
+++ b/test/testContainers/docker-compose.yml
@@ -10,6 +10,15 @@ services:
 
   # These tests run on all platforms; x86_64 and aarch64
 
+  alpine:
+    image: ghcr.io/criblio/appscope-test-alpine:${TAG:?Missing TAG environment variable}
+    build:
+      cache_from:
+        - ghcr.io/criblio/appscope-test-alpine:${TAG:?Missing TAG environment variable}
+      context: .
+      dockerfile: ./alpine/Dockerfile
+    <<: *scope-common
+
   syscalls:
     image: ghcr.io/criblio/appscope-test-syscalls:${TAG:?Missing TAG environment variable}
     build:

--- a/test/testContainers/glibc/Dockerfile
+++ b/test/testContainers/glibc/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update \
+    && apt install -y \
+      binutils \
+      musl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/extract_scope && \
+    mkdir -p /opt/patch_libscope
+
+ENV SCOPE_LOG_LEVEL=error
+ENV SCOPE_METRIC_VERBOSITY=4
+ENV SCOPE_EVENT_LOGFILE=true
+ENV SCOPE_EVENT_CONSOLE=true
+ENV SCOPE_EVENT_METRIC=true
+ENV SCOPE_EVENT_HTTP=true
+ENV SCOPE_EVENT_NET=true
+ENV SCOPE_EVENT_FS=true
+ENV SCOPE_LOG_DEST=file:///opt/test-runner/logs/scope.log
+ENV SCOPE_EVENT_DEST=file:///opt/test-runner/logs/events.log
+
+ENV PATH="/usr/local/scope:/usr/local/scope/bin:${PATH}"
+COPY scope-profile.sh /etc/profile.d/scope.sh
+COPY gdbinit /root/.gdbinit
+
+RUN  mkdir /usr/local/scope && \
+     mkdir /usr/local/scope/bin && \
+     mkdir /usr/local/scope/lib && \
+     mkdir -p /opt/test-runner/logs/ && \
+     ln -s /opt/appscope/bin/linux/$(uname -m)/scope /usr/local/scope/bin/scope && \
+     ln -s /opt/appscope/bin/linux/$(uname -m)/ldscope /usr/local/scope/bin/ldscope && \
+     ln -s /opt/appscope/lib/linux/$(uname -m)/libscope.so /usr/local/scope/lib/libscope.so
+
+COPY glibc/scope-test /usr/local/scope/scope-test
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["test"]

--- a/test/testContainers/glibc/scope-test
+++ b/test/testContainers/glibc/scope-test
@@ -1,0 +1,119 @@
+#! /bin/bash
+
+DEBUG=0  # set this to 1 to capture the EVT_FILE for each test
+
+FAILED_TEST_LIST=""
+FAILED_TEST_COUNT=0
+
+EVT_FILE="/opt/test-runner/logs/events.log"
+
+starttest(){
+    CURRENT_TEST=$1
+    echo "==============================================="
+    echo "             Testing $CURRENT_TEST             "
+    echo "==============================================="
+    ERR=0
+}
+
+evaltest(){
+    echo "             Evaluating $CURRENT_TEST"
+}
+
+endtest(){
+    if [ $ERR -eq "0" ]; then
+        RESULT=PASSED
+    else
+        RESULT=FAILED
+        FAILED_TEST_LIST+=$CURRENT_TEST
+        FAILED_TEST_LIST+=" "
+        FAILED_TEST_COUNT=$(($FAILED_TEST_COUNT + 1))
+    fi
+
+    echo "*************** $CURRENT_TEST $RESULT ***************"
+    echo ""
+    echo ""
+
+    # copy the EVT_FILE to help with debugging
+    if (( $DEBUG )) || [ $RESULT == "FAILED" ]; then
+        cp -f $EVT_FILE $EVT_FILE.$CURRENT_TEST
+    fi
+
+    rm -f $EVT_FILE
+}
+
+#
+# extract on glibc
+#
+starttest extract_musl
+
+scope extract /opt/extract_scope
+ERR+=$?
+
+count=$(readelf -d /opt/extract_scope/libscope.so | grep 'Shared library:.*ld-linux' | wc -l)
+if [ $count -ne 1 ] ; then 
+    ERR+=1
+fi
+
+count=$(readelf -d /opt/extract_scope/libscope.so | grep 'Shared library:.*ld-musl' | wc -l)
+if [ $count -ne 0 ] ; then 
+    ERR+=1
+fi
+
+endtest
+
+#
+# ldscope patch
+#
+starttest patch_on_musl
+cp /usr/local/scope/lib/libscope.so /opt/patch_libscope
+cp /usr/local/scope/bin/ldscope /opt/patch_libscope
+
+md5_before_patch=$(md5sum /opt/patch_libscope/libscope.so)
+
+count=$(readelf -d /opt/patch_libscope/libscope.so | grep 'Shared library:.*ld-linux' | wc -l)
+if [ $count -ne 1 ] ; then
+    ERR+=1
+fi
+
+/opt/patch_libscope/ldscope --patch /opt/patch_libscope/libscope.so
+if [ $? -eq 0 ]; then
+    ERR+=1
+fi
+
+md5_after_patch=$(md5sum /opt/patch_libscope/libscope.so)
+
+count=$(readelf -d /opt/patch_libscope/libscope.so | grep 'Shared library:.*ld-musl' | wc -l)
+if [ $count -ne 0 ] ; then
+    ERR+=1
+fi
+
+if [ "$md5_before_patch" != "$md5_after_patch" ]; then
+    ERR+=1
+fi
+
+endtest
+
+starttest patch_on_musl_dummy_file
+
+echo "Lorem ipsum" >> /opt/patch_libscope/dummy_file
+/opt/patch_libscope/ldscope --patch /opt/patch_libscope/dummy_file
+if [ $? -eq 0 ]; then
+    ERR+=1
+fi
+
+endtest
+
+if (( $FAILED_TEST_COUNT == 0 )); then
+    echo ""
+    echo ""
+    echo "*************** ALL TESTS PASSED ***************"
+else
+    echo "*************** SOME TESTS FAILED ***************"
+    echo "Failed tests: $FAILED_TEST_LIST"
+    echo "Refer to these files for more info:"
+    for FAILED_TEST in $FAILED_TEST_LIST; do
+        echo "  $EVT_FILE.$FAILED_TEST"
+    done
+fi
+
+exit ${FAILED_TEST_COUNT}

--- a/test/testContainers/musl/Dockerfile
+++ b/test/testContainers/musl/Dockerfile
@@ -1,10 +1,13 @@
 FROM alpine:latest
 
-RUN apk add bash curl gcc gdb musl-dev
+RUN apk add bash binutils curl gcc gdb musl-dev
 
 RUN mkdir -p /opt/fwrite
 COPY ./musl/fwrite.c /opt/fwrite/fwrite.c
 RUN gcc -o /opt/fwrite/fwrite /opt/fwrite/fwrite.c
+
+RUN mkdir -p /opt/extract_scope && \
+    mkdir -p /opt/patch_libscope
 
 ENV SCOPE_LOG_LEVEL=error
 ENV SCOPE_METRIC_VERBOSITY=4

--- a/test/testContainers/musl/scope-test
+++ b/test/testContainers/musl/scope-test
@@ -42,6 +42,61 @@ endtest(){
 }
 
 #
+# extract on musl
+#
+starttest extract_musl
+
+scope extract /opt/extract_scope
+ERR+=$?
+
+count=$(readelf -d /opt/extract_scope/libscope.so | grep 'Shared library:.*ld-linux' | wc -l)
+if [ $count -ne 0 ] ; then 
+    ERR+=1
+fi
+
+count=$(readelf -d /opt/extract_scope/libscope.so | grep 'Shared library:.*ld-musl' | wc -l)
+if [ $count -ne 1 ] ; then 
+    ERR+=1
+fi
+
+endtest
+
+#
+# ldscope patch
+#
+starttest patch_on_musl
+cp /usr/local/scope/lib/libscope.so /opt/patch_libscope
+cp /usr/local/scope/bin/ldscope /opt/patch_libscope
+
+count=$(readelf -d /opt/patch_libscope/libscope.so | grep 'Shared library:.*ld-linux' | wc -l)
+if [ $count -ne 1 ] ; then
+    ERR+=1
+fi
+
+/opt/patch_libscope/ldscope -p /opt/patch_libscope/libscope.so
+ERR+=$?
+
+md5_after_first_patch=$(md5sum /opt/patch_libscope/libscope.so)
+
+count=$(readelf -d /opt/patch_libscope/libscope.so | grep 'Shared library:.*ld-musl' | wc -l)
+if [ $count -ne 1 ] ; then
+    ERR+=1
+fi
+
+/opt/patch_libscope/ldscope -p /opt/patch_libscope/libscope.so
+if [ $? -eq 0 ]; then
+    ERR+=1
+fi
+
+md5_after_second_patch=$(md5sum /opt/patch_libscope/libscope.so)
+
+if [ "$md5_after_first_patch" != "$md5_after_second_patch" ]; then
+    ERR+=1
+fi
+
+endtest
+
+#
 # fwrite binary
 #
 starttest fwrite
@@ -51,22 +106,22 @@ ERR+=$?
 
 sleep 0.5
 count=$(grep '"source":"fs.op.open"' $EVT_FILE | wc -l)
-if [ $count -ne 1 ] ; then 
+if [ $count -ne 1 ] ; then
     ERR+=1
 fi
 
 count=$(grep '"source":"fs.duration"' $EVT_FILE | wc -l)
-if [ $count -ne 1 ] ; then 
+if [ $count -ne 1 ] ; then
     ERR+=1
 fi
 
 count=$(grep '"source":"fs.write"' $EVT_FILE | wc -l)
-if [ $count -ne 1 ] ; then 
+if [ $count -ne 1 ] ; then
     ERR+=1
 fi
 
 count=$(grep '"source":"fs.op.close"' $EVT_FILE | wc -l)
-if [ $count -ne 1 ] ; then 
+if [ $count -ne 1 ] ; then
     ERR+=1
 fi
 


### PR DESCRIPTION
The intention of this PR is to provide support for ldscope on ARM:

TODO:
- [x] Extend validation (Alpine)
- [x] Check the behaviour of LD_LIBRARY mechanism without modifying the `interp` and `dynamic section` - Extend documentation with [information](https://github.com/criblio/appscope/issues/602#issuecomment-965135917)
~~- [ ] Extend building library with the stage where we reserved a place for the loader in the previously mentioned sections~~
~~- [ ] Add test where loader path size is extending the original loader path size~~
~~- [ ] Check the syscalls integration test on musl (x86_64 and aarch64)~~ - will be done in another PR
- [x] Modify scope extract mechanism
