### PR TITLE
Add timestamp to scope logs

### DIFF
--- a/src/dbg.c
+++ b/src/dbg.c
@@ -146,8 +146,9 @@ dbgOutputHeaderLine(FILE *f)
     struct timeval tv;
     gettimeofday(&tv, NULL);
 
+    struct tm t;
     char buf[128] = {0};
-    strftime(buf, sizeof(buf), "%FT%TZ", gmtime(&tv.tv_sec));
+    strftime(buf, sizeof(buf), "%FT%TZ", gmtime_r(&tv.tv_sec, &t));
     fprintf(f, "Scope Version: %s   Dump From: %s\n", SCOPE_VER, buf);
 }
 

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -4795,7 +4795,7 @@ scopeLog(cfg_log_level_t level, const char *format, ...)
     char *local_buf;
     char time_buf[LOG_TIME_SIZE];
     int msec;
-    struct tm* tm_info;
+    struct tm tm_info;
     struct timeval tv;
 
     if (!g_log) {
@@ -4842,8 +4842,8 @@ scopeLog(cfg_log_level_t level, const char *format, ...)
         tv.tv_sec++;
         msec = 0;
     }
-    tm_info = localtime(&tv.tv_sec);
-    strftime(time_buf, LOG_TIME_SIZE, "%Y-%m-%d %H:%M:%S", tm_info);
+    localtime_r(&tv.tv_sec, &tm_info);
+    strftime(time_buf, LOG_TIME_SIZE, "%Y-%m-%d %H:%M:%S", &tm_info);
 
     local_buf = scope_log_var_buf + snprintf(scope_log_var_buf, LOG_BUF_SIZE, "Scope: %s(pid:%d): [%s.%03d] ", g_proc.procname, g_proc.pid, time_buf, msec);
     size_t local_buf_len = sizeof(scope_log_var_buf) + (scope_log_var_buf - local_buf) - 1;

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -4784,6 +4784,7 @@ getentropy(void *buffer, size_t length)
 }
 
 #define LOG_BUF_SIZE 4096
+#define LOG_TIME_SIZE 23
 
 // This overrides a weak definition in src/dbg.c
 void
@@ -4792,6 +4793,10 @@ scopeLog(cfg_log_level_t level, const char *format, ...)
     char scope_log_var_buf[LOG_BUF_SIZE];
     const char overflow_msg[] = "WARN: scopeLog msg truncated.\n";
     char *local_buf;
+    char time_buf[LOG_TIME_SIZE];
+    int msec;
+    struct tm* tm_info;
+    struct timeval tv;
 
     if (!g_log) {
         if (!g_constructor_debug_enabled) return;
@@ -4831,7 +4836,16 @@ scopeLog(cfg_log_level_t level, const char *format, ...)
     cfg_log_level_t cfg_level = logLevel(g_log);
     if ((cfg_level == CFG_LOG_NONE) || (cfg_level > level)) return;
 
-    local_buf = scope_log_var_buf + snprintf(scope_log_var_buf, LOG_BUF_SIZE, "Scope: %s(pid:%d): ", g_proc.procname, g_proc.pid);
+    gettimeofday(&tv, NULL);
+    msec = tv.tv_usec / 1000; 
+    if (msec > 999) {
+        tv.tv_sec++;
+        msec = 0;
+    }
+    tm_info = localtime(&tv.tv_sec);
+    strftime(time_buf, LOG_TIME_SIZE, "%Y-%m-%d %H:%M:%S", tm_info);
+
+    local_buf = scope_log_var_buf + snprintf(scope_log_var_buf, LOG_BUF_SIZE, "Scope: %s(pid:%d): [%s.%03d] ", g_proc.procname, g_proc.pid, time_buf, msec);
     size_t local_buf_len = sizeof(scope_log_var_buf) + (scope_log_var_buf - local_buf) - 1;
 
     va_list args;


### PR DESCRIPTION
Add timestamp to scope logs in RFC 3339 format.
Closes https://github.com/criblio/appscope/issues/534

**QA INSTRUCTIONS**

**Part 1**

Do:

```
$ SCOPE_LOG_LEVEL=debug scope top
```
Ctrl+c
```
$ scope logs
```

Expect:

You see timestamps in the logs:
```
Scope: top(pid:83214): [2021-10-20 17:48:33.972] fd:5 lseek
Scope: top(pid:83214): [2021-10-20 17:48:33.972] fd:7 lseek
Scope: top(pid:83214): [2021-10-20 17:48:33.972] fd:4 rewind
Scope: top(pid:83214): [2021-10-20 17:48:36.974] fd:6 lseek
Scope: top(pid:83214): [2021-10-20 17:48:36.974] fd:5 lseek
```