### PR TITLE
0.8.0 post-update docs fix 01

### DIFF
--- a/conf/scope.yml
+++ b/conf/scope.yml
@@ -164,7 +164,7 @@ metric:
 
     # Connection port
     #   Type:     integer or string
-    #   Values:   IP port number or service name
+    #   Values:   Port number or service name
     #   Default:  8125
     #   Override: the port token in the $SCOPE_METRIC_DEST URL
     #
@@ -457,7 +457,7 @@ event:
 
     # Connection port
     #   Type:     integer or string
-    #   Values:   IP port number or service name
+    #   Values:   Port number or service name
     #   Default:  9109
     #   Override: the port token in the $SCOPE_EVENT_DEST URL
     #
@@ -650,7 +650,7 @@ libscope:
 
       # Connection port
       #   Type:     integer or string
-      #   Values:   IP port number or service name
+      #   Values:   Port number or service name
       #   Default:  (none)
       #   Override: the port token in the $SCOPE_LOG_DEST URL
       #
@@ -741,7 +741,7 @@ cribl:
 
     # Connection port
     #   Type:     integer or string
-    #   Values:   IP port number or service name
+    #   Values:   Port number or service name
     #   Default:  10090
     #   Override: the port token in the $SCOPE_CRIBL or $SCOPE_CRIBL_CLOUD URL
     #

--- a/conf/scope.yml
+++ b/conf/scope.yml
@@ -928,7 +928,7 @@ custom:
   #   ancestor: string
   #
   #     Matches if given string matches the basename of the scoped process's
-  #     partent, parent's parent, etc.
+  #     parent, parent's parent, etc.
   #
   # The `config` section specifies the settings that should be overridden when
   # the filter matches. Entries under `config` use the same schema as the

--- a/website/src/components/Hero.js
+++ b/website/src/components/Hero.js
@@ -37,7 +37,7 @@ export default function Hero() {
             <p>{data.heroYaml.hero.subText}</p>
             <Button
               onClick={() => {
-                navigate("/docs/installing");
+                navigate("/docs/overview");
               }}
             >
               {data.heroYaml.hero.ctaText}

--- a/website/src/pages/docs/tls.md
+++ b/website/src/pages/docs/tls.md
@@ -19,7 +19,7 @@ ldscope --help configuration | grep TLS
 
 ## Using TLS in Cribl.Cloud
 
-AppScope uses TLS by default to communicate with LogStream in Cribl.Cloud. LogStream has an AppScope Source ready to use out-of-the-box.
+AppScope uses TLS by default to communicate with LogStream Cloud (that is, LogStream in Cribl.Cloud). LogStream has an AppScope Source ready to use out-of-the-box.
 
 Within Cribl.Cloud, a front-end load balancer (reverse proxy) handles the encrypted TLS traffic and relays it to the AppScope Source port in LogStream. The connection from the load balancer to LogStream does **not** use TLS, and you should not enable TLS on the [AppScope Source](https://docs.cribl.io/docs/sources-appscope) in LogStream. No changes in LogStream configuration are needed.
 
@@ -63,8 +63,6 @@ cribl:
 
 ## Scoping Without TLS
 
-If you prefer to communicate without encryption, connect to port 10091 instead of port 10090.
+If you prefer to connect to LogStream Cloud without encryption, connect to port 10091 instead of port 10090, and disable the `tls` element in `scope.yml`.
 
-If it is enabled, disable the `tls` element in `scope.yml`.
-
-If connecting to LogStream in Cribl.Cloud, no changes in LogStream configuration are needed.
+No changes in LogStream configuration are needed.


### PR DESCRIPTION
1.
Fixes Get Started button link on https://appscope.dev/

2.
Fixes `scope.yml` typo in comments: `partent` --> `*parent`.

3.
Fixes `scope.yml` comments referring to `IP port number` --> `Port number`.

4.
Clarifies wording in https://appscope.dev/docs/tls#scoping-without-tls