### PR TITLE
Avoid creating certs dir in Appscope working dir

### DIFF
--- a/test/testContainers/alpine/test_tls.sh
+++ b/test/testContainers/alpine/test_tls.sh
@@ -79,6 +79,7 @@ evalPayload(){
 # OpenSSL
 #
 starttest OpenSSL
+cd /opt/test
 ldscope /opt/test/curl-ssl --http1.1 --head https://cribl.io
 evaltest
 


### PR DESCRIPTION
Avoid create certs dir in Appscope working dir
    
Calling scipt:
`/opt/test/bin/testssl.py create_certs`
Results with the creation of `certs` dir - owned by Docker
container user - `root`. Later trying to remove `certs` dir
as a user different than `root` results with permission denied.
Alpine integration test working directory is always
`/opt/appscope` this results in the creation of the `certs` dir
outside of the container and the `certs` dir will be available
after the test.
Removing the `certs` directly from the host (outside the Docker
container) results with permission denied and issues with
cleaning up the test environment for future test runs.
Changing the test working directory to `/opt/test` solve the
initial problem.
