### PR TITLE
Extend syscall tests to musl 

### DIFF
--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -116,7 +116,7 @@ setEnvVariable(char *env, char *value)
 
 // modify NEEDED entries in libscope.so to avoid dependencies
 static int
-set_library(const char* libpath)
+set_library(const char *libpath)
 {
     int i, fd, found, name;
     struct stat sbuf;
@@ -446,7 +446,7 @@ setup_loader(char *ldscope)
 }
 
 static int
-patch_library(const char* so_path) {
+patch_library(const char *so_path) {
     int result = EXIT_FAILURE;
 
     char *ldso = get_loader(EXE_TEST_FILE);

--- a/test/testContainers/README.md
+++ b/test/testContainers/README.md
@@ -60,7 +60,7 @@ AppScope Integration Test Runner
   `make (test)-shell` - run a shell in the test's container
   `make (test)-exec` - run a shell in the existing test's container
   `make (test)-build` - build the test's image
-Tests: alpine attach-glibc attach-musl bash cli console detect_proto elastic glibc gogen go_2 go_3 go_4 go_5 go_6 go_7 go_8 go_9 go_10 go_11 go_12 go_13 go_14 go_15 go_16 go_17 http java7 java8 java9 java10 java11 java12 java13 java14 kafka logstream nginx oracle-java7 oracle-java8 oracle-java9 oracle-java10 oracle-java11 musl oracle-java12 oracle-java13 oracle-java14 service-initd service-systemd splunk syscalls tls transport
+Tests: alpine attach-glibc attach-musl bash cli console detect_proto elastic glibc gogen go_2 go_3 go_4 go_5 go_6 go_7 go_8 go_9 go_10 go_11 go_12 go_13 go_14 go_15 go_16 go_17 http java7 java8 java9 java10 java11 java12 java13 java14 kafka logstream nginx oracle-java7 oracle-java8 oracle-java9 oracle-java10 oracle-java11 musl oracle-java12 oracle-java13 oracle-java14 service-initd service-systemd splunk syscalls syscalls-alpine tls transport
 ```
 
 Developers can run tests locally pretty easily with this setup. We use it for
@@ -85,7 +85,7 @@ Test the standalone version of Cribl LogStream.
 Tests Splunk Enterprise. Splunk instance has Cribl LogStream as Splunk
 Application, but LogStream capabilities are not tested or used.
 
-### `syscalls`
+### `syscalls` and `syscalls-alpine`
 
 Tests Linux syscalls supported by Scope using executable syscall unit tests.
 Some unit tests provided by [LTP Project][LTP]; others are custom C tests

--- a/test/testContainers/docker-compose.x86_64.yml
+++ b/test/testContainers/docker-compose.x86_64.yml
@@ -36,16 +36,6 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
     <<: *scope-common
 
-  # requires "privileged" on ARM but not on x86
-  syscalls:
-    image: ghcr.io/criblio/appscope-test-syscalls:${TAG:?Missing TAG environment variable}
-    build:
-      cache_from:
-        - ghcr.io/criblio/appscope-test-syscalls:${TAG:?Missing TAG environment variable}
-      context: .
-      dockerfile: ./syscalls/Dockerfile
-    <<: *scope-common
-
   # There are no arm64 splunk/splunk images at Docker Hub
   splunk:
     image: ghcr.io/criblio/appscope-test-splunk:${TAG:?Missing TAG environment variable}

--- a/test/testContainers/docker-compose.yml
+++ b/test/testContainers/docker-compose.yml
@@ -28,6 +28,15 @@ services:
       dockerfile: ./syscalls/Dockerfile
     <<: *scope-common
 
+  syscalls-alpine:
+    image: ghcr.io/criblio/appscope-test-syscalls-alpine:${TAG:?Missing TAG environment variable}
+    build:
+      cache_from:
+        - ghcr.io/criblio/appscope-test-syscalls-alpine:${TAG:?Missing TAG environment variable}
+      context: .
+      dockerfile: ./syscalls/Dockerfile.alpine
+    <<: *scope-common
+
   logstream:
     image: ghcr.io/criblio/appscope-test-logstream:${TAG:?Missing TAG environment variable}
     build:

--- a/test/testContainers/elastic/scope-test
+++ b/test/testContainers/elastic/scope-test
@@ -3,4 +3,4 @@ exec /opt/test-runner/bin/python \
   /opt/test-runner/app.py \
   -t elastic \
   -l /opt/test-runner/logs/ \
-  -s //usr/local/scope/lib/libscope.so
+  -s /usr/local/scope/lib/libscope.so

--- a/test/testContainers/glibc/scope-test
+++ b/test/testContainers/glibc/scope-test
@@ -44,7 +44,7 @@ endtest(){
 #
 # extract on glibc
 #
-starttest extract_musl
+starttest extract_glibc
 
 scope extract /opt/extract_scope
 ERR+=$?
@@ -64,7 +64,8 @@ endtest
 #
 # ldscope patch
 #
-starttest patch_on_musl
+starttest patch_on_glibc
+
 cp /usr/local/scope/lib/libscope.so /opt/patch_libscope
 cp /usr/local/scope/bin/ldscope /opt/patch_libscope
 
@@ -93,7 +94,7 @@ fi
 
 endtest
 
-starttest patch_on_musl_dummy_file
+starttest patch_on_glibc_dummy_file
 
 echo "Lorem ipsum" >> /opt/patch_libscope/dummy_file
 /opt/patch_libscope/ldscope --patch /opt/patch_libscope/dummy_file

--- a/test/testContainers/syscalls/Dockerfile
+++ b/test/testContainers/syscalls/Dockerfile
@@ -14,7 +14,7 @@ RUN cd /opt/test && \
       unzip 20210524.zip && \
       rm -f 20210524.zip && \
       mv ltp-20210524 ltp && \
-    cd /opt/test/ltp && \
+      cd /opt/test/ltp && \
       make autotools && \
       ./configure && \
       make -j
@@ -29,8 +29,6 @@ ENV SCOPE_EVENT_LOGFILE=true
 ENV SCOPE_EVENT_CONSOLE=true
 ENV SCOPE_EVENT_METRIC=true
 ENV SCOPE_EVENT_HTTP=true
-#ENV SCOPE_EVENT_DEST=tcp://172.16.198.132:9109
-ENV SCOPE_THREAD_DELAY="dup205"
 
 COPY ./syscalls/altp /opt/test/altp
 RUN cd /opt/test/altp && make -j

--- a/test/testContainers/syscalls/Dockerfile
+++ b/test/testContainers/syscalls/Dockerfile
@@ -23,7 +23,7 @@ RUN source scl_source enable rh-python38 && \
     virtualenv -p $(which python) /opt/test-runner/
 
 ENV SCOPE_LOG_LEVEL=info
-ENV SCOPE_METRIC_DEST=udp://localhost:8125
+ENV SCOPE_METRIC_DEST=tcp://localhost:8125
 ENV SCOPE_METRIC_VERBOSITY=4
 ENV SCOPE_EVENT_LOGFILE=true
 ENV SCOPE_EVENT_CONSOLE=true

--- a/test/testContainers/syscalls/Dockerfile.alpine
+++ b/test/testContainers/syscalls/Dockerfile.alpine
@@ -19,7 +19,7 @@ RUN cd /opt/test && \
 RUN virtualenv -p python3 /opt/test-runner/
 
 ENV SCOPE_LOG_LEVEL=info
-ENV SCOPE_METRIC_DEST=udp://localhost:8125
+ENV SCOPE_METRIC_DEST=tcp://localhost:8125
 ENV SCOPE_METRIC_VERBOSITY=4
 ENV SCOPE_EVENT_LOGFILE=true
 ENV SCOPE_EVENT_CONSOLE=true

--- a/test/testContainers/syscalls/Dockerfile.alpine
+++ b/test/testContainers/syscalls/Dockerfile.alpine
@@ -1,0 +1,55 @@
+FROM alpine:latest
+
+RUN apk add bash python3 py3-pip wget
+RUN pip3 install virtualenv
+
+RUN mkdir -p /opt/test-runner/logs/ /opt/test
+
+RUN cd /opt/test && \
+      wget https://github.com/linux-test-project/ltp/archive/refs/tags/20210927.zip && \
+      unzip 20210927.zip && \
+      rm -f 20210927.zip && \
+      mv ltp-20210927 ltp && \
+      cd /opt/test/ltp && \
+      ./ci/alpine.sh && \
+      make autotools && \
+      ./configure && \
+      make -j
+
+RUN virtualenv -p python3 /opt/test-runner/
+
+ENV SCOPE_LOG_LEVEL=info
+ENV SCOPE_METRIC_DEST=udp://localhost:8125
+ENV SCOPE_METRIC_VERBOSITY=4
+ENV SCOPE_EVENT_LOGFILE=true
+ENV SCOPE_EVENT_CONSOLE=true
+ENV SCOPE_EVENT_METRIC=true
+ENV SCOPE_EVENT_HTTP=true
+
+COPY ./syscalls/altp /opt/test/altp
+RUN cd /opt/test/altp && make -j
+
+COPY ./test_runner/requirements.txt /opt/test-runner/requirements.txt
+RUN /opt/test-runner/bin/pip install -r /opt/test-runner/requirements.txt
+
+COPY ./test_runner /opt/test-runner/
+COPY ./syscalls/syscall_tests_conf.json /opt/test-runner/syscall_tests_conf.json
+
+# # # Switching to Python 3.8 required this hack. Not sure where the kafka packages are coming from.
+RUN sed -i 's/\basync\b/is_async/g' /opt/test-runner/lib/python3.9/site-packages/kafka/producer/*.py
+
+ENV PATH="/usr/local/scope:/usr/local/scope/bin:${PATH}"
+COPY scope-profile.sh /etc/profile.d/scope.sh
+COPY gdbinit /root/.gdbinit
+RUN  mkdir /usr/local/scope && \
+     mkdir /usr/local/scope/bin && \
+     mkdir /usr/local/scope/lib && \
+     ln -s /opt/appscope/bin/linux/$(uname -m)/scope /usr/local/scope/bin/scope && \
+     ln -s /opt/appscope/bin/linux/$(uname -m)/ldscope /usr/local/scope/bin/ldscope && \
+     ln -s /opt/appscope/lib/linux/$(uname -m)/libscope.so /usr/local/scope/lib/libscope.so
+
+COPY ./syscalls/scope-test /usr/local/scope/
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["test"]

--- a/test/testContainers/syscalls/scope-test
+++ b/test/testContainers/syscalls/scope-test
@@ -1,7 +1,8 @@
 #!/bin/bash
+scope extract /opt/test/
 exec /opt/test-runner/bin/python \
     /opt/test-runner/app.py \
     -t syscalls \
     -l /opt/test-runner/logs/ \
-    -s /usr/local/scope/lib/libscope.so \
+    -s /opt/test/libscope.so \
     --syscalls_tests_config /opt/test-runner/syscall_tests_conf.json

--- a/test/testContainers/syscalls/scope-test
+++ b/test/testContainers/syscalls/scope-test
@@ -5,4 +5,5 @@ exec /opt/test-runner/bin/python \
     -t syscalls \
     -l /opt/test-runner/logs/ \
     -s /opt/test/libscope.so \
-    --syscalls_tests_config /opt/test-runner/syscall_tests_conf.json
+    --syscalls_tests_config /opt/test-runner/syscall_tests_conf.json \
+    -m tcp

--- a/test/testContainers/syscalls/syscall_tests_conf.json
+++ b/test/testContainers/syscalls/syscall_tests_conf.json
@@ -128,7 +128,18 @@
       ],
       "exclude_x86_64_tests": [],
       "exclude_aarch64_tests": [],
-      "exclude_musl_tests": [],
+      "Notes for exclude musl tests" : [
+        "the musl exclusions are tests that fail on musl unscoped",
+        "revisit these to see if we can fix them instead of excluding them"
+      ],
+      "exclude_musl_tests": [
+        "fstatfs02_64",
+        "fstatfs02",
+        "gethostbyname_r01",
+        "open13",
+        "statfs02_64",
+        "statfs02"
+      ],
       "exclude_glibc_tests": []
     },
     {
@@ -137,7 +148,7 @@
       "exclude_tests": [],
       "Notes for exclude arch tests" : [
         "the aarch64 exclusions are tests that fail on ARM unscoped",
-	"revisit these to see if we can fix them instead of excluding them"
+        "revisit these to see if we can fix them instead of excluding them"
       ],
       "exclude_x86_64_tests": [],
       "exclude_aarch64_tests": [

--- a/test/testContainers/syscalls/syscall_tests_conf.json
+++ b/test/testContainers/syscalls/syscall_tests_conf.json
@@ -127,7 +127,9 @@
         "fcntl38_64"
       ],
       "exclude_x86_64_tests": [],
-      "exclude_aarch64_tests": []
+      "exclude_aarch64_tests": [],
+      "exclude_musl_tests": [],
+      "exclude_glibc_tests": []
     },
     {
       "home": "/opt/test/altp/tests",
@@ -147,7 +149,9 @@
         "__xstat_01",
         "__xstat64_01",
         "__fxstat_01"
-      ]
+      ],
+      "exclude_musl_tests": [],
+      "exclude_glibc_tests": []
     }
   ]
 }

--- a/test/testContainers/test_runner/app.py
+++ b/test/testContainers/test_runner/app.py
@@ -11,7 +11,7 @@ import splunk
 import syscalls
 from reporting import print_summary, store_results_to_file
 from runner import Runner
-from scope import ScopeDataCollector, ScopeUDPDataListener, get_scope_version
+from scope import ScopeDataCollector, get_scope_version, create_listener
 from validation import default_test_set_validators
 from watcher import TestWatcher
 
@@ -26,6 +26,9 @@ def main():
     parser.add_argument("-l", "--logs_path", help="path to store the execution results and logs", default="/tmp/")
     parser.add_argument("-s", "--scope_path", help="path to scope application executable",
                         default="/usr/lib/libscope.so")
+    parser.add_argument("-m", "--metric_type", help="metric destination type",
+                        choices=["udp", "tcp"],
+                        default="udp")
 
     parser.add_argument("--syscalls_tests_config", help="path to syscalls tests config")
 
@@ -41,14 +44,16 @@ def main():
 
     logging.info("Execution ID: " + execution_id)
     logging.info("Logs path: " + logs_path)
+    logging.info(f"Metrics destination type: {args.metric_type}")
 
     scope_version = get_scope_version(args.scope_path)
     logging.info(f"Scope Version: {scope_version}")
     test_watcher = TestWatcher(execution_id)
     test_watcher.start()
-    scope_data_collector = ScopeDataCollector()
+    scope_data_collector = ScopeDataCollector(args.metric_type)
+    data_listener = create_listener(args.metric_type, scope_data_collector)
 
-    with ScopeUDPDataListener(scope_data_collector, "localhost", 8125):
+    with data_listener:
         try:
             runner = Runner(test_watcher, scope_data_collector)
             runner.add_test_set_validators(default_test_set_validators)

--- a/test/testContainers/test_runner/app.py
+++ b/test/testContainers/test_runner/app.py
@@ -42,8 +42,9 @@ def main():
     format = "%(asctime)s %(levelname)s %(name)s - %(message)s"
     logging.basicConfig(level=log_level, format=format)
 
-    logging.info("Execution ID: " + execution_id)
-    logging.info("Logs path: " + logs_path)
+    logging.info(f"Execution ID: {execution_id}")
+    logging.info(f"Scope path: {args.scope_path}")
+    logging.info(f"Logs path: {logs_path}")
     logging.info(f"Metrics destination type: {args.metric_type}")
 
     scope_version = get_scope_version(args.scope_path)

--- a/test/testContainers/test_runner/app.py
+++ b/test/testContainers/test_runner/app.py
@@ -44,7 +44,7 @@ def main():
 
     scope_version = get_scope_version(args.scope_path)
     logging.info(f"Scope Version: {scope_version}")
-    test_watcher = TestWatcher(execution_id, scope_version)
+    test_watcher = TestWatcher(execution_id)
     test_watcher.start()
     scope_data_collector = ScopeDataCollector()
 

--- a/test/testContainers/test_runner/runner.py
+++ b/test/testContainers/test_runner/runner.py
@@ -101,7 +101,7 @@ class Runner:
                 if data:
                     logging.info(data)
 
-            time.sleep(1)
+            self.__collector.wait()
             scope_messages = self.__collector.get_all()
             logging.info(f"Received {len(scope_messages)} messages from scope")
             if len(scope_messages) > 0: logging.debug(f"Last 10 messages:\n {''.join(scope_messages[-9:])}")

--- a/test/testContainers/test_runner/scope.py
+++ b/test/testContainers/test_runner/scope.py
@@ -1,10 +1,11 @@
+import abc
 import logging
 import socketserver
 import subprocess
+import time
 import threading
 
-
-def get_scope_version(scope_path):
+def get_scope_version(scope_path: str) -> str:
     completed_proc = subprocess.run([scope_path], universal_newlines=True, stdout=subprocess.PIPE)
     stdout = completed_proc.stdout
     for line in stdout.splitlines():
@@ -14,51 +15,118 @@ def get_scope_version(scope_path):
 
 class ScopeDataCollector:
 
-    def __init__(self):
+    def __init__(self, metric_type: str) -> None:
+        default_timeouts = {"udp": 1, "tcp": 0.05}
+
+        self.timeout = default_timeouts[metric_type]
         self.__messages = []
 
-    def add(self, msg):
+    def add(self, msg: str) -> None:
         self.__messages.append(msg)
 
-    def get_all(self):
+    def get_all(self) -> list:
         return self.__messages
 
-    def reset(self):
+    def reset(self) -> None:
         logging.debug("Reset collector.")
         self.__messages = []
 
+    def wait(self) -> None:
+        time.sleep(self.timeout)
 
-class ScopeUDPDataListener:
+
+class DataListener(abc.ABC):
+
+    def __init__(self, collector: ScopeDataCollector, host: str, port: int) -> None:
+        self.port = port
+        self.host = host
+        self.collector = collector
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def start_server(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def stop_server(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def create_server(self) -> None:
+        pass
+
+    def start_server_thread(self, server: socketserver.BaseServer) -> None:
+        server_thread = threading.Thread(target=server.serve_forever)
+        # Exit the server thread when the main thread terminates
+        server_thread.daemon = True
+        server_thread.start()
+
+    def __enter__(self) -> 'DataListener':
+        self.start_server()
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb) -> None:
+        self.stop_server()
+
+class ScopeUDPDataListener(DataListener):
+    __server = None
     class __Handler(socketserver.DatagramRequestHandler):
         collector = None
 
         def handle(self):
             self.collector.add(self.rfile.read().decode())
 
-    def __init__(self, collector: ScopeDataCollector, host, port):
-        self.port = port
-        self.host = host
-        self.collector = collector
-        self.__server = None
+    @property
+    def name(self) -> str:
+        return "UDP"
 
-    def start(self):
+    def create_server(self) -> socketserver.ThreadingUDPServer:
         self.__Handler.collector = self.collector
+        logging.info(f"Starting scope {self.name} listener at {self.host}:{self.port}")
+        return socketserver.ThreadingUDPServer((self.host, self.port), self.__Handler)
 
-        logging.info(f"Starting scope UDP listener at {self.host}:{self.port}")
-        self.__server = socketserver.ThreadingUDPServer((self.host, self.port), self.__Handler)
+    def start_server(self) -> None:
+        self.__server = self.create_server()  
+        self.start_server_thread(self.__server)
 
-        server_thread = threading.Thread(target=self.__server.serve_forever)
-        # Exit the server thread when the main thread terminates
-        server_thread.daemon = True
-        server_thread.start()
+    def stop_server(self) -> None:
+         logging.info(f"Stopping scope {self.name} listener.")
+         self.__server.shutdown()
 
-    def stop(self):
-        logging.info("Stopping scope UDP listener.")
-        self.__server.shutdown()
+class ScopeTCPDataListener(DataListener):
+    server = None
 
-    def __enter__(self):
-        self.start()
-        return self
+    class __Handler(socketserver.StreamRequestHandler):
+        collector = None
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.stop()
+        def handle(self):
+            for line in self.rfile.readlines():  
+                self.collector.add(line.decode())
+
+    @property
+    def name(self) -> str:
+        return "TCP"
+
+    def create_server(self) ->  socketserver.ThreadingTCPServer:
+        self.__Handler.collector = self.collector
+        logging.info(f"Starting scope {self.name} listener at {self.host}:{self.port}")
+        return socketserver.ThreadingTCPServer((self.host, self.port), self.__Handler)
+
+    def start_server(self) -> None:
+        self.__server = self.create_server()  
+        self.start_server_thread(self.__server)
+
+    def stop_server(self) -> None:
+         logging.info(f"Stopping scope {self.name} listener.")
+         self.__server.shutdown()
+
+def create_listener(type: str, collector: ScopeDataCollector) -> DataListener:
+    default_listeners = {"udp": ScopeUDPDataListener, "tcp": ScopeTCPDataListener}
+    
+    listener = default_listeners[type]
+    return listener(collector, "localhost", 8125)
+

--- a/test/testContainers/test_runner/syscalls.py
+++ b/test/testContainers/test_runner/syscalls.py
@@ -102,12 +102,20 @@ def configure(runner: Runner, app_config):
         included_tests = location.get("include_tests", [])
         excluded_tests = location.get("exclude_tests", [])
         arch = subprocess.check_output(["uname","-m"])
+        loader = subprocess.run(["ldd","--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout
+
         if b'x86_64' in arch:
             logging.info("merging x86_64 excluded tests")
             excluded_tests = excluded_tests + location.get("exclude_x86_64_tests", [])
         elif b'aarch64' in arch:
             logging.info("merging aarch64 excluded tests")
             excluded_tests = excluded_tests + location.get("exclude_aarch64_tests", [])
+        if b'musl libc' in loader:
+            logging.info("merging musl loader excluded tests")
+            excluded_tests = excluded_tests + location.get("exclude_musl_tests", [])
+        elif b'GLIBC' in loader:
+            logging.info("merging glibc loader excluded tests")
+            excluded_tests = excluded_tests + location.get("exclude_glibc_tests", [])
 
         tests = locate_tests(home_dir, included_tests, excluded_tests)
 

--- a/test/testContainers/test_runner/watcher.py
+++ b/test/testContainers/test_runner/watcher.py
@@ -7,7 +7,7 @@ from common import TestSetResult, TestResult
 
 class TestWatcher:
 
-    def __init__(self, execution_id, scope_version):
+    def __init__(self, execution_id):
         self.execution_id = execution_id
         self.finish_date = None
         self.start_date = None


### PR DESCRIPTION
- [x] Required #606 
- [x] Investigate failing test under scope: x86_64/aarch64 ` ldscope /opt/test/ltp/testcases/kernel/syscalls/send/send02`
- [x] Investigate integration on CI

The root cause of failing test:

 - the `msghdr` structure implementation in musl is compatible with POSIX standard [1]
- the `msghdr` structure implementation in glibc is not compatible with POSIX [2][3]:
```
      "According to POSIX.1, the msg_controllen field of the msghdr
      structure should be typed as socklen_t, and the msg_iovlen field
      should be typed as int, but glibc currently types both as size_t."
```

 - `msghdr` structure according to POSIX standard includes at least the following members [4]:
```
      void         *msg_name;
      socklen_t     msg_namelen;
      struct iovec *msg_iov;
      int           msg_iovlen;
      void         *msg_control;
      socklen_t     msg_controllen;
      int           msg_flags;
```
 - `msghdr` structure implementation on glibc:
```
      struct msghdr {
        void         *msg_name;
        socklen_t     msg_namelen;
        struct iovec *msg_iov;
        size_t        msg_iovlen;
        void         *msg_control;
        size_t        msg_controllen;
        int           msg_flags;
      };
```
 - `msghdr` structure implementation on musl (Little Endian):
```
      struct msghdr {
        void         *msg_name;
        socklen_t     msg_namelen;
        struct iovec *msg_iov;
        int           msg_iovlen;
        int           __pad1;
        void         *msg_control;
        socklen_t     msg_controllen;
        int           __pad2;
        int           msg_flags;
      };
```
The main differences between glibc and musl implementation are:   
 - different type of fields `msg_iovlen` and `msg_controllen`
 - musl have additional members as `int __pad1` and `int __pad2` [5][6]
    
In the AppScope library we use glibc implementation so we need to adjust the
`msg_iovlen` and `msg_controllen` interpretation when scoping under musl.
    
Link: https://repo.or.cz/w/musl-tools.git/blob_plain/HEAD:/tab_posix.html [1]
Link: https://man7.org/linux/man-pages/man2/send.2.html [2]
Link: https://man7.org/linux/man-pages/man2/recvmsg.2.html [3]
Link: https://pubs.opengroup.org/onlinepubs/009695299/basedefs/sys/socket.h.html [4]
Link: https://git.musl-libc.org/cgit/musl/commit/?id=a0252bc75b8546008c6b87e58344c4340683d5eb [5]
Link: https://git.musl-libc.org/cgit/musl/commit/?id=7168790763cdeb794df52be6e3b39fbb021c5a64 [6]

