### PR TITLE
Extend triggering workflow config for PR event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,9 @@ on:
   push:
   # Run on manually triggered workflow
   workflow_dispatch:
-  # Run on PRs targeting the default branch or a release branche
+  # Run on PRs targeting the default branch or a release branches
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 'main'
       - 'master'


### PR DESCRIPTION
- enable to run GitHub workflow with integration tests, when
  changing Pull Request state from "Draft" to "Ready to review"
- "By default, a workflow only runs when a pull_request's activity type
   is opened, synchronize, or reopened. To trigger workflows for more
   activity types, use the types keyword."[1]

Link: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request [1]