### PR TITLE
Exclude ASCII escape character from binary data detection

### DIFF
--- a/src/ctl.c
+++ b/src/ctl.c
@@ -22,6 +22,7 @@
 
 #define BINARY_DATA_MSG "Binary data detected--- message"
 #define DEFAULT_BINARY_DATA_SAMPLE_SIZE (256U)
+#define ESC_CHARACTER (0x1B)
 
 typedef struct {
     char *buf;
@@ -838,7 +839,7 @@ is_data_binary(const void *buf, size_t count)
     size_t min_len = (count < DEFAULT_BINARY_DATA_SAMPLE_SIZE) ? count : DEFAULT_BINARY_DATA_SAMPLE_SIZE;
     size_t i;
     for (i = 0; i < min_len; i++) {
-        if (!isprint(b_buf[i]) && (!isspace(b_buf[i]))) {
+        if (!isprint(b_buf[i]) && !isspace(b_buf[i]) && b_buf[i] != ESC_CHARACTER) {
             return TRUE;
         }
     }

--- a/test/testContainers/console/Dockerfile
+++ b/test/testContainers/console/Dockerfile
@@ -3,10 +3,12 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update \
     && apt install -y \
+      bsdmainutils \
       curl \
+      xxd \
     && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /opt/test/log
+RUN mkdir -p /opt/test/log && mkdir -p /opt/tar_test
 
 ENV SCOPE_LOG_LEVEL=error
 ENV SCOPE_METRIC_VERBOSITY=4

--- a/test/testContainers/console/scope-test
+++ b/test/testContainers/console/scope-test
@@ -74,7 +74,6 @@ ERR+=$?
 
 endtest
 
-
 #
 # curl png
 #
@@ -101,6 +100,68 @@ if [ $? -ne 0 ]; then
 fi
 
 evaltest
+
+endtest
+
+#
+# ls with color - including ASCII ESC character (negative test)
+#
+
+starttest ls_with_color
+
+ldscope ls --color=always > /dev/null
+evaltest
+grep "$BINARY_MSG" $EVT_FILE > /dev/null
+if [ $? -eq 0 ]; then
+    ERR+=1
+fi
+
+endtest
+
+#
+# hexdump (negative test)
+#
+
+starttest hexdump
+
+ldscope hexdump /usr/local/scope/lib/libscope.so > /dev/null
+evaltest
+grep "$BINARY_MSG" $EVT_FILE > /dev/null
+if [ $? -eq 0 ]; then
+    ERR+=1
+fi
+
+endtest
+
+#
+# xxd (negative test)
+#
+
+starttest xxd
+
+ldscope xxd /usr/local/scope/lib/libscope.so > /dev/null
+evaltest
+grep "$BINARY_MSG" $EVT_FILE > /dev/null
+if [ $? -eq 0 ]; then
+    ERR+=1
+fi
+
+endtest
+
+#
+# tar
+#
+
+starttest tar_to_stdout
+
+cd /opt/tar_test
+tar -Pczvf test.tar.gz /usr/bin > /dev/null
+
+ldscope tar -PxOzf test.tar.gz > /dev/null
+evaltest
+
+grep "$BINARY_MSG" $EVT_FILE > /dev/null
+ERR+=$?
 
 endtest
 


### PR DESCRIPTION
- extend tests with one which confirms fix: `ls --color=always`
- extend tests with negative tests (`xxd`, `hexdump`)
- closes: #574