### PR TITLE
Collect uid and gid

### DIFF
--- a/cli/run/run_test.go
+++ b/cli/run/run_test.go
@@ -53,6 +53,8 @@ func TestRunPassthrough(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "true\n", outb.String())
 	assert.Contains(t, errb.String(), "proc.start")
+	assert.Contains(t, errb.String(), "gid:")
+	assert.Contains(t, errb.String(), "uid:")
 }
 
 func TestRun(t *testing.T) {

--- a/src/com.c
+++ b/src/com.c
@@ -54,6 +54,8 @@ sendProcessStartMetric()
     event_field_t fields[] = {
         STRFIELD("proc", (g_proc.procname), 4, TRUE),
         NUMFIELD("pid", (g_proc.pid), 4, TRUE),
+        NUMFIELD("gid", (g_proc.gid), 4, TRUE),
+        NUMFIELD("uid", (g_proc.uid), 4, TRUE),
         STRFIELD("host", (g_proc.hostname), 4, TRUE),
         STRFIELD("args", (command), 7, TRUE),
         STRFIELD("unit", ("process"), 1, TRUE),

--- a/src/com.c
+++ b/src/com.c
@@ -189,6 +189,8 @@ jsonProcessObject(proc_id_t *proc)
 
     if (!(cJSON_AddNumberToObjLN(root, "pid", proc->pid))) goto err;
     if (!(cJSON_AddNumberToObjLN(root, "ppid", proc->ppid))) goto err;
+    if (!(cJSON_AddNumberToObjLN(root, "gid", proc->gid))) goto err;
+    if (!(cJSON_AddNumberToObjLN(root, "uid", proc->uid))) goto err;
     if (!(cJSON_AddStringToObjLN(root, "hostname", proc->hostname))) goto err;
     if (!(cJSON_AddStringToObjLN(root, "procname", proc->procname))) goto err;
     if (proc->cmd) {

--- a/test/comtest.c
+++ b/test/comtest.c
@@ -75,6 +75,8 @@ msgStartHasExpectedSubNodes(void** state)
 {
     proc_id_t proc = {.pid = 4848,
                       .ppid = 4847,
+                      .gid = 4849,
+                      .uid = 4850,
                       .hostname = "host",
                       .procname = "comtest",
                       .cmd = "cmd",

--- a/website/src/pages/docs/cli-using.md
+++ b/website/src/pages/docs/cli-using.md
@@ -139,7 +139,7 @@ To see the monitoring and visualization features AppScope offers, exercise some 
 
 ```
 NAME         	VALUE	TYPE 	UNIT       	PID	TAGS
-proc.start   	1    	Count	process    	525	args: %2Fusr%2Fbin%2Fps%20-ef,host: 771f60292e26,proc: ps
+proc.start   	1    	Count	process    	525	args: %2Fusr%2Fbin%2Fps%20-ef,gid: 0,host: 771f60292e26,proc: ps,uid: 0
 proc.cpu     	10000	Count	microsecond	525	host: 771f60292e26,proc: ps
 proc.cpu_perc	0.1  	Gauge	percent    	525	host: 771f60292e26,proc: ps
 proc.mem     	16952	Gauge	kibibyte   	525	host: 771f60292e26,proc: ps


### PR DESCRIPTION
Ref #229 

~~- [ ] not strictly related to the original issue but more with converting the `uid` and `gid` values to names e.g. in Agent (@pdugas). Looking up for these values can be non-portable so the idea is to retrieve it and store it on the Appscope side
Ref: https://man7.org/linux/man-pages/man3/getpwent.3.html~~
