### PR TITLE
Remove scopeLog call which results with stack overflow

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -2120,7 +2120,6 @@ doWrite(int fd, uint64_t initialTime, int success, const void *buf, ssize_t byte
     struct net_info_t *net = getNetEntry(fd);
 
     if (success) {
-        scopeLog(CFG_LOG_TRACE, "fd:%d %s", fd, func);
         if (net) {
             // This is a network descriptor
             doSetAddrs(fd);

--- a/test/testContainers/console/scope-test
+++ b/test/testContainers/console/scope-test
@@ -89,6 +89,21 @@ ERR+=$?
 
 endtest
 
+#
+# trace log level
+#
+
+starttest trace_level_test
+
+SCOPE_LOG_LEVEL=trace ldscope ps -ef
+if [ $? -ne 0 ]; then
+    ERR+=1
+fi
+
+evaltest
+
+endtest
+
 unset SCOPE_PAYLOAD_ENABLE
 unset SCOPE_PAYLOAD_HEADER
 


### PR DESCRIPTION
- avoid stack overflow with `doWrite` when log destination path
  is file

  `doWrite`
     |
  'scopeLog'
     |
  'logSend'
     |
  'transportSend'
     |
  '__write_libc'
     |
  `doWrite`
  ...

closes #645