### PR TITLE
Fix overwrite file descriptor owned by the AppScope by the application (dup2)

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -293,29 +293,11 @@ shutdownTlsSession(transport_t *trans)
             // protocol error occurred
             int ssl_err = SSL_get_error(trans->net.tls.ssl, ret);
             scopeLogInfo("Client SSL_shutdown failed: ssl_err=%d\n", ssl_err);
-        } else if (ret == 0) {
-            // shutdown not complete, call again
-            char buf[4096];
-            while(1) {
-               ret = SCOPE_SSL_read(trans->net.tls.ssl, buf, sizeof(buf));
-               if (ret <= 0) {
-                   break;
-               }
-            }
-
-            ret = SSL_shutdown(trans->net.tls.ssl);
-            if (ret != 1) {
-                // second shutdown not successful
-                int ssl_err = SSL_get_error(trans->net.tls.ssl, ret);
-                scopeLogInfo("Waiting for server shutdown using SSL_shutdown failed: ssl_err=%d\n", ssl_err);
-            }
         }
-    }
-
-    if (trans->net.tls.ssl) {
         SSL_free(trans->net.tls.ssl);
         trans->net.tls.ssl = NULL;
     }
+
     if (trans->net.tls.ctx) {
         SSL_CTX_free(trans->net.tls.ctx);
         trans->net.tls.ctx = NULL;

--- a/src/transport.c
+++ b/src/transport.c
@@ -254,8 +254,8 @@ transportNeedsConnection(transport_t *trans)
     return 0;
 }
 
-const char *
-rootCertFile(transport_t *trans)
+static const char *
+rootCertFile(void)
 {
     // Based off of this: https://golang.org/src/crypto/x509/root_linux.go
     const char* rootFileList[] = {
@@ -370,7 +370,7 @@ establishTlsSession(transport_t *trans)
     // If the configuration provides a cacertpath, use it.
     // Otherwise, find a distro-specific root cert file.
     const char *cafile = trans->net.tls.cacertpath;
-    if (!cafile) cafile = rootCertFile(trans);
+    if (!cafile) cafile = rootCertFile();
 
     long loc_rv = SSL_CTX_load_verify_locations(trans->net.tls.ctx, cafile, NULL);
     if (trans->net.tls.validateserver && !loc_rv) {

--- a/src/transport.c
+++ b/src/transport.c
@@ -202,7 +202,7 @@ transportConnection(transport_t *trans)
 int
 transportNeedsConnection(transport_t *trans)
 {
-    if (!trans) return 0;
+    if (!trans) return FALSE;
     switch (trans->type) {
         case CFG_UDP:
         case CFG_TCP:
@@ -243,7 +243,7 @@ transportNeedsConnection(transport_t *trans)
         default:
             DBG(NULL);
     }
-    return 0;
+    return FALSE;
 }
 
 static const char *

--- a/src/transport.c
+++ b/src/transport.c
@@ -162,14 +162,6 @@ placeDescriptor(int fd, transport_t *t)
     return -1;
 }
 
-int
-transportSetFD(int fd, transport_t *trans)
-{
-    if (!trans) return -1;
-
-    return placeDescriptor(fd, trans);
-}
-
 cfg_transport_t
 transportType(transport_t *trans)
 {

--- a/src/transport.h
+++ b/src/transport.h
@@ -35,7 +35,6 @@ int                 transportConnection(transport_t *);
 int                 transportDisconnect(transport_t *);
 int                 transportReconnect(transport_t *);
 cfg_transport_t     transportType(transport_t *);
-int                 transportSetFD(int, transport_t *);
 uint64_t            transportConnectAttempts(transport_t *);
 net_fail_t          transportFailureReason(transport_t *);
 

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -4202,6 +4202,14 @@ EXPORTON int
 dup2(int oldfd, int newfd)
 {
     WRAP_CHECK(dup2, -1);
+
+    if (isAnAppScopeConnection(newfd)) {
+        if (newfd == ctlConnection(g_ctl, CFG_CTL)) ctlDisconnect(g_ctl, CFG_CTL);
+        if (newfd == ctlConnection(g_ctl, CFG_LS)) ctlDisconnect(g_ctl, CFG_LS);
+        if (newfd == mtcConnection(g_mtc)) mtcDisconnect(g_mtc);
+        if (newfd == logConnection(g_log)) logDisconnect(g_log);
+    }
+
     int rc = g_fn.dup2(oldfd, newfd);
 
     doDup2(oldfd, newfd, rc, "dup2");
@@ -4213,6 +4221,14 @@ EXPORTON int
 dup3(int oldfd, int newfd, int flags)
 {
     WRAP_CHECK(dup3, -1);
+
+    if (isAnAppScopeConnection(newfd)) {
+        if (newfd == ctlConnection(g_ctl, CFG_CTL)) ctlDisconnect(g_ctl, CFG_CTL);
+        if (newfd == ctlConnection(g_ctl, CFG_LS)) ctlDisconnect(g_ctl, CFG_LS);
+        if (newfd == mtcConnection(g_mtc)) mtcDisconnect(g_mtc);
+        if (newfd == logConnection(g_log)) logDisconnect(g_log);
+    }
+
     int rc = g_fn.dup3(oldfd, newfd, flags);
     doDup2(oldfd, newfd, rc, "dup3");
 


### PR DESCRIPTION
While waiting for actual connection (when TCP connection is
pending) the socket was already created by the AppScope and
stored in `net.pending_connect` field.
The file descriptor returned by the `socket` function will be
the lowest-number file descriptor not currently open for the
process[1] e.g. with value equals 3.

The scoped application can try to use low id file descriptor for
`dup2(oldf,newfd)` function. If the new file descriptor (`newfd`)
will be equal to file descriptor previously used for socket
creation, then the socket will be silenty closed [2] and file
descriptor will be reused for the application purpose:
duplication of `oldfd`.

After this operation value stored in `net.pending_connect` does
not point longer to a socket initially created by the AppScope.
The file descriptor now belongs to the scoped application.

Later AppScope in `checkPendingSocketStatus` will try to verify
socket status using `getsockopt` and can fail if the file
descriptor now points for something different than the socket,
e.g. the pipe. After failing AppScope will close the file
descriptor which now belongs to the scoped application.

This results in an issue that if the application later will try
to use the file descriptor closed by the Appscope it will fail.

-- [**Appscope**] Starts TCP connection by creating a socket
-- [**FD state**] File descriptor 3 points to a socket
-- [**Appscope**] value 3 is stored in `net.pending_connect` field
-- ...
-- [**Application**] Duplicate stdout to fd=3, `dup2(1,3)`
-- [**FD state**] File descriptor 3 points to a pipe
-- [**Appscope**] Tries to finish starting connection procedure
-- [**Appscope**] `getsockopt` fails
-- [**Appscope**] `close` is called for value stored in `net.pending_connect`
-- [**FD state**] File descriptor 3 is closed now
-- ...
-- [**Application**] Duplicate fd=3 to stdout, `dup2(3,1)` fails
-- [**Application**] errno=EBADF because the file descriptor 3 was closed

The solution is to fix file descriptor acquisition by moving
the file descriptor right after socket creation in
`socketConnectionStart`.

Link: https://man7.org/linux/man-pages/man2/socket.2.html [1]
Link: https://man7.org/linux/man-pages/man2/dup.2.html [2]