### PR TITLE
Modify timestamps format (add time zone info)

### DIFF
--- a/src/wrap.c
+++ b/src/wrap.c
@@ -4860,6 +4860,7 @@ getentropy(void *buffer, size_t length)
 
 #define LOG_BUF_SIZE 4096
 #define LOG_TIME_SIZE 23
+#define LOG_TZ_BUF_SIZE 7
 
 // This overrides a weak definition in src/dbg.c
 void
@@ -4869,6 +4870,7 @@ scopeLog(cfg_log_level_t level, const char *format, ...)
     const char overflow_msg[] = "WARN: scopeLog msg truncated.\n";
     char *local_buf;
     char time_buf[LOG_TIME_SIZE];
+    char tz_buf[LOG_TZ_BUF_SIZE];
     int msec;
     struct tm tm_info;
     struct timeval tv;
@@ -4918,9 +4920,10 @@ scopeLog(cfg_log_level_t level, const char *format, ...)
         msec = 0;
     }
     localtime_r(&tv.tv_sec, &tm_info);
-    strftime(time_buf, LOG_TIME_SIZE, "%Y-%m-%d %H:%M:%S", &tm_info);
+    strftime(time_buf, LOG_TIME_SIZE, "%Y-%m-%dT%H:%M:%S", &tm_info); 
+    strftime(tz_buf, LOG_TZ_BUF_SIZE, "%z", &tm_info); 
 
-    local_buf = scope_log_var_buf + snprintf(scope_log_var_buf, LOG_BUF_SIZE, "Scope: %s(pid:%d): [%s.%03d] ", g_proc.procname, g_proc.pid, time_buf, msec);
+    local_buf = scope_log_var_buf + snprintf(scope_log_var_buf, LOG_BUF_SIZE, "Scope: %s(pid:%d): [%s.%03d%s] ", g_proc.procname, g_proc.pid, time_buf, msec, tz_buf);
     size_t local_buf_len = sizeof(scope_log_var_buf) + (scope_log_var_buf - local_buf) - 1;
 
     va_list args;


### PR DESCRIPTION
Change it from previous format [1]:
e.g. "2021-10-20 17:48:33.972"
To ISO 8601:
YYYY-MM-DDThh:mm:ss.sTZD
e.g. "1997-07-16T19:20:30.45+01:00"

Link: #618 [1]
closes #678