### PR TITLE
Add firefox test

### DIFF
--- a/test/testContainers/console/Dockerfile
+++ b/test/testContainers/console/Dockerfile
@@ -5,6 +5,7 @@ RUN apt update \
     && apt install -y \
       bsdmainutils \
       curl \
+      firefox \
       xxd \
     && rm -rf /var/lib/apt/lists/*
 

--- a/test/testContainers/console/scope-test
+++ b/test/testContainers/console/scope-test
@@ -45,6 +45,22 @@ export SCOPE_PAYLOAD_ENABLE=true
 export SCOPE_PAYLOAD_HEADER=true
 
 #
+# test firefox
+#
+starttest firefox
+
+scope run -- firefox --headless &
+scope_pid=$!
+sleep 1
+
+kill -s 0 $scope_pid
+if [ $? -ne 0 ]; then
+    ERR+=1
+fi
+
+endtest
+
+#
 # cat html (negative test)
 #
 


### PR DESCRIPTION
closes #624

The following test pass on the current master branch but it fails on e.g. `v0.8.0-rc0` tag (state before PR #621)