### PR TITLE
Update website/deploy.sh to account for updated node version.

### DIFF
--- a/website/deploy.sh
+++ b/website/deploy.sh
@@ -4,7 +4,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd ${DIR}
 
-# for debugging...
+# manage the version of node used
+echo "versions of npm and node originally provided by the environment"
+npm --version
+node --version
+nvm install 14.18.1
+nvm use 14.18.1
+echo "versions of npm and node we're going to use"
 npm --version
 node --version
 


### PR DESCRIPTION
The last time a website build was successful was Nov 2nd:
https://github.com/criblio/appscope/actions/runs/1418204929

We believe that it was due to a change of default versions of npm and node provided by our github builders...
https://github.com/actions/virtual-environments
