### PR TITLE
Docs/0.8.1 bugathon fixes part 2

### DIFF
--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -79,18 +79,18 @@ scope attach --payloads 2000
 #### Flags
 
 ```
-  -a, --authtoken string      Set AuthToken for Cribl
-  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -a, --authtoken string      Set AuthToken for Cribl LogStream
+  -c, --cribldest string      Set Cribl LogStream destination for metrics & events (host:port defaults to tls://)
   -e, --eventdest string      Set destination for events (host:port defaults to tls://)
   -h, --help                  Help for attach
   -l, --librarypath string    Set path for dynamic libraries
       --loglevel string       Set ldscope log level (debug, warning, info, error, none)
   -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
-      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
-  -n, --nobreaker             Set Cribl to not break streams into events.
-      --passthrough           Runs ldscope with current environment & no config.
+      --metricformat string   Set format of metrics output (statsd|ndjson); default is "ndjson"
+  -n, --nobreaker             Set Cribl LogStream to not break streams into events
+      --passthrough           Runs ldscope with current environment & no config
   -p, --payloads              Capture payloads of network transactions
-  -u, --userconfig string     Run ldscope with a user specified config file. Overrides all other settings.
+  -u, --userconfig string     Run ldscope with a user specified config file; overrides all other settings
   -v, --verbosity int         Set scope metric verbosity (default 4)
 
 ```
@@ -167,7 +167,7 @@ scope events -n 1000 -e 'sourcetype!="console" && source.indexOf("cribl.log") ==
   -f, --follow               Follow a file, like tail -f
   -h, --help                 Help for events
   -i, --id int               Display info from specific from session ID (default -1)
-  -j, --json                 Output as newline delimited JSON
+  -j, --json                 Output as newline-delimited JSON
   -n, --last int             Show last <n> events (default 20)
   -m, --match string         Display events containing supplied string
   -s, --source strings       Display events matching supplied sources
@@ -199,13 +199,13 @@ scope extract --metricdest tcp://some.host:8125 --eventdest tcp://other.host:100
 #### Flags:
  
 ```
-  -a, --authtoken string      Set AuthToken for Cribl
-  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -a, --authtoken string      Set AuthToken for Cribl LogStream
+  -c, --cribldest string      Set Cribl LogStream destination for metrics & events (host:port defaults to tls://)
   -e, --eventdest string      Set destination for events (host:port defaults to tls://)
   -h, --help                  Help for extract
   -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
-      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
-  -n, --nobreaker             Set Cribl to not break streams into events.
+      --metricformat string   Set format of metrics output (statsd|ndjson); default is "ndjson"
+  -n, --nobreaker             Set Cribl LogStream to not break streams into events
 ```
 
 ### flows
@@ -234,7 +234,7 @@ scope flows --out 124x3c   # Displays the outbound payload of that flow
   -h, --help          Help for flows
   -i, --id int        Display flows from specific from session ID (default -1)
       --in            Output contents of the inbound payload. Requires flow ID specified.
-  -j, --json          Output as newline delimited JSON
+  -j, --json          Output as newline-delimited JSON
   -n, --last int      Show last <n> flows (default 20)
       --out           Output contents of the outbound payload. Requires flow ID specified.
   -p, --peer ipNet    Filter to peers in the given network
@@ -246,35 +246,20 @@ scope flows --out 124x3c   # Displays the outbound payload of that flow
 ### help
 ---
 
-Displays help content for any AppScope command. Just type scope help [path to command] for full details.
+Displays help content for any AppScope command. Just type `scope help [path to command]` for full details.
 
 #### Usage
 
-`scope help [command] [flags]`
-
-<!--
+`scope help [command]
 
 #### Examples
 
-`scope foo`
-
--->
-
-#### Flags
-
-```
-  -h, --help   Help for help
-  
-```
+`scope help run`
 
 ### history
 ---
 
-<!-- first sentence is bad, revisit -->
-
-Each scope execution maintains a directory full of information collected by scope. The `history` subcommand lists and 
-prints information about sessions. Session information includes what commands were executed, when they started, how many events they output, and so on.
-
+The `history` subcommand lists and prints information about sessions. Every time you scope a command, that is called an AppScope session. Each session has a directory which is referenced by a session ID. By default, the AppScope CLI stores all the information it collects during a given session in that session's directory. When you run `history`, you see a listing of sessions, one session per scoped command, along with information about when the session started, how many events were output during the session, and so on. 
 
 #### Usage
 
@@ -310,11 +295,7 @@ cat $(scope hist -d)/args.json   # Outputs contents of args.json in the scope hi
 ### k8s
 ---
 
-<!-- verify with John, original is not clear -->
-
-Prints configurations to pass to `kubectl` which then automatically instruments newly-launched containers. This installs
-a mutating admission webhook which adds an `initContainer` to each pod. The webhook also along sets environment variables which install AppScope for all
-processes in that container.
+Prints configurations to pass to `kubectl`, which then automatically instruments newly-launched containers. This installs a mutating admission webhook, which adds an `initContainer` to each pod. The webhook also sets environment variables that install AppScope for all processes in that container.
 
 The `--*dest` flags accept file names like `/tmp/scope.log`; URLs like `file:///tmp/scope.log`; or sockets specified with the pattern `tcp://hostname:port`, `udp://hostname:port`, or `tls://hostname:port`.
 
@@ -333,17 +314,17 @@ kubectl label namespace default scope=enabled
 
 ```
       --app string            Name of the app in Kubernetes (default "scope")
-  -a, --authtoken string      Set AuthToken for Cribl
+  -a, --authtoken string      Set AuthToken for Cribl LogStream
       --certfile string       Certificate file for TLS in the container (mounted secret) (default "/etc/certs/tls.crt")
-  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -c, --cribldest string      Set Cribl LogStream destination for metrics & events (host:port defaults to tls://)
       --debug                 Turn on debug logging in the scope webhook container
   -e, --eventdest string      Set destination for events (host:port defaults to tls://)
   -h, --help                  Help for k8s
       --keyfile string        Private key file for TLS in the container (mounted secret) (default "/etc/certs/tls.key")
   -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
-      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
-      --namespace string      Name of the namespace to install in (default "default")
-  -n, --nobreaker             Set Cribl to not break streams into events.
+      --metricformat string   Set format of metrics output (statsd|ndjson); default is "ndjson"
+      --namespace string      Name of the namespace in which to install; default is "default"
+  -n, --nobreaker             Set Cribl LogStream to not break streams into events
       --port int              Port to listen on (default 4443)
       --server                Run Webhook server
       --version string        Version of scope to deploy
@@ -372,7 +353,7 @@ scope logs
   -i, --id int           Display logs from specific from session ID (default -1)
   -n, --last int         Show last <n> lines (default 20)
   -s, --scope            Show scope.log (from CLI) instead of ldscope.log (from library)
-  -S, --service string   Display logs from a Systemd service instead of a session)
+  -S, --service string   Display logs from a systemd service instead of a session)
  
 ```
 
@@ -436,32 +417,13 @@ List all processes into which the libscope library is injected.
 
 #### Usage
 
-`scope ps [flags]`
-
-<!-- 
-
-No examples, really?
-
-#### Examples
-
-```
-
-```
-
--->
-
-#### Flags
-
-```
-  -h, --help     Help for ps
-  
-```
+`scope ps`
 
 ### run
 ----
 
-Executes a scoped command. By default, calling scope with no subcommands will execute run for the args after 
-scope. However, scope allows for additional arguments to be passed to run to capture payloads or to increase metric 
+Executes a scoped command. By default, calling `scope` with no subcommands will run the executables passed as arguments to 
+`scope`. However, `scope` allows for additional arguments to be passed to `run`, to capture payloads or to increase metrics' 
 verbosity. Must be called with the `--` flag, e.g., `scope watch -- <command>`, to prevent AppScope from attempting to parse flags passed to the executed command.
 
 The `--*dest` flags accept file names like `/tmp/scope.log`; URLs like `file:///tmp/scope.log`; or sockets specified with the pattern `tcp://hostname:port`, `udp://hostname:port`, or `tls://hostname:port`.
@@ -484,18 +446,18 @@ scope run -c tcp://127.0.0.1:10091 -- curl https://wttr.in/94105
 #### Flags
 
 ```
-  -a, --authtoken string      Set AuthToken for Cribl
-  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -a, --authtoken string      Set AuthToken for Cribl LogStream
+  -c, --cribldest string      Set Cribl LogStream destination for metrics & events (host:port defaults to tls://)
   -e, --eventdest string      Set destination for events (host:port defaults to tls://)
   -h, --help                  Help for run
   -l, --librarypath string    Set path for dynamic libraries
       --loglevel string       Set ldscope log level (debug, warning, info, error, none)
   -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
-      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
-  -n, --nobreaker             Set Cribl to not break streams into events.
-      --passthrough           Runs ldscope with current environment & no config.
+      --metricformat string   Set format of metrics output (statsd|ndjson); default is "ndjson"
+  -n, --nobreaker             Set Cribl LogStream to not break streams into events
+      --passthrough           Run ldscope with current environment & no config
   -p, --payloads              Capture payloads of network transactions
-  -u, --userconfig string     Run ldscope with a user specified config file. Overrides all other settings.
+  -u, --userconfig string     Run ldscope with a user specified config file; overrides all other settings.
   -v, --verbosity int         Set scope metric verbosity (default 4)
 
 ```
@@ -518,14 +480,14 @@ scope service  cribl -c tls://in.my-instance.cribl.cloud:10090
 #### Flags
 
 ```
-  -a, --authtoken string      Set AuthToken for Cribl
-  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -a, --authtoken string      Set AuthToken for Cribl LogStream
+  -c, --cribldest string      Set Cribl LogStream destination for metrics & events (host:port defaults to tls://)
   -e, --eventdest string      Set destination for events (host:port defaults to tls://)
       --force                 Bypass confirmation prompt
   -h, --help                  Help for service
   -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
-      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
-  -n, --nobreaker             Set Cribl to not break streams into events.
+      --metricformat string   Set format of metrics output (statsd|ndjson); default is "ndjson"
+  -n, --nobreaker             Set Cribl LogStream to not break streams into events
   -u, --user string           Specify owner username
   
 ```
@@ -552,32 +514,12 @@ scope version --tag
 #### Flags
 
 ```
-      --date      output just the date
+      --date      Output just the date
   -h, --help      Help for version
-      --summary   output just the summary
-      --tag       output just the tag
+      --summary   Output just the summary
+      --tag       Output just the tag
 ```
 
-### --verbose
-----
-
-<!-- this is not a subcommand, what's going on? -->
-
-This flag sets the verbosity level. `0` is least verbose, `4` is the default, and `9` is most verbose. For descriptions of individual levels, see [Config File](/docs/config-file).
-
-#### Usage
-
-```
-scope --verbose <level>
-scope -v <level>
-```
-
-#### Examples
-
-```
-scope --verbose <level>
-scope -v <level>
-```
 ### watch
 ---
 
@@ -600,17 +542,17 @@ scope watch --interval=10s -- curl https://wttr.in/94105
 #### Flags
 
 ```
-  -a, --authtoken string      Set AuthToken for Cribl
-  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -a, --authtoken string      Set AuthToken for Cribl LogStream
+  -c, --cribldest string      Set Cribl LogStream destination for metrics & events (host:port defaults to tls://)
   -e, --eventdest string      Set destination for events (host:port defaults to tls://)
   -h, --help                  Help for watch
   -i, --interval string       Run every <x>(s|m|h)
   -l, --librarypath string    Set path for dynamic libraries
       --loglevel string       Set ldscope log level (debug, warning, info, error, none)
   -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
-      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
-  -n, --nobreaker             Set Cribl to not break streams into events.
-      --passthrough           Runs ldscope with current environment & no config.
+      --metricformat string   Set format of metrics output (statsd|ndjson); default is "ndjson"
+  -n, --nobreaker             Set Cribl LogStream to not break streams into events
+      --passthrough           Run ldscope with current environment & no config
   -p, --payloads              Capture payloads of network transactions
   -u, --userconfig string     Run ldscope with a user specified config file. Overrides all other settings.
   -v, --verbosity int         Set scope metric verbosity (default 4)

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -250,7 +250,7 @@ Displays help content for any AppScope subcommand. Just type `scope help [subcom
 
 #### Usage
 
-`scope help [subcommand]
+`scope help [subcommand]`
 
 #### Examples
 

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -424,7 +424,7 @@ List all processes into which the libscope library is injected.
 
 Executes a scoped command. By default, calling `scope` with no subcommands will run the executables passed as arguments to 
 `scope`. However, `scope` allows for additional arguments to be passed to `run`, to capture payloads or to increase metrics' 
-verbosity. Must be called with the `--` flag, e.g., `scope watch -- <command>`, to prevent AppScope from attempting to parse flags passed to the executed command.
+verbosity. Must be called with the `--` flag, e.g., `scope run -- <command>`, to prevent AppScope from attempting to parse flags passed to the executed command.
 
 The `--*dest` flags accept file names like `/tmp/scope.log`; URLs like `file:///tmp/scope.log`; or sockets specified with the pattern `tcp://hostname:port`, `udp://hostname:port`, or `tls://hostname:port`.
 

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -7,15 +7,15 @@ title: CLI Reference
 
 ### Command Syntax
 
-To execute CLI commands, the basic syntax is:
+To execute CLI subcommands, the basic syntax is:
 
 ```
-./scope <command> [flags] [options]
+./scope <subcommand> [flags] [options]
 ```
 
 ### Commands Available
 
-To see a list of available commands, enter `./scope` alone, or `./scope -h`, or `./scope --help`. This displays the basic help listing below.
+To see a list of available subcommands, enter `./scope` alone, or `./scope -h`, or `./scope --help`. This displays the basic help listing below.
 
 ```
 Cribl AppScope Command Line Interface
@@ -25,7 +25,7 @@ AppScope is a general-purpose observable application telemetry system.
 Running `scope` with no subcommands will execute the `scope run` command.
 
 Usage:
-  scope [command]
+  scope [subcommand]
 
 Available Commands:
   attach      Scope an existing PID
@@ -34,7 +34,7 @@ Available Commands:
   events      Outputs events for a session
   extract     Output instrumentary library files to <dir>
   flows       Observed flows from the session, potentially including payloads
-  help        Help about any command
+  help        Help about any subcommand
   history     List scope session history
   k8s         Install scope in kubernetes
   logs        Display scope logs
@@ -49,14 +49,14 @@ Available Commands:
 Flags:
   -h, --help   Help for scope
 
-Use "scope [command] --help" for more information about a command.
+Use "scope [subcommand] --help" for more information about a subcommand.
 ```
 
-As noted just above, to see a specific command's help or its required parameters, enter: 
-`./scope <command> -h` 
+As noted just above, to see a specific subcommand's help or its required parameters, enter: 
+`./scope <subcommand> -h` 
 
 …or: 
-`./scope help <command> [flags]`.
+`./scope help <subcommand> [flags]`.
 
 ---
 
@@ -246,11 +246,11 @@ scope flows --out 124x3c   # Displays the outbound payload of that flow
 ### help
 ---
 
-Displays help content for any AppScope command. Just type `scope help [path to command]` for full details.
+Displays help content for any AppScope subcommand. Just type `scope help [subcommand]` for full details.
 
 #### Usage
 
-`scope help [command]
+`scope help [subcommand]
 
 #### Examples
 

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -422,7 +422,7 @@ List all processes into which the libscope library is injected.
 ### run
 ----
 
-Executes a scoped command. By default, calling `scope` with no subcommands will run the executables passed as arguments to 
+Executes a scoped command. By default, calling `scope` with no subcommands will run the executables you pass as arguments to 
 `scope`. However, `scope` allows for additional arguments to be passed to `run`, to capture payloads or to increase metrics' 
 verbosity. Must be called with the `--` flag, e.g., `scope run -- <command>`, to prevent AppScope from attempting to parse flags passed to the executed command.
 
@@ -457,7 +457,7 @@ scope run -c tcp://127.0.0.1:10091 -- curl https://wttr.in/94105
   -n, --nobreaker             Set Cribl LogStream to not break streams into events
       --passthrough           Run ldscope with current environment & no config
   -p, --payloads              Capture payloads of network transactions
-  -u, --userconfig string     Run ldscope with a user specified config file; overrides all other settings.
+  -u, --userconfig string     Run ldscope with a user specified config file; overrides all other settings
   -v, --verbosity int         Set scope metric verbosity (default 4)
 
 ```

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -47,7 +47,7 @@ Available Commands:
   watch       Executes a scoped command on an interval
 
 Flags:
-  -h, --help   help for scope
+  -h, --help   Help for scope
 
 Use "scope [command] --help" for more information about a command.
 ```
@@ -57,6 +57,67 @@ As noted just above, to see a specific command's help or its required parameters
 
 …or: 
 `./scope help <command> [flags]`.
+
+---
+
+### attach
+---
+
+Scopes an existing PID. Pass additional arguments if you want to capture payloads or to increase metric verbosity.
+
+#### Usage
+
+`scope attach [flags] [PID]`
+
+#### Examples
+
+```
+scope attach 1000
+scope attach --payloads 2000
+```
+
+#### Flags
+
+```
+  -a, --authtoken string      Set AuthToken for Cribl
+  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -e, --eventdest string      Set destination for events (host:port defaults to tls://)
+  -h, --help                  Help for attach
+  -l, --librarypath string    Set path for dynamic libraries
+      --loglevel string       Set ldscope log level (debug, warning, info, error, none)
+  -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
+      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
+  -n, --nobreaker             Set Cribl to not break streams into events.
+      --passthrough           Runs ldscope with current environment & no config.
+  -p, --payloads              Capture payloads of network transactions
+  -u, --userconfig string     Run ldscope with a user specified config file. Overrides all other settings.
+  -v, --verbosity int         Set scope metric verbosity (default 4)
+
+```
+
+### completion
+---
+
+Generates completion code for specified shell.
+
+#### Usage
+
+`scope completion [bash|zsh] [flags]`
+
+#### Examples
+
+```
+scope completion bash > /etc/bash_completion.d/scope  # Generates and installs scope autocompletion for bash
+source <(scope completion bash)                       # Generates and loads scope autocompletion for bash
+```
+
+#### Flags
+
+```
+  -h, --help   Help for completion
+  
+```
+
 
 ### dash
 ---
@@ -74,7 +135,7 @@ Displays an interactive dashboard with an overview of what's happening with the 
 #### Flags
 
 ```
-  -h, --help     help for dash
+  -h, --help     Help for dash
   -i, --id int   Display info from specific from session ID (default -1)
 ```
 
@@ -104,7 +165,7 @@ scope events -n 1000 -e 'sourcetype!="console" && source.indexOf("cribl.log") ==
       --color                Force color on (if tty detection fails or pipeing)
   -e, --eval string          Evaluate JavaScript expression against event. Must return truthy to print event.
   -f, --follow               Follow a file, like tail -f
-  -h, --help                 help for events
+  -h, --help                 Help for events
   -i, --id int               Display info from specific from session ID (default -1)
   -j, --json                 Output as newline delimited JSON
   -n, --last int             Show last <n> events (default 20)
@@ -119,7 +180,10 @@ scope events -n 1000 -e 'sourcetype!="console" && source.indexOf("cribl.log") ==
 Outputs `ldscope`, `libscope.so`, `scope.yml`, and `scope_protocol.yml` to the provided directory. You can configure these files to instrument any application, and to output the data to any existing tool via simple TCP protocols. The `libscope` component can easily be used with any dynamic or static application, regardless of the runtime.
 
 #### Usage
-  `scope extract (<dir>) [flags]`
+
+<!-- Do we have the arguments in correct order? John's notes reverse them. -->
+
+  `scope extract [flags] (<dir>)`
 
 #### Aliases:
   `extract`, `excrete`, `expunge`, `extricate`, `exorcise`
@@ -129,18 +193,88 @@ Outputs `ldscope`, `libscope.so`, `scope.yml`, and `scope_protocol.yml` to the p
 ```
 scope extract
 scope extract /opt/libscope
+scope extract --metricdest tcp://some.host:8125 --eventdest tcp://other.host:10070 .
 ```
 
 #### Flags:
  
 ```
-  -h, --help   help for extract
+  -a, --authtoken string      Set AuthToken for Cribl
+  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -e, --eventdest string      Set destination for events (host:port defaults to tls://)
+  -h, --help                  Help for extract
+  -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
+      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
+  -n, --nobreaker             Set Cribl to not break streams into events.
 ```
 
+### flows
+---
+
+Displays observed flows from the given session. If run with payload capture on, outputs full payloads from the flow.
+
+#### Usage
+
+<!-- How should we notate ID arguments? see also scope events -->
+
+`scope flows [flags] <sessionId>`
+
+#### Examples
+
+```
+scope flows                # Displays all flows
+scope flows 124x3c         # Displays more info about the flow
+scope flows --out 124x3c   # Displays the outbound payload of that flow
+```
+
+#### Flags
+
+```
+  -a, --all           Show all flows
+  -h, --help          Help for flows
+  -i, --id int        Display flows from specific from session ID (default -1)
+      --in            Output contents of the inbound payload. Requires flow ID specified.
+  -j, --json          Output as newline delimited JSON
+  -n, --last int      Show last <n> flows (default 20)
+      --out           Output contents of the outbound payload. Requires flow ID specified.
+  -p, --peer ipNet    Filter to peers in the given network
+  -r, --reverse       Reverse sort to ascending
+  -s, --sort string   Sort descending by field (look at JSON output for field names)
+  
+```
+
+### help
+---
+
+Displays help content for any AppScope command. Just type scope help [path to command] for full details.
+
+#### Usage
+
+`scope help [command] [flags]`
+
+<!--
+
+#### Examples
+
+`scope foo`
+
+-->
+
+#### Flags
+
+```
+  -h, --help   Help for help
+  
+```
 
 ### history
 ---
-Lists scope session history.
+
+<!-- first sentence is bad, revisit -->
+
+Each scope execution maintains a directory full of information collected by scope. The `history` subcommand lists and 
+prints information about sessions. Session information includes what commands were executed, when they started, how many events they output, and so on.
+
 
 #### Usage
 
@@ -152,17 +286,94 @@ Lists scope session history.
 
 #### Examples
 
-`scope history`
+```
+scope history                    # Displays session history
+scope hist                       # Shortcut for scope history
+scope hist -r                    # Displays running sessions
+scope hist --id 2                # Displays detailed information for session 2
+scope hist -n 50                 # Displays last 50 sessions
+scope hist -d                    # Displays directory for the last session
+cat $(scope hist -d)/args.json   # Outputs contents of args.json in the scope history directory for the current session
+```
 
 #### Flags
 
 ```
   -a, --all        List all sessions
   -d, --dir        Output just directory (with -i)
-  -h, --help       help for history
+  -h, --help       Help for history
   -i, --id int     Display info from specific from session ID (default -1)
   -n, --last int   Show last <n> sessions (default 20)
   -r, --running    List running sessions
+```
+
+### k8s
+---
+
+<!-- verify with John, original is not clear -->
+
+Prints configurations to pass to `kubectl` which then automatically instruments newly-launched containers. This installs
+a mutating admission webhook which adds an `initContainer` to each pod. The webhook also along sets environment variables which install AppScope for all
+processes in that container.
+
+The `--*dest` flags accept file names like `/tmp/scope.log`; URLs like `file:///tmp/scope.log`; or sockets specified with the pattern `tcp://hostname:port`, `udp://hostname:port`, or `tls://hostname:port`.
+
+#### Usage
+
+`scope k8s [flags]`
+
+#### Examples
+
+```
+scope k8s --metricdest tcp://some.host:8125 --eventdest tcp://other.host:10070 | kubectl apply -f -
+kubectl label namespace default scope=enabled
+```
+
+#### Flags
+
+```
+      --app string            Name of the app in Kubernetes (default "scope")
+  -a, --authtoken string      Set AuthToken for Cribl
+      --certfile string       Certificate file for TLS in the container (mounted secret) (default "/etc/certs/tls.crt")
+  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+      --debug                 Turn on debug logging in the scope webhook container
+  -e, --eventdest string      Set destination for events (host:port defaults to tls://)
+  -h, --help                  Help for k8s
+      --keyfile string        Private key file for TLS in the container (mounted secret) (default "/etc/certs/tls.key")
+  -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
+      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
+      --namespace string      Name of the namespace to install in (default "default")
+  -n, --nobreaker             Set Cribl to not break streams into events.
+      --port int              Port to listen on (default 4443)
+      --server                Run Webhook server
+      --version string        Version of scope to deploy
+
+```
+
+### logs
+---
+
+Displays internal AppScope logs for troubleshooting AppScope itself.
+
+#### Usage
+
+`scope logs [flags]`
+
+#### Examples
+
+```
+scope logs
+```
+
+#### Flags
+
+```
+  -h, --help             Help for logs
+  -i, --id int           Display logs from specific from session ID (default -1)
+  -n, --last int         Show last <n> lines (default 20)
+  -s, --scope            Show scope.log (from CLI) instead of ldscope.log (from library)
+  -S, --service string   Display logs from a Systemd service instead of a session)
+ 
 ```
 
 ### metrics
@@ -183,9 +394,9 @@ Outputs metrics for a session.
 ```
   -c, --cols             Display metrics as columns
   -g, --graph            Graph this metric
-  -h, --help             help for metrics
+  -h, --help             Help for metrics
   -i, --id int           Display info from specific from session ID (default -1)
-  -m, --metric strings   Display only supplied metrics
+  -m, --metric strings   Display for specified metrics only
   -u, --uniq             Display first instance of each unique metric
 ```
 
@@ -214,31 +425,111 @@ Negative arguments are not allowed.
   -a, --all          Delete all sessions
   -d, --delete int   Delete last <delete> sessions
   -f, --force        Do not prompt for confirmation
-  -h, --help         help for prune
+  -h, --help         Help for prune
   -k, --keep int     Keep last <keep> sessions, delete all others
+```
+
+### ps
+---
+
+List all processes into which the libscope library is injected.
+
+#### Usage
+
+`scope ps [flags]`
+
+<!-- 
+
+No examples, really?
+
+#### Examples
+
+```
+
+```
+
+-->
+
+#### Flags
+
+```
+  -h, --help     Help for ps
+  
 ```
 
 ### run
 ----
 
-Executes a scoped command (or application.
+Executes a scoped command. By default, calling scope with no subcommands will execute run for the args after 
+scope. However, scope allows for additional arguments to be passed to run to capture payloads or to increase metric 
+verbosity. Must be called with the `--` flag, e.g., `scope watch -- <command>`, to prevent AppScope from attempting to parse flags passed to the executed command.
+
+The `--*dest` flags accept file names like `/tmp/scope.log`; URLs like `file:///tmp/scope.log`; or sockets specified with the pattern `tcp://hostname:port`, `udp://hostname:port`, or `tls://hostname:port`.
 
 #### Usage
 
-`scope run [flags]`
+`scope run [flags] [command]`
 
 #### Examples
 
-`scope run /bin/echo "foo"`
+```
+scope run -- /bin/echo "foo"
+scope run -- perl -e 'print "foo\n"'
+scope run --payloads -- nc -lp 10001
+scope run -- curl https://wttr.in/94105
+scope run -c tcp://127.0.0.1:10091 -- curl https://wttr.in/94105
+
+```
 
 #### Flags
 
 ```
-  -h, --help            help for run
-      --passthrough     Runs scopec with current environment & no config.
-  -p, --payloads        Capture payloads of network transactions
-  -v, --verbosity int   Set scope metric verbosity (default 4)
+  -a, --authtoken string      Set AuthToken for Cribl
+  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -e, --eventdest string      Set destination for events (host:port defaults to tls://)
+  -h, --help                  Help for run
+  -l, --librarypath string    Set path for dynamic libraries
+      --loglevel string       Set ldscope log level (debug, warning, info, error, none)
+  -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
+      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
+  -n, --nobreaker             Set Cribl to not break streams into events.
+      --passthrough           Runs ldscope with current environment & no config.
+  -p, --payloads              Capture payloads of network transactions
+  -u, --userconfig string     Run ldscope with a user specified config file. Overrides all other settings.
+  -v, --verbosity int         Set scope metric verbosity (default 4)
+
 ```
+
+### service
+---
+
+Configures the specificied `systemd` service to be scoped upon starting.
+
+#### Usage
+
+`scope service SERVICE [flags]`
+
+#### Examples
+
+```
+scope service  cribl -c tls://in.my-instance.cribl.cloud:10090
+```
+
+#### Flags
+
+```
+  -a, --authtoken string      Set AuthToken for Cribl
+  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -e, --eventdest string      Set destination for events (host:port defaults to tls://)
+      --force                 Bypass confirmation prompt
+  -h, --help                  Help for service
+  -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
+      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
+  -n, --nobreaker             Set Cribl to not break streams into events.
+  -u, --user string           Specify owner username
+  
+```
+
 
 ### version
 ----
@@ -255,18 +546,22 @@ Outputs version info.
 scope version
 scope version --date
 scope version --summary
+scope version --tag
 ```
 
 #### Flags
 
 ```
       --date      output just the date
-  -h, --help      help for version
+  -h, --help      Help for version
       --summary   output just the summary
+      --tag       output just the tag
 ```
 
 ### --verbose
 ----
+
+<!-- this is not a subcommand, what's going on? -->
 
 This flag sets the verbosity level. `0` is least verbose, `4` is the default, and `9` is most verbose. For descriptions of individual levels, see [Config File](/docs/config-file).
 
@@ -282,4 +577,42 @@ scope -v <level>
 ```
 scope --verbose <level>
 scope -v <level>
+```
+### watch
+---
+
+Executes a scoped command on an interval. Must be called with the `--` flag, e.g., `scope watch -- <command>`, to prevent AppScope from attempting to parse flags passed to the executed command.
+
+#### Usage
+
+`scope watch [flags]`
+
+#### Examples
+
+```
+scope watch -i 5s -- /bin/echo "foo"
+scope watch --interval=1m-- perl -e 'print "foo\n"'
+scope watch --interval=5s --payloads -- nc -lp 10001
+scope watch -i 1h -- curl https://wttr.in/94105
+scope watch --interval=10s -- curl https://wttr.in/94105
+```
+
+#### Flags
+
+```
+  -a, --authtoken string      Set AuthToken for Cribl
+  -c, --cribldest string      Set Cribl destination for metrics & events (host:port defaults to tls://)
+  -e, --eventdest string      Set destination for events (host:port defaults to tls://)
+  -h, --help                  Help for watch
+  -i, --interval string       Run every <x>(s|m|h)
+  -l, --librarypath string    Set path for dynamic libraries
+      --loglevel string       Set ldscope log level (debug, warning, info, error, none)
+  -m, --metricdest string     Set destination for metrics (host:port defaults to tls://)
+      --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
+  -n, --nobreaker             Set Cribl to not break streams into events.
+      --passthrough           Runs ldscope with current environment & no config.
+  -p, --payloads              Capture payloads of network transactions
+  -u, --userconfig string     Run ldscope with a user specified config file. Overrides all other settings.
+  -v, --verbosity int         Set scope metric verbosity (default 4)
+  
 ```

--- a/website/src/pages/docs/downloading.md
+++ b/website/src/pages/docs/downloading.md
@@ -55,7 +55,7 @@ Now you are ready to explore the CLI:
 
 Where AppScope lives on your system is up to you. To decide wisely, first consider which of the [two ways of working](/docs/working-with) with AppScope fit your situation: ad hoc or planned-out.
 
-For ad hoc exploration and investigation, one choice that follows [standard practice](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) for an "add-on software package" is to locate AppScope in `/opt`. Cribl does not recommend running AppScope from any user's home directory, because if additional users try to run AppScope, file ownership and permissions issues will likely ensue.
+For ad hoc exploration and investigation, one choice that follows [standard practice](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) for an "add-on software package" is to locate AppScope in `/opt`. Cribl does not recommend running AppScope from any user's home directory, because that leads to file ownership and permissions problems if additional users try to run AppScope.
 
 By default, the AppScope CLI will output data to the local filesystem where it's running. While this can work fine for "ad hoc" investigations, it can cause problems for longer-duration scenarios like application monitoring, where the local filesystem may not have room for the data being written. 
 

--- a/website/src/pages/docs/downloading.md
+++ b/website/src/pages/docs/downloading.md
@@ -4,17 +4,15 @@ title: Downloading AppScope
 
 ## Downloading AppScope
 
-Download AppScope, then explore its CLI. Getting started is that easy.
+From [Cribl's download page](https://cribl.io/download/#tab-1), you can download AppScope and then explore its CLI. Getting started is that easy.
 
 You can download AppScope as a binary to run on your Linux OS, or as a container.
 
 ### Download as Binary
 
-First, see [Requirements](/docs/requirements) to ensure that you’re on a supported system. 
+Review the AppScope [Requirements](/docs/requirements) to ensure that you’re completing these steps on a supported system. 
 
-Next, decide on the [best location](#where-from) to run AppScope from (the example commands below download to `/opt/scope`).
-
-Then you can download the most-recent binary from [Cribl's download page](https://cribl.io/download/#tab-1) and follow the instructions there.
+Then, from [Cribl's download page](https://cribl.io/download/#tab-1), download the binary and follow the instructions there.
 
 Or, you can use these CLI commands to directly download the binary and make it executable:
 
@@ -27,7 +25,11 @@ chmod +x /opt/scope
 
 ### Download as Container
 
-Visit the [AppScope repo on Docker Hub](https://hub.docker.com/r/cribl/scope) to download and run the most recently tagged container. The container provides the AppScope binary on Ubuntu 20.04.
+From [Cribl's download page](https://cribl.io/download/#tab-1) you can also download AppScope's most recently tagged Ubuntu container.
+
+This will link you to the [AppScope repo on Docker Hub](https://hub.docker.com/r/cribl/scope), which provides instructions and access to earlier builds.
+
+Each container provides the AppScope binary on Ubuntu 20.04.
 
 ### Verify AppScope
 

--- a/website/src/pages/docs/downloading.md
+++ b/website/src/pages/docs/downloading.md
@@ -49,7 +49,7 @@ Now you are ready to explore the CLI:
 - Try some basic CLI commands in [Using the CLI](/docs/cli-using).
 - See the complete [CLI Reference](/docs/cli-reference).
 
-<span id="where-from"> </span>span>
+<span id="where-from"> </span>
 
 ### What's the Best Location to Run AppScope From?
 

--- a/website/src/pages/docs/downloading.md
+++ b/website/src/pages/docs/downloading.md
@@ -18,9 +18,9 @@ Or, you can use these CLI commands to directly download the binary and make it e
 
 ```
 LATEST=$(curl -Ls https://cdn.cribl.io/dl/scope/latest)
-curl -Lo /opt/scope https://cdn.cribl.io/dl/scope/$LATEST/linux/$(uname -m)/scope
+curl -Lo scope https://cdn.cribl.io/dl/scope/$LATEST/linux/$(uname -m)/scope
 curl -Ls https://cdn.cribl.io/dl/scope/$LATEST/linux/$(uname -m)/scope.md5 | md5sum -c 
-chmod +x /opt/scope
+chmod +x scope
 ```
 
 Congratulations! 

--- a/website/src/pages/docs/downloading.md
+++ b/website/src/pages/docs/downloading.md
@@ -25,7 +25,7 @@ chmod +x /opt/scope
 
 ### Download as Container
 
-From [Cribl's download page](https://cribl.io/download/#tab-1) you can also download AppScope's most recently tagged Ubuntu container.
+From [Cribl's download page](https://cribl.io/download/#tab-1), you can also download AppScope's most recently tagged Ubuntu container.
 
 This will link you to the [AppScope repo on Docker Hub](https://hub.docker.com/r/cribl/scope), which provides instructions and access to earlier builds.
 

--- a/website/src/pages/docs/downloading.md
+++ b/website/src/pages/docs/downloading.md
@@ -4,7 +4,7 @@ title: Downloading AppScope
 
 ## Downloading AppScope
 
-From [Cribl's download page](https://cribl.io/download/#tab-1), you can download AppScope and then explore its CLI. Getting started is that easy.
+From Cribl's download page, you can download AppScope and then explore its CLI. Getting started is that easy.
 
 You can download AppScope as a binary to run from a [suitable location](#where-from) in your Linux OS, or as a container.
 

--- a/website/src/pages/docs/downloading.md
+++ b/website/src/pages/docs/downloading.md
@@ -10,25 +10,24 @@ You can download AppScope as a binary to run on your Linux OS, or as a container
 
 ### Download as Binary
 
-First, see [Requirements](/docs/requirements) to ensure that you’re completing these steps on a supported system. 
+First, see [Requirements](/docs/requirements) to ensure that you’re on a supported system. 
 
-Next, use these commands to download the CLI binary and make it executable:
+Next, decide on the [best location](#where-from) to run AppScope from (the example commands below download to `/opt/scope`).
+
+Then you can download the most-recent binary from [Cribl's download page](https://cribl.io/download/#tab-1) and follow the instructions there.
+
+Or, you can use these CLI commands to directly download the binary and make it executable:
 
 ```
 LATEST=$(curl -Ls https://cdn.cribl.io/dl/scope/latest)
-curl -Lo scope https://cdn.cribl.io/dl/scope/$LATEST/linux/$(uname -m)/scope
+curl -Lo /opt/scope https://cdn.cribl.io/dl/scope/$LATEST/linux/$(uname -m)/scope
 curl -Ls https://cdn.cribl.io/dl/scope/$LATEST/linux/$(uname -m)/scope.md5 | md5sum -c 
-chmod +x scope
+chmod +x /opt/scope
 ```
 
 ### Download as Container
 
-Visit the AppScope repo on Docker Hub to download and run the most recently tagged container:
-
-https://hub.docker.com/r/cribl/scope
-
-The container provides the AppScope binary on Ubuntu 20.04.
-
+Visit the [AppScope repo on Docker Hub](https://hub.docker.com/r/cribl/scope) to download and run the most recently tagged container. The container provides the AppScope binary on Ubuntu 20.04.
 
 ### Verify AppScope
 
@@ -48,10 +47,18 @@ Now you are ready to explore the CLI:
 - Try some basic CLI commands in [Using the CLI](/docs/cli-using).
 - See the complete [CLI Reference](/docs/cli-reference).
 
+<span id="where-from"> </span>span>
+
 ### What's the Best Location to Run AppScope From?
 
 Where AppScope lives on your system is up to you. To decide wisely, first consider which of the [two ways of working](/docs/working-with) with AppScope fit your situation: ad hoc or planned-out.
 
-For ad hoc exploration and investigation, one choice that follows [standard practice](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) for an "add-on software package" is to locate AppScope in `/opt`. Running AppScope from a user's home directory is not recommended.
+For ad hoc exploration and investigation, one choice that follows [standard practice](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) for an "add-on software package" is to locate AppScope in `/opt`. Cribl does not recommend running AppScope from any user's home directory, because if additional users try to run AppScope, file ownership and permissions issues will likely ensue.
 
-You should consider what level of logging you want from AppScope, and where those logs should go, as configured in [`scope.yml`](/docs/config-file). In planned-out scenarios, where AppScope runs persistently (including as a service), these choices can prevent AppScope from using up too much disk space. 
+By default, the AppScope CLI will output data to the local filesystem where it's running. While this can work fine for "ad hoc" investigations, it can cause problems for longer-duration scenarios like application monitoring, where the local filesystem may not have room for the data being written. 
+
+Also consider what level of logging you want from AppScope, and where those logs should go. In planned-out scenarios, where AppScope runs persistently (including as a service), configuring logging judiciously can prevent AppScope from using up too much disk space. 
+
+To customize AppScope's data-writing and logging, edit the [`scope.yml`](/docs/config-file) config file.
+
+

--- a/website/src/pages/docs/downloading.md
+++ b/website/src/pages/docs/downloading.md
@@ -4,7 +4,7 @@ title: Downloading AppScope
 
 ## Downloading AppScope
 
-From Cribl's download page, you can download AppScope and then explore its CLI. Getting started is that easy.
+Download AppScope, then explore its CLI. Getting started is that easy.
 
 You can download AppScope as a binary to run from a [suitable location](#where-from) in your Linux OS, or as a container.
 

--- a/website/src/pages/docs/downloading.md
+++ b/website/src/pages/docs/downloading.md
@@ -47,3 +47,11 @@ Now you are ready to explore the CLI:
 - Run `scope --help` or `scope -h` to view CLI options.
 - Try some basic CLI commands in [Using the CLI](/docs/cli-using).
 - See the complete [CLI Reference](/docs/cli-reference).
+
+### What's the Best Location to Run AppScope From?
+
+Where AppScope lives on your system is up to you. To decide wisely, first consider which of the [two ways of working](/docs/working-with) with AppScope fit your situation: ad hoc or planned-out.
+
+For ad hoc exploration and investigation, one choice that follows [standard practice](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) for an "add-on software package" is to locate AppScope in `/opt`. Running AppScope from a user's home directory is not recommended.
+
+You should consider what level of logging you want from AppScope, and where those logs should go, as configured in [`scope.yml`](/docs/config-file). In planned-out scenarios, where AppScope runs persistently (including as a service), these choices can prevent AppScope from using up too much disk space. 

--- a/website/src/pages/docs/downloading.md
+++ b/website/src/pages/docs/downloading.md
@@ -6,7 +6,7 @@ title: Downloading AppScope
 
 From [Cribl's download page](https://cribl.io/download/#tab-1), you can download AppScope and then explore its CLI. Getting started is that easy.
 
-You can download AppScope as a binary to run on your Linux OS, or as a container.
+You can download AppScope as a binary to run from a [suitable location](#where-from) in your Linux OS, or as a container.
 
 ### Download as Binary
 
@@ -62,5 +62,3 @@ By default, the AppScope CLI will output data to the local filesystem where it's
 Also consider what level of logging you want from AppScope, and where those logs should go. In planned-out scenarios, where AppScope runs persistently (including as a service), configuring logging judiciously can prevent AppScope from using up too much disk space. 
 
 To customize AppScope's data-writing and logging, edit the [`scope.yml`](/docs/config-file) config file.
-
-

--- a/website/src/pages/docs/library-using.md
+++ b/website/src/pages/docs/library-using.md
@@ -8,7 +8,7 @@ To use the library for the first time in a given environment, complete this quic
 
 1. Download AppScope. 
 
-2. Choose a `SCOPE_HOME` directory, i.e., the directory from which AppScope should run in your environment.
+2. Choose a `SCOPE_HOME` directory, i.e., the [directory from which AppScope should run](/docs/downloading.mdx#where-from) in your environment.
 
 3. Extract (`scope extract`) the contents of the AppScope binary into the `SCOPE_HOME` directory.
 

--- a/website/src/pages/docs/library-using.md
+++ b/website/src/pages/docs/library-using.md
@@ -40,7 +40,7 @@ How the library is loaded depends on the type of executable. A dynamic loader ca
 To see the full set of library environment variables, run the following command:
 
 ```
-/opt/scope/assets/ldscope --help | egrep "^[[:space:]]{2}SCOPE_"
+/opt/scope/assets/ldscope --help | egrep "^[[:space:]]{8}SCOPE_"
 ```
 
 For the default settings in the sample `scope.yml` configuration file, see [Config File](/docs/config-file), or inspect the most-recent file on [GitHub](https://github.com/criblio/appscope/blob/master/conf/scope.yml).

--- a/website/src/pages/docs/tls.md
+++ b/website/src/pages/docs/tls.md
@@ -4,12 +4,15 @@ title: Using TLS for Secure Connections
 
 ## Using TLS for Secure Connections
 
-AppScope supports TLS over TCP connections: 
+AppScope supports TLS over TCP connections. Here's how that works:
 
-- AppScope can use TLS when connecting to LogStream or another application (including its events and metrics destinations).
-- LogStream can use TLS when connecting to AppScope over TCP.
+- AppScope can use TLS when connecting to LogStream or another application (including its events and metrics destinations). 
+- Once AppScope establishes the connection, data can flow over that connection **in both directions**. 
+- This means that when you tell AppScope to connect using TLS, the connection is secured by TLS in both directions.
 
-In the `scope.yml` config file, set the `transport : tls` element to `true` to enable TLS. See [Config File](/docs/config-file).
+For security's sake, AppScope never opens ports, nor does it listen for or allow incoming connections.
+
+To enable TLS: In the `scope.yml` [config file](/docs/config-file), set the `transport : tls` element to `true`.
 
 To see the TLS-related environment variables, run the command: 
 

--- a/website/src/pages/docs/updating.md
+++ b/website/src/pages/docs/updating.md
@@ -4,7 +4,7 @@ title: Updating
 
 ## Updating
 
-You can update AppScope in place. First, download a fresh version of the binary. (This example assumes that you are running AppScope from `/opt/scope` as described [here](/docs/downloading.mdx#where-from). If you're running AppScope from a different location, adapt the command accordingly.) 
+You can update AppScope in place. First, download a fresh version of the binary. (This example assumes that you are running AppScope from `/opt/scope`, as described [here](/docs/downloading.mdx#where-from). If you're running AppScope from a different location, adapt the command accordingly.) 
 
 ```
 curl -Lo /opt/scope https://s3-us-west-2.amazonaws.com/io.cribl.cdn/dl/scope/cli/linux/scope && chmod 755 /opt/scope

--- a/website/src/pages/docs/updating.md
+++ b/website/src/pages/docs/updating.md
@@ -4,11 +4,10 @@ title: Updating
 
 ## Updating
 
-You can update AppScope in place. First, download a fresh version of the binary:
+You can update AppScope in place. First, download a fresh version of the binary. (This example assumes that you are running AppScope from `/opt/scope` as described [here](/docs/downloading.mdx#where-from). If you're running AppScope from a different location, adapt the command accordingly.) 
 
 ```
-cd <your-appscope-directory>
-curl -Lo scope https://s3-us-west-2.amazonaws.com/io.cribl.cdn/dl/scope/cli/linux/scope && chmod 755 ./scope
+curl -Lo /opt/scope https://s3-us-west-2.amazonaws.com/io.cribl.cdn/dl/scope/cli/linux/scope && chmod 755 /opt/scope
 ```
 
 Then, to confirm the overwrite, verify AppScope's version and build date:


### PR DESCRIPTION
@jrcheli @mQkatz 

Once https://github.com/criblio/appscope/pull/673 has merged, it should be possible to merge this one. I've held back on merging the first because some tests are failing.

The CLI reference has some unresolved issues. See the HTML comments. I corrected some funky grammar from the original help subcommand output. Let's plan to migrate my fixes into the code for 1.0.0 so that in real life, our help output does not cause eyebrows to raise.

