### PR TITLE
Check for attach to a process started from a static exec

### DIFF
--- a/os/linux/os.c
+++ b/os/linux/os.c
@@ -196,18 +196,21 @@ osUnixSockPeer(ino_t lnode)
 }
 
 int
-osGetExePath(char **path)
+osGetExePath(pid_t pid, char **path)
 {
     if (!path) return -1;
     char *buf = *path;
+    char pidpath[PATH_MAX];
 
     if (!(buf = calloc(1, PATH_MAX))) {
         scopeLogError("ERROR:calloc in osGetExePath");
         return -1;
     }
 
-    if (readlink("/proc/self/exe", buf, PATH_MAX - 1) == -1) {
-        scopeLogError("osGetPath: can't get path to self exe");
+    snprintf(pidpath, PATH_MAX, "/proc/%d/exe", pid);
+
+    if (readlink(pidpath, buf, PATH_MAX - 1) == -1) {
+        scopeLogError("osGetExePath: can't get path to pid %d exe", pid);
         free(buf);
         return -1;
     }
@@ -224,7 +227,7 @@ osGetProcname(char *pname, int len)
     } else {
         char *ppath = NULL;
 
-        if (osGetExePath(&ppath) != -1) {
+        if (osGetExePath(getpid(), &ppath) != -1) {
             strncpy(pname, basename(ppath), len);
             if (ppath) free(ppath);
         } else {

--- a/os/linux/os.h
+++ b/os/linux/os.h
@@ -56,7 +56,7 @@ extern bool osThreadInit(void(*handler)(int), unsigned);
 extern int osUnixSockPeer(ino_t);
 extern void osInitJavaAgent(void);
 extern int osGetPageProt(unsigned long);
-extern int osGetExePath(char **);
+extern int osGetExePath(pid_t, char **);
 extern bool osTimerStop(void);
 extern bool osGetCgroup(pid_t, char *, size_t);
 extern char *osGetFileMode(mode_t);

--- a/src/scope.c
+++ b/src/scope.c
@@ -203,17 +203,20 @@ main(int argc, char **argv, char **env)
         }
 
         if ((ebuf = getElf(exe_path)) == NULL) {
+            free(exe_path);
             fprintf(stderr, "error: can't read the executable %s\n", exe_path);
             return EXIT_FAILURE;
         }
 
         if (is_static(ebuf->buf) == TRUE) {
             fprintf(stderr, "error: can't attach to the static executable: %s\nNote that the executable can be 'scoped' using the command 'scope run -- %s'\n", exe_path, exe_path);
+            free(exe_path);
+            freeElf(ebuf->buf, ebuf->len);
             return EXIT_FAILURE;
         }
 
-        if (exe_path) free(exe_path);
-        if (ebuf) freeElf(ebuf->buf, ebuf->len);
+        free(exe_path);
+        freeElf(ebuf->buf, ebuf->len);
 
         printf("Attaching to process %d\n", pid);
         int ret = injectScope(pid, scopeLibPath);

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -1279,7 +1279,7 @@ initHook(int attachedFlag)
 
     // env vars are not always set as needed, be explicit here
     // this is duplicated if we were started from the scope exec
-    if ((osGetExePath(&full_path) != -1) &&
+    if ((osGetExePath(getpid(), &full_path) != -1) &&
         ((ebuf = getElf(full_path))) &&
         (is_static(ebuf->buf) == FALSE) && (is_go(ebuf->buf) == TRUE)) {
 #ifdef __GO__
@@ -1517,7 +1517,7 @@ init(void)
         if (!g_fn.close) g_fn.close = dlsym(RTLD_DEFAULT, "close");
 
         g_ismusl =
-            ((osGetExePath(&full_path) != -1) &&
+            ((osGetExePath(getpid(), &full_path) != -1) &&
             !strstr(full_path, "ldscope") &&
             ((ebuf = getElf(full_path))) &&
             !is_static(ebuf->buf) &&

--- a/test/options.sh
+++ b/test/options.sh
@@ -189,8 +189,7 @@ returns 1
 
 export SCOPE_LIB_PATH=./lib/linux/${ARCH}/libscope.so
 run ./bin/linux/${ARCH}/ldscopedyn -a 999999999
-outputs "fopen(/proc/PID/maps) failed"
-outputs "failed to find libc in target process"
+outputs "error: can't get path to executable for pid 999999999"
 returns 1
 export -n SCOPE_LIB_PATH
 


### PR DESCRIPTION
Resolves #640 
We don't support attach to a process started from a static executable. Add checks for static and emit a descriptive message.