### PR TITLE
Add `edge` support for cfgLogStreamDefault

### DIFF
--- a/src/cfgutils.c
+++ b/src/cfgutils.c
@@ -2637,9 +2637,15 @@ cfgLogStreamDefault(config_t *cfg)
 
     snprintf(g_logmsg, sizeof(g_logmsg), DEFAULT_LOGSTREAM_LOGMSG);
 
-    if (cfgTransportType(cfg, CFG_LS) == CFG_UNIX) {
+    cfg_transport_t ls_type = cfgTransportType(cfg, CFG_LS);
+
+    if (ls_type == CFG_UNIX) {
         const char *path = cfgTransportPath(cfg, CFG_LS);
         cfgTransportPathSet(cfg, CFG_CTL, path);
+    } else if (ls_type == CFG_EDGE) {
+        char* edge_path = cfgEdgePath();
+        cfgTransportPathSet(cfg, CFG_CTL, edge_path);
+        free(edge_path);
     } else {
         // override the CFG_LS transport type to be TCP for type different than UNIX
         cfgTransportTypeSet(cfg, CFG_LS, CFG_TCP);

--- a/test/integration/cli/test_edge.sh
+++ b/test/integration/cli/test_edge.sh
@@ -57,7 +57,7 @@ starttest event_edge
 nc -lU $CRIBL_SOCKET > $DEST_FILE &
 ERR+=$?
 
-SCOPE_EVENT_DEST=edge scope run ls
+scope run --eventdest=edge ls
 ERR+=$?
 
 count=$(grep '"type":"evt"' $DEST_FILE | wc -l)
@@ -76,10 +76,34 @@ starttest event_edge_cribl_home
 nc -lU $CRIBL_HOME_SOCKET > $DEST_FILE &
 ERR+=$?
 
-CRIBL_HOME=$CRIBL_HOME_PATH SCOPE_EVENT_DEST=edge scope run ls
+CRIBL_HOME=$CRIBL_HOME_PATH scope run --eventdest=edge ls
 ERR+=$?
 
 count=$(grep '"type":"evt"' $DEST_FILE | wc -l)
+if [ $count -eq 0 ] ; then
+    ERR+=1
+fi
+
+endtest
+
+#
+# scope cribl destination edge
+#
+
+starttest cribl_edge_cribl_home
+
+nc -lU $CRIBL_HOME_SOCKET > $DEST_FILE &
+ERR+=$?
+
+CRIBL_HOME=$CRIBL_HOME_PATH scope run --cribldest=edge ls
+ERR+=$?
+
+count=$(grep '"type":"evt"' $DEST_FILE | wc -l)
+if [ $count -eq 0 ] ; then
+    ERR+=1
+fi
+
+count=$(grep '"type":"metric"' $DEST_FILE | wc -l)
 if [ $count -eq 0 ] ; then
     ERR+=1
 fi


### PR DESCRIPTION
- fix missing support for `edge` when using `scope run --cribldest`[1]
- the similar solution was already presented for the UNIX destination path
  [2]

Link: 227e82c [1]
Link: 5e395d3 [2]

This Pull Request is an additional fix (post fix) for functionality introduced for the issue: #670 in Pull Request #688
Related: https://github.com/criblio/appscope/issues/700

### QA Instructions:
#### Scenario:
##### Goal: Verify that when using:
- AppScope cli 
- `edge` transport type as `cribl` destination

Terminal 1 - start server listening on UNIX socket /opt/cribl/state/appscope.sock

```
docker run --rm -it cribl/scope:<VERSION_ID>
apt update && apt install netcat -y
mkdir -p /opt/cribl/state/
nc -lU /opt/cribl/state/appscope.sock
```

Terminal 2 - start scoping `ls` using `cribldest`

```
docker exec -it <AppScope_container> bash
scope run -c edge ls
```

Observe that you were able to see events and metrics on Terminal 2.