### PR TITLE
Fix http aggregation 

### DIFF
--- a/src/report.c
+++ b/src/report.c
@@ -3252,6 +3252,13 @@ doConnection(void)
 }
 
 void
+doHttpAgg()
+{
+    httpAggSendReport(g_http_agg, g_mtc);
+    httpAggReset(g_http_agg);
+}
+
+void
 doEvent()
 {
     uint64_t data;
@@ -3292,8 +3299,6 @@ doEvent()
             free(event);
         }
     }
-    httpAggSendReport(g_http_agg, g_mtc);
-    httpAggReset(g_http_agg);
     reportAllCapturedMetrics();
     ctlFlushLog(g_ctl);
     ctlFlush(g_ctl);

--- a/src/report.h
+++ b/src/report.h
@@ -91,6 +91,7 @@ void doProcMetric(metric_t, long long);
 void doStatMetric(const char *, const char *, void *);
 void doTotal(metric_t);
 void doTotalDuration(metric_t);
+void doHttpAgg(void);
 void doEvent(void);
 void doPayload(void);
 bool doConnection(void);

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -26,6 +26,7 @@
 #include "dbg.h"
 #include "dns.h"
 #include "fn.h"
+#include "httpagg.h"
 #include "os.h"
 #include "plattime.h"
 #include "report.h"
@@ -879,6 +880,9 @@ reportPeriodicStuff(void)
     int nthread, nfds, children;
     long long cpu = 0;
     static long long cpuState = 0;
+
+    // aggregate and send http metrics
+    doHttpAgg();
 
     // empty the event queues
     doEvent();

--- a/test/integration/http/Dockerfile
+++ b/test/integration/http/Dockerfile
@@ -5,6 +5,7 @@ RUN apt update && apt install -y \
   emacs \
   gdb \
   net-tools \
+  nginx \
   vim \
 && rm -rf /var/lib/apt/lists/*
 

--- a/test/integration/http/scope-test
+++ b/test/integration/http/scope-test
@@ -74,7 +74,7 @@ if [ ! "$(wait_for_port 10090)" ]; then
     exit 1
 fi
 
-# Each of these testst are running scoped curl connected to the local LogStream's
+# Each of these tests are running scoped curl connected to the local LogStream's
 # AppScope source. Logstream is setup to dump data sent to that source to NDJSON
 # files in ${DEST} named CriblOut-*.json.
 
@@ -272,6 +272,27 @@ else
     ERR+=1
 fi
 endtest
+
+# This test validates that http aggregation is working as expected
+# Scope should aggregate http events within the default summary period
+# even when we exit early (before the summary period elapses)
+starttest "HTTP aggregation"
+scope run -m out.txt -- nginx 
+sleep 2
+curl 127.0.0.1 >/dev/null 2>&1
+curl 127.0.0.1 >/dev/null 2>&1
+curl 127.0.0.1 >/dev/null 2>&1
+sleep 1
+nginx -s stop # kindly exit, to let handleExit() flush the http metrics
+sleep 1
+if grep '"_metric":"http.requests","_metric_type":"counter","_value":3,' out.txt >/dev/null; then
+    echo "PASS: aggregated http.requests found"
+else
+    echo "FAIL: aggregated http.requests not found"
+    ERR+=1
+fi
+endtest
+
 
 # Results
 echo ""


### PR DESCRIPTION
This PR re-instates http aggregation as it was intended. In recent changes, we inadvertently aggregated and sent http metrics every 1ms. We are moving the calls to aggregate http metrics from `doEvent()` into the periodic thread, in the block that runs every [summary time (default 10s)]. As a result, we should see http metrics with the same target and status code be aggregated over periods of 10 seconds.

This PR also adds integration tests to ensure that: aggregation is happening ; http metrics are still sent when we exit before the summary period ends (i.e. 5 seconds).

See #232 for issue and QA instructions.