### PR TITLE
Added /var/run/appscope/appscope.sock as the first option for edge.

### DIFF
--- a/src/cfgutils.c
+++ b/src/cfgutils.c
@@ -769,8 +769,15 @@ cfgMtcVerbositySetFromStr(config_t* cfg, const char* value)
     cfgMtcVerbositySet(cfg, x);
 }
 
+#define EDGE_PATH "/var/run/appscope/appscope.sock"
 static char*
 cfgEdgePath(void){
+    // 1) If EDGE_PATH can be accessed, return that.
+    if (g_fn.access(EDGE_PATH, R_OK|W_OK) == 0) {
+        return strdup(EDGE_PATH);
+    }
+
+    // 2) If CRIBL_HOME is defined, return $CRIBL_HOME/state/appscope.sock
     const char *cribl_home = getenv("CRIBL_HOME");
     if (cribl_home) {
         char new_path[PATH_MAX];
@@ -779,6 +786,7 @@ cfgEdgePath(void){
             return realpath(new_path, NULL);
         }
     }
+    // 3) Otherwise, return /opt/cribl/state/appscope.sock
     return strdup("/opt/cribl/state/appscope.sock");
 }
 


### PR DESCRIPTION
This is a temporary thing to make today's lunch and learn demo go more smoothly.

I'm leaving #707 to do this in a more robust way.  I suspect that we'll need to do more than is being done here to make sure that appscope will be able to connect to edge even if this socket isn't created before appscope is started.