### PR TITLE
Add support for fs delete (unlink/unlinkat) events

### DIFF
--- a/src/fn.c
+++ b/src/fn.c
@@ -164,6 +164,8 @@ initFn(void)
     GETADDR(g_fn.close, "close");
     GETADDR(g_fn.fclose, "fclose");
     GETADDR(g_fn.fcloseall, "fcloseall");
+    GETADDR(g_fn.unlink, "unlink");
+    GETADDR(g_fn.unlinkat, "unlinkat");
     GETADDR(g_fn.read, "read");
     GETADDR(g_fn.pread, "pread");
     GETADDR(g_fn.readv, "readv");

--- a/src/fn.h
+++ b/src/fn.h
@@ -54,6 +54,8 @@ typedef struct {
     int (*close)(int);
     int (*fclose)(FILE *);
     int (*fcloseall)(void);
+    int (*unlink)(const char *); 
+    int (*unlinkat)(int, const char *, int);   
     ssize_t (*read)(int, void *, size_t);
     ssize_t (*readv)(int, const struct iovec *, int);
     size_t (*fread)(void *, size_t, size_t, FILE *);

--- a/src/report.c
+++ b/src/report.c
@@ -2423,6 +2423,22 @@ doFSMetric(metric_t type, fs_info *fs, control_type_t source,
         break;
     }
 
+    case FS_DELETE:
+    {
+        event_field_t fields[] = {
+            PROC_FIELD(g_proc.procname),
+            PID_FIELD(g_proc.pid),
+            HOST_FIELD(g_proc.hostname),
+            OP_FIELD(op),
+            FILE_FIELD(pathname),
+            UNIT_FIELD("operation"),
+            FIELDEND
+        };
+
+        event_t evt = INT_EVENT("fs.delete", 1, DELTA, fields);
+        cmdSendEvent(g_ctl, &evt, fs->uid, &g_proc);
+    }
+
     default:
         DBG(NULL);
     }

--- a/src/report.c
+++ b/src/report.c
@@ -2438,6 +2438,7 @@ doFSMetric(metric_t type, fs_info *fs, control_type_t source,
         event_t evt = INT_EVENT("fs.delete", 1, DELTA, fields);
         evt.src = CFG_SRC_FS;
         cmdSendEvent(g_ctl, &evt, fs->uid, &g_proc);
+        break;
     }
 
     default:

--- a/src/report.c
+++ b/src/report.c
@@ -2436,6 +2436,7 @@ doFSMetric(metric_t type, fs_info *fs, control_type_t source,
         };
 
         event_t evt = INT_EVENT("fs.delete", 1, DELTA, fields);
+        evt.src = CFG_SRC_FS;
         cmdSendEvent(g_ctl, &evt, fs->uid, &g_proc);
     }
 

--- a/src/report.h
+++ b/src/report.h
@@ -34,6 +34,7 @@ typedef enum {
     FS_WRITE,
     FS_OPEN,
     FS_CLOSE,
+    FS_DELETE,
     FS_SEEK,
     TOT_READ,
     TOT_WRITE,

--- a/src/state.c
+++ b/src/state.c
@@ -798,6 +798,7 @@ doUpdateState(metric_t type, int fd, ssize_t size, const char *funcop, const cha
     case FS_DELETE:
     {
         postFSState(fd, type, NULL, funcop, pathname);
+        break;
     }
 
     case FS_SEEK:

--- a/src/state.c
+++ b/src/state.c
@@ -456,16 +456,16 @@ postFSState(int fd, metric_t type, fs_info *fs, const char *funcop, const char *
     fs_info *fsp = calloc(1, len);
     if (!fsp) return FALSE;
 
-    memmove(fsp, fs, len);
+    if (fs) memmove(fsp, fs, len);
     fsp->fd = fd;
     fsp->evtype = EVT_FS;
     fsp->data_type = type;
 
-    if (pathname && (fs->path[0] == '\0')) {
+    if (pathname && (!fs || fs->path[0] == '\0')) {
         strncpy(fsp->path, pathname, strnlen(pathname, sizeof(fsp->path)));
     }
 
-    if (funcop && (fs->funcop[0] == '\0')) {
+    if (funcop && (!fs || fs->funcop[0] == '\0')) {
         strncpy(fsp->funcop, funcop, strnlen(funcop, sizeof(fsp->funcop)));
     }
 

--- a/src/state.c
+++ b/src/state.c
@@ -439,6 +439,7 @@ postFSState(int fd, metric_t type, fs_info *fs, const char *funcop, const char *
         case FS_SEEK:
             summarize = &g_summary.fs.seek;
             break;
+        case FS_DELETE:
         default:
             break;
     }
@@ -792,6 +793,11 @@ doUpdateState(metric_t type, int fd, ssize_t size, const char *funcop, const cha
         }
         atomicSwapU64(&g_fsinfo[fd].numClose.evt, 0);
         break;
+    }
+
+    case FS_DELETE:
+    {
+        postFSState(fd, type, NULL, funcop, pathname);
     }
 
     case FS_SEEK:
@@ -2328,6 +2334,12 @@ doDup2(int oldfd, int newfd, int rc, const char *func)
             doUpdateState(NET_ERR_CONN, oldfd, (size_t)0, func, "nopath");
         }
     }
+}
+
+void
+doDelete(const char *pathname, const char *func)
+{
+    doUpdateState(FS_DELETE, -1, 0, func, pathname);
 }
 
 void

--- a/src/state.h
+++ b/src/state.h
@@ -61,6 +61,7 @@ int doDupFile(int, int, const char *);
 int doDupSock(int, int);
 void doDup(int, int, const char *, int);
 void doDup2(int, int, int, const char *);
+void doDelete(const char *, const char *);
 void doClose(int, const char *);
 void doOpen(int, const char *, fs_type_t, const char *);
 void doSendFile(int, int, uint64_t, int, const char *);

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -168,6 +168,8 @@ static got_list_t inject_hook_list[] = {
     {"close", NULL, &g_fn.close},
     {"fclose", NULL, &g_fn.fclose},
     {"fcloseall", NULL, &g_fn.fcloseall},
+    {"unlink", NULL, &g_fn.unlink},
+    {"unlinkat", NULL, &g_fn.unlinkat},
     {"lseek", NULL, &g_fn.lseek},
     {"fseek", NULL, &g_fn.fseek},
     {"fseeko", NULL, &g_fn.fseeko},
@@ -3540,6 +3542,32 @@ fcloseall(void)
         doCloseAllStreams();
     } else {
         doUpdateState(FS_ERR_OPEN_CLOSE, -1, 0, "fcloseall", "nopath");
+    }
+
+    return rc;
+}
+
+EXPORTON int
+unlink(const char *pathname)
+{
+    WRAP_CHECK(unlink, -1);
+
+    int rc = g_fn.unlink(pathname);
+    if (rc != -1) {
+        doDelete(pathname, "unlink");
+    }
+
+    return rc;
+}
+
+EXPORTON int
+unlinkat(int dirfd, const char *pathname, int flags)
+{
+    WRAP_CHECK(unlinkat, -1);
+
+    int rc = g_fn.unlinkat(dirfd, pathname, flags);
+    if (rc != -1) {
+        doDelete(pathname, "unlinkat");
     }
 
     return rc;

--- a/test/integration/syscalls/syscall_tests_conf.json
+++ b/test/integration/syscalls/syscall_tests_conf.json
@@ -50,6 +50,8 @@
         "statvfs",
         "statx",
         "syscall",
+        "unlink",
+        "unlinkat",
         "write",
         "writev"
       ],


### PR DESCRIPTION
This PR adds interposing of the `unlink` and `unlinkat` system calls, wrapping the calls and generating `fs.delete` events to notify the user of file removal.

**Considerations**

- We created a new metric type `FS_DELETE`, since there was no appropriate `DELETE` type in existence. We now handle that type in doUpdateState() and on the reporting side in doFSMetric().
- We decided that there was no need for error handling in the unlink function i.e. we don't need to report an error with unlinking. 

**Testing**

- Integration tests for unlink, unlinkat were added to the syscalls tests. This can be tested with the following commands:
```
cd test/integration
make syscalls # runs in a container
```
- QA instructions can be found [here](https://github.com/criblio/appscope/issues/709)

**Questions for Reviewers**

1. In the case of `unlinkat`, should I pass the `dirfd` into doDelete(...) and into doUpdateState(...) ?

Closes: https://github.com/criblio/appscope/issues/709