### PR TITLE
Fix bugs in doDupSock()

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -2296,8 +2296,9 @@ doDupSock(int oldfd, int newfd)
         return -1;
     }
 
-    memmove(&g_netinfo[newfd], &g_netinfo[oldfd], sizeof(struct fs_info_t));
+    memmove(&g_netinfo[newfd], &g_netinfo[oldfd], sizeof(struct net_info_t));
     g_netinfo[newfd].active = TRUE;
+    g_netinfo[newfd].uid = getTime();
     g_netinfo[newfd].numTX = (counters_element_t){.mtc=0, .evt=0};
     g_netinfo[newfd].numRX = (counters_element_t){.mtc=0, .evt=0};
     g_netinfo[newfd].txBytes = (counters_element_t){.mtc=0, .evt=0};


### PR DESCRIPTION
While testing http performance in #614 we noticed two bugs in `doDupSock()`.

- When duplicating the socket, we weren't creating a new unique ID for the net object.
- When duplicating the socket, the call to `memmove()` had an incorrect length argument causing adjacent memory to be overwritten. The result of this in our testing was that there appeared to be an active, valid net object stored in g_netinfo[4] which was not the case. When `doSend()` was called and nginx tried to write to the `access.log` file on file descriptor 4, it was incorrectly perceived as a net object.

We recently added a call to `doDupSock()` in `doAccept()` which is why we noticed these today.

This PR fixes both of these bugs.