### PR TITLE
Configure the queue size

### DIFF
--- a/src/ctl.c
+++ b/src/ctl.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
@@ -578,7 +579,18 @@ ctlCreate()
         goto err;
     }
 
-    ctl->log.ringbuf = cbufInit(DEFAULT_CBUF_SIZE);
+    size_t buf_size = DEFAULT_CBUF_SIZE;
+    char *qlen_str;
+    if ((qlen_str = getenv("SCOPE_QUEUE_LENGTH")) != NULL) {
+        unsigned long qlen;
+        errno = 0;
+        qlen = strtoul(qlen_str, NULL, 10);
+        if (!errno && qlen) {
+            buf_size = qlen;
+        }
+    }
+
+    ctl->log.ringbuf = cbufInit(buf_size);
     if (!ctl->log.ringbuf) {
         DBG(NULL);
         goto err;
@@ -586,7 +598,7 @@ ctlCreate()
     ctl->log.max_agg_bytes = DEFAULT_LOG_MAX_AGG_BYTES;
     ctl->log.flush_period_in_ms = DEFAULT_LOG_FLUSH_PERIOD_IN_MS;
 
-    ctl->events = cbufInit(DEFAULT_CBUF_SIZE);
+    ctl->events = cbufInit(buf_size);
     if (!ctl->events) {
         DBG(NULL);
         goto err;
@@ -596,7 +608,7 @@ ctlCreate()
 
     ctl->payload.enable = DEFAULT_PAYLOAD_ENABLE;
     ctl->payload.dir = (DEFAULT_PAYLOAD_DIR) ? strdup(DEFAULT_PAYLOAD_DIR) : NULL;
-    ctl->payload.ringbuf = cbufInit(DEFAULT_PAYLOAD_RING_SIZE);
+    ctl->payload.ringbuf = cbufInit(buf_size);
     if (!ctl->payload.ringbuf) {
         DBG(NULL);
         goto err;

--- a/src/scopetypes.h
+++ b/src/scopetypes.h
@@ -155,7 +155,6 @@ typedef unsigned int bool;
  * of as requirements. SO, we'll extend this over time.
  */
 #define DEFAULT_CBUF_SIZE (DEFAULT_MAXEVENTSPERSEC * DEFAULT_SUMMARY_PERIOD)
-#define DEFAULT_PAYLOAD_RING_SIZE 10000
 #define DEFAULT_CONFIG_SIZE 30 * 1024
 
 // Unpublished scope env vars that are not processed by config:
@@ -173,6 +172,7 @@ typedef unsigned int bool;
 //    SCOPE_PID                      provided by library
 //    SCOPE_PAYLOAD_HEADER           write payload headers to files
 //    SCOPE_ALLOW_CONSTRUCT_DBG      allows debug inside the constructor
+//    SCOPE_QUEUE_LENGTH             override default circular buffer sizes
 
 #define SCOPE_PID_ENV "SCOPE_PID"
 #define PRESERVE_PERF_REPORTING "SCOPE_PERF_PRESERVE"


### PR DESCRIPTION
**Before this PR**

The default buffer size for _events, logs and metric capture_ is:
`DEFAULT_CBUF_SIZE`
which is calculated from:
```
DEFAULT_MAXEVENTSPERSEC (10,000)
*
DEFAULT_SUMMARY_PERIOD (10) [seconds]
=
100,000
```

This calculation ensures that the ring buffer size complies with the max events limit.

The default buffer size for _payloads_ is:
`DEFAULT_PAYLOAD_RING_SIZE`
which is:
`10000`

**After this PR**

This PR joins `DEFAULT_PAYLOAD_RING_SIZE` and `DEFAULT_CBUF_SIZE` into `DEFAULT_CBUF_SIZE` ; and it adds the possibility to set an environment variable `SCOPE_QUEUE_LENGTH`.

The behavior when creating a buffer has been updated as follows:
Default payload buffer size, event buffer size, log buffer size, metric capture buffer size =
```
DEFAULT_MAXEVENTSPERSEC (10,000)
*
DEFAULT_SUMMARY_PERIOD (10) [seconds]
=
100,000
```
…Unless the `SCOPE_QUEUE_LENGTH` environment variable is specified, in which case that will override the size of all 4 buffers.

Note that as a result, the default payload ring size has effectively increased to 100,000.

Closes #721 
QA Instructions: #721 