### PR TITLE
Add channel field to fs.delete events

### DIFF
--- a/src/ctl.c
+++ b/src/ctl.c
@@ -501,6 +501,8 @@ create_evt_json(upload_t *upld)
     if (upld->uid) {
         if (snprintf(numbuf, sizeof(numbuf), "%llu", upld->uid) < 0) goto err;
         if (!cJSON_AddStringToObjLN(json_root, CHANNEL, numbuf)) goto err;
+    } else {
+        if (!cJSON_AddStringToObjLN(json_root, CHANNEL, "none")) goto err;
     }
     cJSON_AddItemToObjectCS(json_root, "body", upld->body);
     return json_root;

--- a/test/ctltest.c
+++ b/test/ctltest.c
@@ -624,7 +624,7 @@ ctlCreateTxMsgEvt(void** state)
     assert_non_null(msg);
 
     char expected_msg[] =
-        "{\"type\":\"evt\",\"body\":\"yeah, dude\"}";
+        "{\"type\":\"evt\",\"_channel\":\"none\",\"body\":\"yeah, dude\"}";
     assert_string_equal(msg, expected_msg);
 
     free(msg);


### PR DESCRIPTION
We want to ensure that a channel field is always provided, even when unknown, for schema consistency.

Currently, `fs.delete` events do not include a channel field. This is because `unlink` operations do not provide a file descriptor, so we do not add an fs object to our array of known files. Therefore, when we call `postFSState()` we pass a null fs object (uid = 0). When the `fs.delete` event is emitted, the channel field is not included since uid is 0. This PR sets the channel field = "none" where uid is 0.

Now the fs.delete event looks as follows:

`{"type":"evt","id":"vm-rm-rm deleteme","_channel":"none","body":{"sourcetype":"fs","_time":1643825519.802053,"source":"fs.delete","host":"vm","proc":"rm","cmd":"rm deleteme","pid":84066,"data":{"proc":"rm","pid":84066,"host":"vm","op":"unlinkat","file":"deleteme","unit":"operation"}}}`

We talked about trying to discover the fd from our array of known fd's by searching for the path, but considered the performance implications as well as the high likelihood that we would not have that path already in our array.

Related: https://github.com/criblio/appscope/issues/723