### PR TITLE
Fix newline bug in user prompt, and improve 0 sessions error message

### DIFF
--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 
@@ -20,19 +21,22 @@ func sessionByID(id int) history.SessionList {
 	}
 	sessionCount := len(sessions)
 	if sessionCount != 1 {
-		util.ErrAndExit("error expected a single session, saw: %d", sessionCount)
+		util.ErrAndExit("Session not found. Session count: %d", sessionCount)
 	}
 	return sessions
 }
 
 func promptClean(sl history.SessionList) {
-	fmt.Print("Invalid session, likely an invalid command was scoped or a session file was modified. Would you like to delete this session? (default: yes) [y/n] ")
-	var response string
-	_, err := fmt.Scanf("%s", &response)
-	util.CheckErrSprintf(err, "error reading response: %v", err)
-	if !(response == "n" || response == "no") {
-		sl.Remove()
+	fmt.Println("Invalid session, likely an invalid command was scoped or a session file was modified. Would you like to delete this session? (y/yes)")
+	in := bufio.NewScanner(os.Stdin)
+	in.Scan()
+	response := in.Text()
+	if !(response == "y" || response == "yes") {
+		fmt.Println("No action taken")
+		os.Exit(0)
 	}
+	sl.Remove()
+	fmt.Println("Deleted session.")
 	os.Exit(0)
 }
 


### PR DESCRIPTION
- Fixed the newline error reported in #509. Now the prompt works as expected:
```
sean@vm:~/src/appscope-dev/cli$ rm ~/.scope/history/curl_*/event_dest
sean@vm:~/src/appscope-dev/cli$ rm ~/.scope/history/curl_*/events.json
sean@vm:~/src/appscope-dev/cli$ ../bin/linux/x86_64/scope events
Invalid session, likely an invalid command was scoped or a session file was modified. Would you like to delete this session? (y/yes)
n
No action taken
```
```
sean@vm:~/src/appscope-dev/cli$ ../bin/linux/x86_64/scope events
Invalid session, likely an invalid command was scoped or a session file was modified. Would you like to delete this session? (y/yes)

No action taken
```
```
sean@vm:~/src/appscope-dev/cli$ ../bin/linux/x86_64/scope events
Invalid session, likely an invalid command was scoped or a session file was modified. Would you like to delete this session? (y/yes)
y
Deleted session.
```

- Improved the error message and verified consistency following concerns in #613 :
```
sean@vm:~/src/appscope-dev/cli$ ../bin/linux/x86_64/scope dash
Session not found. Session count: 0
sean@vm:~/src/appscope-dev/cli$ ../bin/linux/x86_64/scope flows
Session not found. Session count: 0
sean@vm:~/src/appscope-dev/cli$ ../bin/linux/x86_64/scope events
Session not found. Session count: 0
sean@vm:~/src/appscope-dev/cli$ ../bin/linux/x86_64/scope metrics
Session not found. Session count: 0
sean@vm:~/src/appscope-dev/cli$ ../bin/linux/x86_64/scope logs
Session not found. Session count: 0
```

Closes #613 
Closes #509 