### PR TITLE
Fix scope metrics issues in cli

### DIFF
--- a/cli/util/table.go
+++ b/cli/util/table.go
@@ -191,13 +191,13 @@ func getFieldValue(obj interface{}, field ObjField) interface{} {
 	case reflect.Struct:
 		f := GetJSONField(obj, f)
 		if f == nil {
-			return nil
+			return ""
 		}
 		return f.Value()
 	case reflect.Map:
 		ret, ok := obj.(map[string]interface{})[f]
 		if !ok {
-			return nil
+			return ""
 		}
 		return ret
 	default:


### PR DESCRIPTION
- Add example to the `scope metrics` help menu to show how to use multiple metric names (commit 1)
- Improve the descriptions in the `scope metrics` help menu (commit 1)
- Fix a bug where scope would exit before printing some metrics (commit 1):

Occasionally, `scope metrics` would not display all metrics.
When the cli writes output to the metrics table, it sends output to a goroutine that takes care of tab replacement (for proper alignment) and truncation (for proper table width) before forwarding it to stdout.
Scope was exiting after sending the metrics to that goroutine, killing it sometimes before the data got out to the terminal. This PR tells the main thread to wait until that goroutine is finished processing before exiting.

- Fix a bug where columns would not display correctly when specifying multiple metric names (commit 2):

When the cli was building the metric table, it was not placing some metrics in the correct column index.

- Improve the table UI by hiding <nil> values (commit 2)

Closes https://github.com/criblio/appscope/issues/759
Closes https://github.com/criblio/appscope/issues/762
QA Instructions (Missing metric) https://github.com/criblio/appscope/issues/759#issuecomment-1033826387
QA Instructions (Columns) https://github.com/criblio/appscope/issues/762#issuecomment-1034031209