### PR TITLE
Remove `additionalProperties` condition for `body`

### DIFF
--- a/docs/schemas/event_dns_req.schema.json
+++ b/docs/schemas/event_dns_req.schema.json
@@ -70,8 +70,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_dns_resp.schema.json
+++ b/docs/schemas/event_dns_resp.schema.json
@@ -73,8 +73,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_fs_close.schema.json
+++ b/docs/schemas/event_fs_close.schema.json
@@ -112,8 +112,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_fs_delete.schema.json
+++ b/docs/schemas/event_fs_delete.schema.json
@@ -82,8 +82,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_fs_duration.schema.json
+++ b/docs/schemas/event_fs_duration.schema.json
@@ -94,8 +94,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_fs_error.schema.json
+++ b/docs/schemas/event_fs_error.schema.json
@@ -91,8 +91,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_fs_open.schema.json
+++ b/docs/schemas/event_fs_open.schema.json
@@ -97,8 +97,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_fs_read.schema.json
+++ b/docs/schemas/event_fs_read.schema.json
@@ -94,8 +94,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_fs_seek.schema.json
+++ b/docs/schemas/event_fs_seek.schema.json
@@ -91,8 +91,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_fs_stat.schema.json
+++ b/docs/schemas/event_fs_stat.schema.json
@@ -88,8 +88,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_fs_write.schema.json
+++ b/docs/schemas/event_fs_write.schema.json
@@ -94,8 +94,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_http_req.schema.json
+++ b/docs/schemas/event_http_req.schema.json
@@ -109,8 +109,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_http_resp.schema.json
+++ b/docs/schemas/event_http_resp.schema.json
@@ -115,8 +115,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_app.schema.json
+++ b/docs/schemas/event_net_app.schema.json
@@ -79,8 +79,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_close.schema.json
+++ b/docs/schemas/event_net_close.schema.json
@@ -100,8 +100,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_duration.schema.json
+++ b/docs/schemas/event_net_duration.schema.json
@@ -94,8 +94,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_error.schema.json
+++ b/docs/schemas/event_net_error.schema.json
@@ -88,8 +88,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_open.schema.json
+++ b/docs/schemas/event_net_open.schema.json
@@ -88,8 +88,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_other.schema.json
+++ b/docs/schemas/event_net_other.schema.json
@@ -91,8 +91,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_port.schema.json
+++ b/docs/schemas/event_net_port.schema.json
@@ -91,8 +91,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_rx.schema.json
+++ b/docs/schemas/event_net_rx.schema.json
@@ -115,8 +115,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_tcp.schema.json
+++ b/docs/schemas/event_net_tcp.schema.json
@@ -91,8 +91,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_tx.schema.json
+++ b/docs/schemas/event_net_tx.schema.json
@@ -115,8 +115,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_net_udp.schema.json
+++ b/docs/schemas/event_net_udp.schema.json
@@ -91,8 +91,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_notice.schema.json
+++ b/docs/schemas/event_notice.schema.json
@@ -60,8 +60,7 @@
         "data": {
           "$ref": "definitions/body.schema.json#/$defs/data"
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_stderr.schema.json
+++ b/docs/schemas/event_stderr.schema.json
@@ -67,8 +67,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/event_stdout.schema.json
+++ b/docs/schemas/event_stdout.schema.json
@@ -67,8 +67,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
-  when `SCOPE_TAG` is defined it will be included in `body`