### PR TITLE
Improve cli error messages

### DIFF
--- a/cli/cmd/dash.go
+++ b/cli/cmd/dash.go
@@ -35,7 +35,7 @@ import (
 // dashCmd represents the dash command
 var dashCmd = &cobra.Command{
 	Use:     "dash [flags]",
-	Short:   "Display scope dashboard",
+	Short:   "Display scope dashboard for a previous or active session",
 	Long:    `Displays an interactive dashboard with an overview of whats happening with the selected session.`,
 	Example: `scope dash`,
 	Args:    cobra.NoArgs,

--- a/cli/cmd/flows.go
+++ b/cli/cmd/flows.go
@@ -153,7 +153,7 @@ scope flows --out 124x3c   # Displays the outbound payload of that flow
 						path = filepath.Join(f.BaseDir, f.OutFile)
 					}
 					file, err := os.Open(path)
-					util.CheckErrSprintf(err, "error opening in file %s: %v", path, err)
+					util.CheckErrSprintf(err, "Error opening payload file, did you enable payloads with -p?")
 					io.Copy(os.Stdout, file)
 					return
 				}


### PR DESCRIPTION
When payload files are missing (most often due to the user not enabling payloads with -p), the existing error message is confusing. That is improved in this PR.

When viewing the help menu in the cli, the description for `scope dash` does not inform the user of the capability to work with previous sessions as well as live sessions. That is improved in this PR.