### PR TITLE
Set concurrency limit in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,15 +9,19 @@ name: Build & Test
 on: 
   # Run on pushes to any branch
   push:
-    paths-ignore:
-      - 'website/**'
+    # paths-ignore does not work as expected
+    # it means the workflow will run on any explicit branch
+    # and any other branch where a change to a file except 
+    # one in paths-ignore happens.
+    # paths-ignore:
+    #  - 'website/**'
   # Run on manually triggered workflow
   workflow_dispatch:
   # Run on PRs targeting the default branch or a release branches
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - 'website/**'
+    # paths-ignore:
+    # - 'website/**'
     branches:
       - 'main'
       - 'master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,18 +9,26 @@ name: Build & Test
 on: 
   # Run on pushes to any branch
   push:
+    paths-ignore:
+      - 'website/**'
   # Run on manually triggered workflow
   workflow_dispatch:
   # Run on PRs targeting the default branch or a release branches
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'website/**'
     branches:
       - 'main'
       - 'master'
       - 'release/*'
 
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  # Cancel "in progress" workflows that are superceded with later commits
+  cancel-in-progress: true
 
+jobs:
   # This is the first stage of the workflow where we do some initial setup.
   info:
     name: Get Build Info

--- a/website/README.md
+++ b/website/README.md
@@ -10,4 +10,4 @@ See the Gatsby docs for complete details but to spin up a local environment for 
 3. Run the local development server with `npm run develop`
 4. Access the local development version of the website at [`http://127.0.0.1:8000/`](https://127.0.0.1:8000/).
 
-> Using Node 16 or higher breaks some if this. It works with 14.
+> Using Node 16 or higher breaks some of this. It works with 14.

--- a/website/README.md
+++ b/website/README.md
@@ -7,7 +7,7 @@ The [`deploy.sh`](./deploy.sh) script is run by the [`website` workflow](../.git
 See the Gatsby docs for complete details but to spin up a local environment for content editors, it should be a matter of:
 1. Install `node` with `brew install node` on MacOS or `apt install nodejs` on Ubuntu. Keep it updated running `brew upgrade node` or `apt update`/`apt upgrade` occasionally.
 2. Install local dependencies in the project with `npm install`.
-3. Run the local development server with `npm run develop`
+3. Run the local development server with `npm run develop`.
 4. Access the local development version of the website at [`http://127.0.0.1:8000/`](https://127.0.0.1:8000/).
 
 > Using Node 16 or higher breaks some of this. It works with 14.


### PR DESCRIPTION
This PR modifies the github actions configuration to prevent running unnecessary jobs, which should reduce the time we spend waiting for integration tests to run:
- Jobs that are superceded by newer commits will be cancelled mid-workfow

We should test this on this branch:
- Push dummy changes, then push to undo them, and monitor git actions to validate cancelled prior workflow

