### PR TITLE
Update elasticsearch integration test to 8.0.0

### DIFF
--- a/test/integration/elastic/Dockerfile
+++ b/test/integration/elastic/Dockerfile
@@ -1,9 +1,15 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.0.0
 ENV discovery.type=single-node
+ENV xpack.security.enabled=false
+USER root
 
 RUN apt update && \
     apt install python3-pip -y
 RUN pip3 install virtualenv
+
+RUN chown elasticsearch:elasticsearch /opt/ /usr/local
+
+USER elasticsearch
 
 RUN mkdir /opt/test-runner/ /opt/test-runner/logs/
 

--- a/test/integration/elastic/Dockerfile
+++ b/test/integration/elastic/Dockerfile
@@ -1,14 +1,13 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.8.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.0
 ENV discovery.type=single-node
 
-RUN yum -y update && \
-    yum -y install centos-release-scl && \
-    yum -y install rh-python38 python-virtualenv which
+RUN apt update && \
+    apt install python3-pip -y
+RUN pip3 install virtualenv
 
 RUN mkdir /opt/test-runner/ /opt/test-runner/logs/
 
-RUN source scl_source enable rh-python38 && \
-    virtualenv -p $(which python) /opt/test-runner/
+RUN virtualenv -p $(which python3) /opt/test-runner/
 
 ENV SCOPE_CRIBL_ENABLE=false
 ENV SCOPE_OUT_DEST=udp://localhost:8125
@@ -19,7 +18,6 @@ ENV SCOPE_EVENT_LOGFILE=true
 ENV SCOPE_EVENT_CONSOLE=true
 ENV SCOPE_EVENT_METRIC=true
 ENV SCOPE_EVENT_HTTP=true
-#ENV SCOPE_EVENT_DEST=tcp://172.16.198.132:9109
 
 COPY ./test_runner/requirements.txt /opt/test-runner/requirements.txt
 RUN /opt/test-runner/bin/pip install -r /opt/test-runner/requirements.txt

--- a/test/integration/test_runner/elastic.py
+++ b/test/integration/test_runner/elastic.py
@@ -12,14 +12,16 @@ from utils import dotdict, random_string
 from validation import validate_all
 
 config = dotdict({
-    "host": "localhost"
+    "scheme": "http",
+    "host": "localhost",
+    "port": 9200
 })
 
 
 class ElasticIndexAndSearchTest(ApplicationTest):
 
     def do_run(self, scoped) -> Tuple[TestResult, Any]:
-        logging.info(f"Connecting to Elasticsearch at {config.host}")
+        logging.info(f"Connecting to Elasticsearch at {config.scheme} {config.host} {config.port}")
         es = self.__connect_to_es()
 
         logging.info(f"Elastic info: {es.info()}")
@@ -72,7 +74,7 @@ class ElasticIndexAndSearchTest(ApplicationTest):
     @retry(stop_max_attempt_number=5, wait_fixed=5000)
     def __connect_to_es(self):
         logging.info("Attempt")
-        elasticsearch = Elasticsearch(hosts=[{"host": config.host}])
+        elasticsearch = Elasticsearch([{"scheme": config.scheme, "host": config.host, "port": config.port}])
         assert elasticsearch.ping()
         return elasticsearch
 
@@ -98,7 +100,7 @@ def configure(runner: Runner, config):
 
 if __name__ == '__main__':
     logging.basicConfig(level=DEBUG)
-    es = Elasticsearch(hosts=[{"host": "localhost"}])
+    es = Elasticsearch([{"scheme": config.scheme, "host": config.host, "port": config.port}])
 
     index = f"test_{random_string(4)}"
 

--- a/test/integration/test_runner/requirements.txt
+++ b/test/integration/test_runner/requirements.txt
@@ -1,5 +1,5 @@
 tabulate
 splunk-sdk
 retrying
-elasticsearch == 7.17.0
+elasticsearch
 kafka


### PR DESCRIPTION
Update elasticsearch image to version 8.0.0
    
- in 8.0.0 default user is `elasticsearch` not `root`
- disable Elasticsearch security [features](https://www.elastic.co/guide/en/elasticsearch/reference/current/release-highlights.html#_better_protection_for_system_indices) as used in version 7.8.1
- for elasticsearch 8.0.0 the base docker image is `Ubuntu 20.04.3 LTS` previously was `CentOS Linux 7 (Core)`