### PR TITLE
Interpose go unlink (unlinkat) and readdir (getdents)

### DIFF
--- a/docs/schemas/definitions/data.schema.json
+++ b/docs/schemas/definitions/data.schema.json
@@ -277,7 +277,7 @@
       "title": "op_fs_delete",
       "description": "op_fs_delete",
       "type": "string",
-      "enum": ["unlink", "unlinkat"]
+      "enum": ["go_unlinkat", "unlink", "unlinkat"]
     },
     "op_fs_open": {
       "title": "op_fs_open",

--- a/docs/schemas/definitions/data.schema.json
+++ b/docs/schemas/definitions/data.schema.json
@@ -289,7 +289,7 @@
       "title": "op_fs_read",
       "description": "op_fs_read",
       "type": "string",
-      "enum": ["go_read", "readdir", "pread64", "__pread64_chk", "preadv", "preadv2", "preadv64v2", "__pread_chk", "__read_chk", "__fread_unlocked_chk", "read", "readv", "pread", "fread", "__fread_chk", "fread_unlocked", "fgets", "__fgets_chk", "fgets_unlocked", "__fgetws_chk", "fgetws", "fgetwc", "fgetc", "fscanf", "getline", "getdelim", "__getdelim"]
+      "enum": ["go_read", "go_getdents", "readdir", "pread64", "__pread64_chk", "preadv", "preadv2", "preadv64v2", "__pread_chk", "__read_chk", "__fread_unlocked_chk", "read", "readv", "pread", "fread", "__fread_chk", "fread_unlocked", "fgets", "__fgets_chk", "fgets_unlocked", "__fgetws_chk", "fgetws", "fgetwc", "fgetc", "fscanf", "getline", "getdelim", "__getdelim"]
     },
     "op_fs_seek": {
       "title": "op_fs_seek",

--- a/src/gocontext.S
+++ b/src/gocontext.S
@@ -55,6 +55,7 @@
     interpose go_hook_write, go_write
     interpose go_hook_open, go_open
     interpose go_hook_unlinkat, go_unlinkat
+    interpose go_hook_getdents, go_getdents
     interpose go_hook_socket, go_socket
     interpose go_hook_accept4, go_accept4
     interpose go_hook_read, go_read

--- a/src/gocontext.S
+++ b/src/gocontext.S
@@ -54,6 +54,7 @@
 .text
     interpose go_hook_write, go_write
     interpose go_hook_open, go_open
+    interpose go_hook_unlinkat, go_unlinkat
     interpose go_hook_socket, go_socket
     interpose go_hook_accept4, go_accept4
     interpose go_hook_read, go_read

--- a/src/gocontext.h
+++ b/src/gocontext.h
@@ -51,6 +51,7 @@ extern void *getSymbol(const char *, char *);
 
 extern void go_hook_write(void);
 extern void go_hook_open(void);
+extern void go_hook_unlinkat(void);
 extern void go_hook_socket(void);
 extern void go_hook_accept4(void);
 extern void go_hook_read(void);

--- a/src/gocontext.h
+++ b/src/gocontext.h
@@ -52,6 +52,7 @@ extern void *getSymbol(const char *, char *);
 extern void go_hook_write(void);
 extern void go_hook_open(void);
 extern void go_hook_unlinkat(void);
+extern void go_hook_getdents(void);
 extern void go_hook_socket(void);
 extern void go_hook_accept4(void);
 extern void go_hook_read(void);

--- a/src/wrap_go.c
+++ b/src/wrap_go.c
@@ -59,6 +59,7 @@ go_offsets_t g_go = {.g_to_m=48,                   // 0x30
 tap_t g_go_tap[] = {
     {"syscall.write",                        go_hook_write,        NULL, 0},
     {"syscall.openat",                       go_hook_open,         NULL, 0},
+    {"syscall.unlinkat",                     go_hook_unlinkat,     NULL, 0},
     {"syscall.socket",                       go_hook_socket,       NULL, 0},
     {"syscall.accept4",                      go_hook_accept4,      NULL, 0},
     {"syscall.read",                         go_hook_read,         NULL, 0},
@@ -992,6 +993,31 @@ EXPORTON void *
 go_write(char *stackptr)
 {
     return go_switch(stackptr, c_write, go_hook_write);
+}
+
+static void
+c_unlinkat(char *stackaddr)
+{
+    uint64_t dirfd  = *(uint64_t *)(stackaddr + 0x8);
+    char *pathname = c_str((gostring_t*)(stackaddr + 0x10));
+    uint64_t flags  = *(uint64_t *)(stackaddr + 0x18);
+
+    if (!pathname) {
+        scopeLogError("ERROR:go_open: null pathname");
+        puts("Scope:ERROR:open:no pathname");
+        return;
+    }
+
+    funcprint("Scope: unlinkat dirfd %ld pathname %s flags %ld\n", dirfd, pathname, flags);
+    doDelete(pathname, "unlinkat");
+
+    if (pathname) free(pathname);
+}
+
+EXPORTON void *
+go_unlinkat(char *stackptr)
+{
+    return go_switch(stackptr, c_unlinkat, go_hook_unlinkat);
 }
 
 static void

--- a/src/wrap_go.c
+++ b/src/wrap_go.c
@@ -233,8 +233,9 @@ patch_return_addrs(funchook_t *funchook,
         uint32_t add_arg = 0;
         if ((!strcmp((const char*)asm_inst[i].mnemonic, "ret") &&
              asm_inst[i].size == 1) &&
-             !strcmp((const char*)asm_inst[i-1].mnemonic, "add") &&
-             (add_arg = add_argument(&asm_inst[i-1]))) {
+             (((!strcmp((const char*)asm_inst[i-1].mnemonic, "add")) ||
+             ((!strcmp((const char*)asm_inst[i-1].mnemonic, "sub")))) &&
+             (add_arg = add_argument(&asm_inst[i-1])))) {
 
             void *pre_patch_addr = (void*)asm_inst[i-1].address;
             void *patch_addr = (void*)asm_inst[i-1].address;

--- a/src/wrap_go.c
+++ b/src/wrap_go.c
@@ -124,6 +124,9 @@ add_argument(cs_insn* asm_inst)
     // In this example, add_argument is 0x58:
     // 000000000063a083 (04) 4883c458                 ADD RSP, 0x58
     // 000000000063a087 (01) c3                       RET
+    // In this example, add_argument is 0xffffffffffffff80:
+    // 000000000046f833 (04) 4883ec80                 SUB RSP, $0xffffffffffffff80
+    // 000000000046f837 (01) c3                       RET
     if (asm_inst->size == 4) {
         unsigned char* inst_addr = (unsigned char*)asm_inst->address;
         return ((unsigned char*)inst_addr)[3];
@@ -132,6 +135,9 @@ add_argument(cs_insn* asm_inst)
     // In this example, add_argument is 0x80:
     // 00000000004a9cc9 (07) 4881c480000000           ADD RSP, 0x80
     // 00000000004a9cd0 (01) c3                       RET
+    // In this example, add_argument is 0xffffffffffffff80:
+    // 000000000046f833 (07) 4883ec80000000           SUB RSP, $0xffffffffffffff80
+    // 000000000046f837 (01) c3                       RET
     if (asm_inst->size == 7) {
         unsigned char* inst_addr = (unsigned char*)asm_inst->address;
         // x86_64 is little-endian.
@@ -229,7 +235,7 @@ patch_return_addrs(funchook_t *funchook,
                (char*)asm_inst[i].op_str);
 
         // If the current instruction is a RET
-        // we want to patch the ADD immediately before it.
+        // we want to patch the ADD or SUB immediately before it.
         uint32_t add_arg = 0;
         if ((!strcmp((const char*)asm_inst[i].mnemonic, "ret") &&
              asm_inst[i].size == 1) &&
@@ -1004,7 +1010,7 @@ c_getdents(char *stackaddr)
     uint64_t rc     = *(uint64_t *)(stackaddr + 0x28);
     uint64_t initialTime = getTime();
 
-    funcprint("Scope: getdents dirfd %ld\n", dirfd);
+    funcprint("Scope: getdents dirfd %ld rc %ld\n", dirfd, rc);
     doRead(dirfd, initialTime, (rc != -1), NULL, rc, "go_getdents", BUF, 0);
 }
 
@@ -1028,7 +1034,7 @@ c_unlinkat(char *stackaddr)
     }
 
     funcprint("Scope: unlinkat dirfd %ld pathname %s flags %ld\n", dirfd, pathname, flags);
-    doDelete(pathname, "unlinkat");
+    doDelete(pathname, "go_unlinkat");
 
     if (pathname) free(pathname);
 }

--- a/src/wrap_go.c
+++ b/src/wrap_go.c
@@ -60,6 +60,7 @@ tap_t g_go_tap[] = {
     {"syscall.write",                        go_hook_write,        NULL, 0},
     {"syscall.openat",                       go_hook_open,         NULL, 0},
     {"syscall.unlinkat",                     go_hook_unlinkat,     NULL, 0},
+    {"syscall.Getdents",                     go_hook_getdents,     NULL, 0},
     {"syscall.socket",                       go_hook_socket,       NULL, 0},
     {"syscall.accept4",                      go_hook_accept4,      NULL, 0},
     {"syscall.read",                         go_hook_read,         NULL, 0},
@@ -993,6 +994,23 @@ EXPORTON void *
 go_write(char *stackptr)
 {
     return go_switch(stackptr, c_write, go_hook_write);
+}
+
+static void
+c_getdents(char *stackaddr)
+{
+    uint64_t dirfd  = *(uint64_t *)(stackaddr + 0x8);
+    uint64_t rc     = *(uint64_t *)(stackaddr + 0x28);
+    uint64_t initialTime = getTime();
+
+    funcprint("Scope: getdents dirfd %ld\n", dirfd);
+    doRead(dirfd, initialTime, (rc != -1), NULL, rc, "go_getdents", BUF, 0);
+}
+
+EXPORTON void *
+go_getdents(char *stackptr)
+{
+    return go_switch(stackptr, c_getdents, go_hook_getdents);
 }
 
 static void

--- a/test/integration/go/Dockerfile
+++ b/test/integration/go/Dockerfile
@@ -11,6 +11,11 @@ RUN mkdir /go/thread
 COPY ./go/thread/fileThread.go /go/thread
 RUN cd /go/thread && CGO_ENABLED=0 go build fileThread.go
 
+RUN mkdir /go/syscalls
+COPY ./go/syscalls/unlinkat.go /go/syscalls
+RUN cd /go/syscalls && \
+    go build -o unlinkat unlinkat.go
+
 RUN mkdir /go/net
 COPY ./go/net/plainServer.go /go/net
 RUN cd /go/net && \

--- a/test/integration/go/Dockerfile
+++ b/test/integration/go/Dockerfile
@@ -15,6 +15,9 @@ RUN mkdir /go/syscalls
 COPY ./go/syscalls/unlinkat.go /go/syscalls
 RUN cd /go/syscalls && \
     go build -o unlinkat unlinkat.go
+COPY ./go/syscalls/readdir.go /go/syscalls
+RUN cd /go/syscalls && \
+    go build -o readdir readdir.go
 
 RUN mkdir /go/net
 COPY ./go/net/plainServer.go /go/net

--- a/test/integration/go/net/plainClient.go
+++ b/test/integration/go/net/plainClient.go
@@ -1,26 +1,31 @@
 package main
 
 import (
-    "bufio"
-    "fmt"
-    "net/http"
+	"bufio"
+	"fmt"
+	"net/http"
+	"os"
 )
 
 func main() {
 
-    resp, err := http.Get("http://cribl.io")
-    if err != nil {
-        panic(err)
-    }
-    defer resp.Body.Close()
+	fd, err := os.Open(".")
+	fmt.Println(fd)
 
-    fmt.Println("Response status:", resp.Status)
+	resp, err := http.Get("http://cribl.io")
+	if err != nil {
 
-    scanner := bufio.NewScanner(resp.Body)
-    for i := 0; scanner.Scan() && i < 5; i++ {
-        fmt.Println(scanner.Text())
-    }
-    if err := scanner.Err(); err != nil {
-        panic(err)
-    }
+		panic(err)
+	}
+	defer resp.Body.Close()
+
+	fmt.Println("Response status:", resp.Status)
+
+	scanner := bufio.NewScanner(resp.Body)
+	for i := 0; scanner.Scan() && i < 5; i++ {
+		fmt.Println(scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		panic(err)
+	}
 }

--- a/test/integration/go/net/plainClient.go
+++ b/test/integration/go/net/plainClient.go
@@ -4,17 +4,12 @@ import (
 	"bufio"
 	"fmt"
 	"net/http"
-	"os"
 )
 
 func main() {
 
-	fd, err := os.Open(".")
-	fmt.Println(fd)
-
 	resp, err := http.Get("http://cribl.io")
 	if err != nil {
-
 		panic(err)
 	}
 	defer resp.Body.Close()

--- a/test/integration/go/syscalls/readdir.go
+++ b/test/integration/go/syscalls/readdir.go
@@ -1,13 +1,15 @@
 package main
 
 import (
+	"io/ioutil"
 	"log"
-	"os"
 )
 
 func main() {
 	// Call syscall.Readdir
-	_, err := os.ReadDir(".")
+	// note: ioutil.ReadDir was superceded by os.ReadDir
+	// but the latter will fail in some versions < go1.16
+	_, err := ioutil.ReadDir(".")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/integration/go/syscalls/readdir.go
+++ b/test/integration/go/syscalls/readdir.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+func main() {
+	// Call syscall.Readdir
+	_, err := os.ReadDir(".")
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/test/integration/go/syscalls/unlinkat.go
+++ b/test/integration/go/syscalls/unlinkat.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+func main() {
+	_, e := os.Create("/tmp/test_file")
+	if e != nil {
+		log.Fatal(e)
+	}
+
+	// Call syscall.unlinkat
+	e = os.Remove("/tmp/test_file")
+	if e != nil {
+		log.Fatal(e)
+	}
+}

--- a/test/integration/go/test_go.sh
+++ b/test/integration/go/test_go.sh
@@ -76,6 +76,22 @@ evalPayload(){
 
 
 #
+# syscalls_unlinkat
+#
+starttest syscalls_unlinkat
+cd /go/syscalls
+
+ldscope ./unlinkat
+
+evaltest
+
+grep unlinkat $EVT_FILE | grep fs.delete > /dev/null
+ERR+=$?
+
+endtest
+
+
+#
 # plainServerDynamic
 #
 starttest plainServerDynamic

--- a/test/integration/go/test_go.sh
+++ b/test/integration/go/test_go.sh
@@ -102,7 +102,7 @@ ldscope ./readdir
 evaltest
 
 grep readdir $EVT_FILE | grep fs.open > /dev/null
-grep readdir $EVT_FILE | grep fs.read > /dev/null
+grep readdir $EVT_FILE | grep fs.close > /dev/null
 ERR+=$?
 
 endtest

--- a/test/integration/go/test_go.sh
+++ b/test/integration/go/test_go.sh
@@ -101,6 +101,7 @@ ldscope ./readdir
 
 evaltest
 
+grep readdir $EVT_FILE | grep fs.open > /dev/null
 grep readdir $EVT_FILE | grep fs.read > /dev/null
 ERR+=$?
 

--- a/test/integration/go/test_go.sh
+++ b/test/integration/go/test_go.sh
@@ -92,6 +92,22 @@ endtest
 
 
 #
+# syscalls_readdir
+#
+starttest syscalls_readdir
+cd /go/syscalls
+
+ldscope ./readdir
+
+evaltest
+
+grep readdir $EVT_FILE | grep fs.read > /dev/null
+ERR+=$?
+
+endtest
+
+
+#
 # plainServerDynamic
 #
 starttest plainServerDynamic


### PR DESCRIPTION
The initial task was to provide interpositions for these system calls in go, to achieve parity with interpositions in libc:
 - `unlink`
 - `unlinkat`
 - `opendir`
 - `closedir`
 - `readdir`

After inspecting go source code and verifying with disassembled output (`objdump -D some-go-app`) I noticed that:
1. go syscall unlink is a wrapper around unlinkat; and when os.Remove is called in go code, syscall unlinkat is used. So we do not need to interpose unlink, only unlinkat.
2. go syscall open is a wrapper around openat; and when os.Readdir is called in go code, syscall openat is used. We already interpose openat.
3. There is no syscall for closedir in the go code; when close is called on a directory in go code, syscall close is used. We already interpose close.
4. There is no syscall for readdir in the go code, instead readdirent is used. go syscall readdirent is a wrapper around getdents; and when os.Readdir is called in go code, syscall getdents is used. So we do not need to interpose readdir or readdirent, only getdents.

So we actually only need to create new interpositions for (thanks go!):
- `unlinkat`
- `getdents`

After adding these, we noticed that we are missing fs.open events (we expect an fs.open _and_ an fs.close from os.Readdir). We saw in the disassembled code that go has, in some cases, deviated from it's convention of adding a positive number to the rsp before returning, to subtracting a negative number (still adding) to the rsp before returning. This PR includes an extension to our pattern matching to include searching for [a sub instruction followed by a ret instruction].  

By they way, the reason that the go devs use a `sub` instruction instead of an `add` sometimes is that:
They want to add 128 to the stack pointer. With a 4 byte op, the first 3 bytes represent an op on a register, the last byte represents the value. With the limits of a 1 byte signed integer being -128 to +127, in order to perform an add 128 instruction they would have to extend to use a > 4 byte op code. Instead they can do the same thing with a 4 byte op if they subtract -128.

**Testing**
Integration tests are included to support the new interpositions.
It's worth noting that in the integration tests, we use ioutil.Readdir to test getdents instead of the new os.Readdir, for support in previous versions of go.

Closes: #738 #864