### PR TITLE
Fix bug in unmap_all that occurs when scoping a go static executable

### DIFF
--- a/src/sysexec.c
+++ b/src/sysexec.c
@@ -204,11 +204,11 @@ load_elf(char *buf)
 static int
 unmap_all(char *buf, const char **argv)
 {
-    int arg = 1;
-    if (is_static(buf)) arg = 0;
+    int proc_arg = 1;
+    if (is_static(buf)) proc_arg = 0;
 
     int flen;
-    if ((flen = get_file_size(argv[arg])) == -1) {
+    if ((flen = get_file_size(argv[proc_arg])) == -1) {
         scopeLogError("ERROR:unmap_all: file size");
         return -1;
     }

--- a/src/sysexec.c
+++ b/src/sysexec.c
@@ -204,9 +204,11 @@ load_elf(char *buf)
 static int
 unmap_all(char *buf, const char **argv)
 {
+    int arg = 1;
+    if (is_static(buf)) arg = 0;
 
     int flen;
-    if ((flen = get_file_size(argv[1])) == -1) {
+    if ((flen = get_file_size(argv[arg])) == -1) {
         scopeLogError("ERROR:unmap_all: file size");
         return -1;
     }


### PR DESCRIPTION
when scoping an executable argv[0]=`ldscopedyn` and argv[1]=`procname`
when we scope a static executable we call exec() with argv[optind], so in unmap_all, if we're in the context of a static executable, we need to reference argv[0] not argv[1] to get procname.

**Testing**
QA Instructions: #862 

Closes: #862