### PR TITLE
Convert `go get` statements to `go install`

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -49,9 +49,9 @@ clean:
 ## deps: install dependencies
 deps: $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT)
 $(GO_BINDATA):
-	$(GO) get github.com/go-bindata/go-bindata/...
+	$(GO) install github.com/go-bindata/go-bindata/...
 $(GOVVV):
-	$(GO) get github.com/ahmetb/govvv
+	$(GO) install github.com/ahmetb/govvv
 $(GOLANGCI_LINT):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
 		sh -s -- -b $(GOBIN) v1.42.1


### PR DESCRIPTION
"Starting in Go 1.17, installing executables with `go get` is deprecated.... In Go 1.18, go get will no longer build packages"

- Ref: https://go.dev/doc/go-get-install-deprecation

Closes #866