### PR TITLE
Updated the script to generate the .md file.

### DIFF
--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -17,6 +17,7 @@ ENV EXAMPLE_TEST_PY="/home/node/validation/main.py"
 
 COPY docker/docs/entrypoint.sh /home/node/entrypoint.sh
 COPY docker/docs/schema2md.js /home/node/schema2md.js
+COPY docker/docs/layout.js /home/node/layout.js
 COPY docker/docs/validation /home/node/validation
 
 RUN mkdir -p /home/node/schemas/
@@ -26,4 +27,4 @@ COPY docs/schemas /home/node/schemas
 RUN mkdir /home/node/schemas/temp
 RUN mkdir /home/node/schemas/md_files
 
-ENTRYPOINT ["/home/node//entrypoint.sh"]
+ENTRYPOINT ["/home/node/entrypoint.sh"]

--- a/docker/docs/layout.js
+++ b/docker/docs/layout.js
@@ -1,0 +1,91 @@
+const documentPreface =
+`In AppScope, events are structured according to one pattern, and metrics are structured according to another. These patterns are defined rigorously, in validatable [JSON Schema](https://json-schema.org/). 
+
+Three [definitions schemas](https://github.com/criblio/appscope/tree/master/docs/schemas/definitions) govern the basic patterns. Then there is an individual schema for each event and metric, documented below. The definitions schemas define the elements that can be present in individual event and metric schemas, as well as the overall structures into which those elements fit. 
+
+When we say "the AppScope schema," we mean the [whole set](https://github.com/criblio/appscope/tree/master/docs/schemas/) of schemas.
+
+In AppScope 1.0.1, a few event and metric schema elements, namely \`title\` and \`description\`, have placeholder values. In future these may be made more informative. They are essentially "internal documentation" within the schemas and do not affect how the schemas function in AppScope. In the event that you develop any code that depends on AppScope schemas, be aware that the content of \`title\` and \`description\` fields may evolve.
+
+**Note**: AppScope 1.0.0 has been omitted from this documentation because it has been replaced by AppScope 1.0.1.`;
+
+const tocOrder = [
+  'event.fs.open',
+  'event.fs.close',
+  'event.fs.duration',
+  'event.fs.error',
+  'event.fs.read',
+  'event.fs.write',
+  'event.fs.delete',
+  'event.fs.seek',
+  'event.fs.stat',
+  'event.net.open',
+  'event.net.close',
+  'event.net.duration',
+  'event.net.error',
+  'event.net.rx',
+  'event.net.tx',
+  'event.net.app',
+  'event.net.port',
+  'event.net.tcp',
+  'event.net.udp',
+  'event.net.other',
+  'event.http.req',
+  'event.http.resp',
+  'event.dns.req',
+  'event.dns.resp',
+  'event.file',
+  'event.stdout',
+  'event.console',
+  'event.stderr',
+  'event.notice',
+
+  'metric.fs.open',
+  'metric.fs.close',
+  'metric.fs.duration',
+  'metric.fs.error',
+  'metric.fs.read',
+  'metric.fs.write',
+  'metric.fs.seek',
+  'metric.fs.stat',
+  'metric.net.open',
+  'metric.net.close',
+  'metric.net.duration',
+  'metric.net.error',
+  'metric.net.rx',
+  'metric.net.tx',
+  'metric.net.port',
+  'metric.net.tcp',
+  'metric.net.udp',
+  'metric.net.other',
+  'metric.http.req',
+  'metric.http.req.content.length',
+  'metric.http.resp.content.length',
+  'metric.http.duration.client',
+  'metric.http.duration.server',
+  'metric.dns.req',
+  'metric.proc.fd',
+  'metric.proc.thread',
+  'metric.proc.start',
+  'metric.proc.child',
+  'metric.proc.cpu',
+  'metric.proc.cpu.perc',
+  'metric.proc.mem',
+];
+
+const tocHeaders = {
+  fs: 'File System',
+  net: 'Network',
+  http: 'HTTP',
+  dns: 'DNS',
+  file: 'File',
+  console: 'Console',
+  notice: 'System Notification',
+  proc: 'Process'
+}
+
+module.exports = {
+  documentPreface,
+  tocOrder,
+  tocHeaders
+}

--- a/docs/schemas/definitions/body.schema.json
+++ b/docs/schemas/definitions/body.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://appscope.dev/docs/schemas/definitions/body.schema.json",
   "title": "Schema for the AppScope event/metric body",
-  "description": "Metadata about the process in which AppScope is running",
+  "description": "Metadata about the process in which AppScope is running.",
   "$defs": {
     "_time": {
       "title": "_time",
@@ -68,17 +68,16 @@
       "type": "string",
       "const": "timer"
     },
-    "sourceconsolestdout": {
-      "title": "stdout",
-      "description": "Source - console stdout",
-      "type": "string",
-      "const": "stdout"
+    "sourcefile": {
+      "title": "file",
+      "description": "String that describes a file path.",
+      "type": "string"
     },
-    "sourceconsolestderr": {
-      "title": "stderr",
-      "description": "Source - console stderr",
+    "sourceconsole": {
+      "title": "source",
+      "description": "Specifies whether AppScope is capturing either `stderr` or `file` from console.",
       "type": "string",
-      "const": "stderr"
+      "enum": ["stderr", "file"]
     },
     "sourcednsduration": {
       "title": "dns.duration",
@@ -88,7 +87,7 @@
     },
     "sourcednsreq": {
       "title": "dns.req",
-      "description": "Source - DNS request",
+      "description": "Source - Net DNS",
       "type": "string",
       "const": "dns.req"
     },
@@ -161,6 +160,12 @@
     "sourcehttpreq" : {
       "title": "http.req",
       "description": "Source - HTTP request",
+      "type": "string",
+      "const": "http.req"
+    },
+    "sourcehttpreqs" : {
+      "title": "http.req",
+      "description": "Source - HTTP requests",
       "type": "string",
       "const": "http.req"
     },
@@ -307,6 +312,12 @@
       "description": "Sourcetype - console",
       "type": "string",
       "const": "console"
+    },
+    "sourcetypefile": {
+      "title": "file",
+      "description": "Sourcetype - file",
+      "type": "string",
+      "const": "file"
     },
     "sourcetypedns": {
       "title": "dns",

--- a/docs/schemas/definitions/body.schema.json
+++ b/docs/schemas/definitions/body.schema.json
@@ -73,11 +73,11 @@
       "description": "String that describes a file path.",
       "type": "string"
     },
-    "sourceconsole": {
+    "sourceconsolestderrstdout": {
       "title": "source",
-      "description": "Specifies whether AppScope is capturing either `stderr` or `file` from console.",
+      "description": "Specifies whether AppScope is capturing either `stderr` or `stdout` from console.",
       "type": "string",
-      "enum": ["stderr", "file"]
+      "enum": ["stderr", "stdout"]
     },
     "sourcednsduration": {
       "title": "dns.duration",

--- a/docs/schemas/definitions/data.schema.json
+++ b/docs/schemas/definitions/data.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://appscope.dev/docs/schemas/definitions/data.schema.json",
   "title": "Schema for the data field of the AppScope event/metric body",
-  "description": "Metadata about the data within an event or metric",
+  "description": "Metadata about the data within an event or metric.",
   "$defs": {
     "addrs": {
       "title": "addrs",

--- a/docs/schemas/definitions/envelope.schema.json
+++ b/docs/schemas/definitions/envelope.schema.json
@@ -2,27 +2,27 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://appscope.dev/docs/schemas/definitions/envelope.schema.json",
   "title": "Schema for the AppScope event/metric envelope",
-  "description": "A set of basic facts that AppScope uses to describe each event or metric",
+  "description": "A set of basic facts that AppScope uses to describe each event or metric.",
   "$defs": {
     "_channel": {
       "title": "_channel",
-      "description": "Identifies the operation during whose lifetime the event or metric is emitted",
+      "description": "Identifies the operation during whose lifetime the event or metric is emitted.",
       "type": "string"
     },
     "event_type": {
       "title": "type",
-      "description": "Distinguishes events from metrics",
+      "description": "Distinguishes events from metrics.",
       "type": "string",
       "const": "evt"
     },
     "id": {
       "title": "id",
-      "description": "Identifies the application that the process is associated with",
+      "description": "Identifies the application that the process is associated with.",
       "type": "string"
     },
     "metric_type": {
       "title": "type",
-      "description": "Distinguishes metrics from events",
+      "description": "Distinguishes metrics from events.",
       "type": "string",
       "const": "metric"
     }

--- a/docs/schemas/event_console.schema.json
+++ b/docs/schemas/event_console.schema.json
@@ -4,7 +4,10 @@
   "type": "object",
   "title": "AppScope `console` Event",
   "description": "Structure of the `console` event",
-  "examples": [{"type":"evt","id":"eaf4d0598443-a.out-./a.out","_channel":"8499188821284","body":{"sourcetype":"console","_time":1643883251.376672,"source":"stderr","host":"eaf4d0598443","proc":"a.out","cmd":"./a.out","pid":986,"data":{"message":"stderr hello world"}}}],
+  "examples": [
+    {"type":"evt","id":"eaf4d0598443-a.out-./a.out","_channel":"8499188821284","body":{"sourcetype":"console","_time":1643883251.376672,"source":"stderr","host":"eaf4d0598443","proc":"a.out","cmd":"./a.out","pid":986,"data":{"message":"stderr hello world"}}},
+    {"type":"evt","id":"ubuntu-sh- /usr/bin/which /usr/bin/firefox","_channel":"13468365092424","body":{"sourcetype":"console","_time":1643735941.602952,"source":"stdout","host":"ubuntu","proc":"sh","cmd":"/bin/sh /usr/bin/which /usr/bin/firefox","pid":6545,"data":{"message":"/usr/bin/firefox\n"}}}
+  ],
   "required": [
     "type",
     "id",
@@ -43,7 +46,7 @@
           "$ref": "definitions/body.schema.json#/$defs/_time"
         },
         "source": {
-          "$ref": "definitions/body.schema.json#/$defs/sourceconsole"
+          "$ref": "definitions/body.schema.json#/$defs/sourceconsolestderrstdout"
         },
         "host": {
           "$ref": "definitions/data.schema.json#/$defs/host"

--- a/docs/schemas/event_console.schema.json
+++ b/docs/schemas/event_console.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://appscope.dev/docs/schemas/event_stdout.schema.json",
+  "$id": "https://appscope.dev/docs/schemas/event_console.schema.json",
   "type": "object",
-  "title": "AppScope `stdout` Event",
-  "description": "Structure of the console `stdout` event",
-  "examples": [{"type":"evt","id":"ubuntu-sh- /usr/bin/which /usr/bin/firefox","_channel":"13468365092424","body":{"sourcetype":"console","_time":1643735941.602952,"source":"stdout","host":"ubuntu","proc":"sh","cmd":"/bin/sh /usr/bin/which /usr/bin/firefox","pid":6545,"data":{"message":"/usr/bin/firefox\n"}}}],
+  "title": "AppScope `console` Event",
+  "description": "Structure of the `console` event",
+  "examples": [{"type":"evt","id":"eaf4d0598443-a.out-./a.out","_channel":"8499188821284","body":{"sourcetype":"console","_time":1643883251.376672,"source":"stderr","host":"eaf4d0598443","proc":"a.out","cmd":"./a.out","pid":986,"data":{"message":"stderr hello world"}}}],
   "required": [
     "type",
     "id",
@@ -43,7 +43,7 @@
           "$ref": "definitions/body.schema.json#/$defs/_time"
         },
         "source": {
-          "$ref": "definitions/body.schema.json#/$defs/sourceconsolestdout"
+          "$ref": "definitions/body.schema.json#/$defs/sourceconsole"
         },
         "host": {
           "$ref": "definitions/data.schema.json#/$defs/host"

--- a/docs/schemas/event_file.schema.json
+++ b/docs/schemas/event_file.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://appscope.dev/docs/schemas/event_stderr.schema.json",
+  "$id": "https://appscope.dev/docs/schemas/event_file.schema.json",
   "type": "object",
-  "title": "AppScope `stderr` Event",
-  "description": "Structure of the console `stderr` event",
-  "examples": [{"type":"evt","id":"eaf4d0598443-a.out-./a.out","_channel":"8499188821284","body":{"sourcetype":"console","_time":1643883251.376672,"source":"stderr","host":"eaf4d0598443","proc":"a.out","cmd":"./a.out","pid":986,"data":{"message":"stderr hello world"}}}],
+  "title": "AppScope `file` Event",
+  "description": "Structure of the `file` event",
+  "examples": [{"type":"evt","id":"ubuntu-sh- /usr/bin/which /usr/bin/firefox","_channel":"13468365092424","body":{"sourcetype":"file","_time":1643735941.602952,"source":"/var/log/firefox.log","host":"ubuntu","proc":"sh","cmd":"/bin/sh /usr/bin/which /usr/bin/firefox","pid":6545,"data":{"message":"/usr/bin/firefox\n"}}}],
   "required": [
     "type",
     "id",
@@ -37,13 +37,13 @@
       ],
       "properties": {
         "sourcetype": {
-          "$ref": "definitions/body.schema.json#/$defs/sourcetypeconsole"
+          "$ref": "definitions/body.schema.json#/$defs/sourcetypefile"
         },
         "_time": {
           "$ref": "definitions/body.schema.json#/$defs/_time"
         },
         "source": {
-          "$ref": "definitions/body.schema.json#/$defs/sourceconsolestderr"
+          "$ref": "definitions/body.schema.json#/$defs/sourcefile"
         },
         "host": {
           "$ref": "definitions/data.schema.json#/$defs/host"

--- a/docs/schemas/metric_http_req.schema.json
+++ b/docs/schemas/metric_http_req.schema.json
@@ -31,7 +31,7 @@
       ],
       "properties": {
         "_metric": {
-          "$ref": "definitions/body.schema.json#/$defs/sourcehttpreq"
+          "$ref": "definitions/body.schema.json#/$defs/sourcehttpreqs"
         },
         "_metric_type": {
           "$ref": "definitions/body.schema.json#/$defs/metric_type_counter"


### PR DESCRIPTION
Updated the script so the generated `schema-reference.md` has the same layout as the current docs file.

I changed the schema files according to the docs content. Abe said that the discrepancies between the JSON files and the docs were cause by some last minute changes by John, that weren't replicated in the schema files.

Those changes are renaming `event.stderr` to `event.console` and `event.stdout` to `event.file`.

Also `event.http.req` and `metric.http.req` have the same body, but they should have slightly different descriptions, so I separated them in the schema. I don't know if it's a correct approach.