### PR TITLE
Update base docs docker image

### DIFF
--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:17.9-slim
 
 RUN npm install -g json-dereference-cli json-schema-gendoc
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
- address the severity issues
- ref: https://snyk.io/advisor/docker/node

- Output md file is the same for `node` and `node:17.9-slim` 
- To test it call make docs-generate and examine the `./docs/md_files/schema-reference.md`