### PR TITLE
Internal libc - use VDSO function variants & remove `_STAT_VER` usage

### DIFF
--- a/contrib/musl/arch/aarch64/syscall_arch.h
+++ b/contrib/musl/arch/aarch64/syscall_arch.h
@@ -71,5 +71,8 @@ static inline long __syscall6(long n, long a, long b, long c, long d, long e, lo
 	__asm_syscall("r"(x8), "0"(x0), "r"(x1), "r"(x2), "r"(x3), "r"(x4), "r"(x5));
 }
 
+#define VDSO_USEFUL
+#define VDSO_CGT_SYM "__kernel_clock_gettime"
+#define VDSO_CGT_VER "LINUX_2.6.39"
 
 #define IPC_64 0

--- a/contrib/musl/arch/x86_64/syscall_arch.h
+++ b/contrib/musl/arch/x86_64/syscall_arch.h
@@ -61,5 +61,10 @@ static __inline long __syscall6(long n, long a1, long a2, long a3, long a4, long
 	return ret;
 }
 
+#define VDSO_USEFUL
+#define VDSO_CGT_SYM "__vdso_clock_gettime"
+#define VDSO_CGT_VER "LINUX_2.6"
+#define VDSO_GETCPU_SYM "__vdso_getcpu"
+#define VDSO_GETCPU_VER "LINUX_2.6"
 
 #define IPC_64 0

--- a/contrib/musl/src/internal/syscall.h
+++ b/contrib/musl/src/internal/syscall.h
@@ -394,5 +394,6 @@ static inline long __alt_socketcall(int sys, int sock, int cp, long a, long b, l
 hidden void __procfdname(char __buf[static 15+3*sizeof(int)], unsigned);
 
 hidden void *__vdsosym(const char *, const char *);
+hidden int __check_ehdr_init(void);
 
 #endif

--- a/contrib/musl/src/internal/vdso.c
+++ b/contrib/musl/src/internal/vdso.c
@@ -6,6 +6,16 @@
 #include "libc.h"
 #include "syscall.h"
 
+static size_t _aux_v_ehdr;
+
+int __check_ehdr_init(void) {
+	return (int)_aux_v_ehdr;
+}
+
+void init_vdso_ehdr(unsigned long ehdr) {
+	_aux_v_ehdr = ehdr;
+}
+
 #ifdef VDSO_USEFUL
 
 #if ULONG_MAX == 0xffffffff
@@ -43,10 +53,7 @@ static int checkver(Verdef *def, int vsym, const char *vername, char *strings)
 void *__vdsosym(const char *vername, const char *name)
 {
 	size_t i;
-	for (i=0; libc.auxv[i] != AT_SYSINFO_EHDR; i+=2)
-		if (!libc.auxv[i]) return 0;
-	if (!libc.auxv[i+1]) return 0;
-	Ehdr *eh = (void *)libc.auxv[i+1];
+	Ehdr *eh = (void *)_aux_v_ehdr;
 	Phdr *ph = (void *)((char *)eh + eh->e_phoff);
 	size_t *dynv=0, base=-1;
 	for (i=0; i<eh->e_phnum; i++, ph=(void *)((char *)ph+eh->e_phentsize)) {

--- a/contrib/musl/src/sched/sched_getcpu.c
+++ b/contrib/musl/src/sched/sched_getcpu.c
@@ -28,11 +28,13 @@ int sched_getcpu(void)
 	unsigned cpu;
 
 #ifdef VDSO_GETCPU_SYM
-	getcpu_f f = (getcpu_f)vdso_func;
-	if (f) {
-		r = f(&cpu, 0, 0);
-		if (!r) return cpu;
-		if (r != -ENOSYS) return __syscall_ret(r);
+	if (__check_ehdr_init()) {
+		getcpu_f f = (getcpu_f)vdso_func;
+		if (f) {
+			r = f(&cpu, 0, 0);
+			if (!r) return cpu;
+			if (r != -ENOSYS) return __syscall_ret(r);
+		}
 	}
 #endif
 

--- a/contrib/musl/src/time/clock_gettime.c
+++ b/contrib/musl/src/time/clock_gettime.c
@@ -58,17 +58,19 @@ int __clock_gettime(clockid_t clk, struct timespec *ts)
 	int r;
 
 #ifdef VDSO_CGT_SYM
-	int (*f)(clockid_t, struct timespec *) =
-		(int (*)(clockid_t, struct timespec *))vdso_func;
-	if (f) {
-		r = f(clk, ts);
-		if (!r) return r;
-		if (r == -EINVAL) return __syscall_ret(r);
-		/* Fall through on errors other than EINVAL. Some buggy
-		 * vdso implementations return ENOSYS for clocks they
-		 * can't handle, rather than making the syscall. This
-		 * also handles the case where cgt_init fails to find
-		 * a vdso function to use. */
+	if (__check_ehdr_init()) {
+		int (*f)(clockid_t, struct timespec *) =
+			(int (*)(clockid_t, struct timespec *))vdso_func;
+		if (f) {
+			r = f(clk, ts);
+			if (!r) return r;
+			if (r == -EINVAL) return __syscall_ret(r);
+			/* Fall through on errors other than EINVAL. Some buggy
+			* vdso implementations return ENOSYS for clocks they
+			* can't handle, rather than making the syscall. This
+			* also handles the case where cgt_init fails to find
+			* a vdso function to use. */
+		}
 	}
 #endif
 

--- a/os/linux/Makefile
+++ b/os/linux/Makefile
@@ -89,6 +89,7 @@ coretest: export USER ?= $(shell id -u -n)
 coretest: $(C_FILES) $(YAML_AR) $(JSON_AR) $(TEST_LIB)
 	@echo "$${CI:+::group::}Building Tests"
 	$(CC) -c $(TEST_CFLAGS) $(C_FILES) $(INCLUDES) $(TEST_INCLUDES)
+	$(CC) $(TEST_CFLAGS) -o test/$(OS)/vdsotest vdsotest.o scopestdlib.o dbg.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/strsettest strsettest.o strset.o scopestdlib.o dbg.o test.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/cfgutilstest cfgutilstest.o cfgutils.o cfg.o mtc.o log.o evtformat.o ctl.o transport.o mtcformat.o strset.o com.o scopestdlib.o dbg.o circbuf.o linklist.o fn.o utils.o os.o test.o report.o search.o httpagg.o state.o httpstate.o metriccapture.o plattime.o $(TEST_AR) $(TEST_LD_FLAGS)
 	$(CC) $(TEST_CFLAGS) -o test/$(OS)/cfgtest cfgtest.o cfg.o scopestdlib.o dbg.o test.o $(TEST_AR) $(TEST_LD_FLAGS)

--- a/os/linux/os.c
+++ b/os/linux/os.c
@@ -459,7 +459,7 @@ osIsFilePresent(pid_t pid, const char *path)
 {
     struct stat sb = {0};
 
-    if (scope___xstat(_STAT_VER, path, &sb) != 0) {
+    if (scope_stat(path, &sb) != 0) {
         return -1;
     } else {
         return sb.st_size;

--- a/src/scopestdlib.c
+++ b/src/scopestdlib.c
@@ -10,6 +10,7 @@
 
 
 // Internal standard library references
+extern void  scopelibc_init_vdso_ehdr(unsigned long);
 extern void  scopelibc_lock_before_fork_op(void);
 extern void  scopelibc_unlock_after_fork_op(int);
 
@@ -191,8 +192,15 @@ extern int           scopelibc_tcgetattr(int, struct termios *);
 extern void*         scopelibc_shmat(int, const void *, int);
 extern int           scopelibc_shmdt(const void *);
 extern int           scopelibc_shmget(key_t, size_t, int);
+extern int           scopelibc_sched_getcpu(void);
 
-// Fork handling operations
+// Internal library operations
+
+void
+scope_init_vdso_ehdr(void) {
+    unsigned long ehdr = getauxval(AT_SYSINFO_EHDR);
+    scopelibc_init_vdso_ehdr(ehdr);
+}
 
 void
 scope_op_before_fork(void) {
@@ -1057,6 +1065,11 @@ scope_shmdt(const void *shmaddr) {
 int
 scope_shmget(key_t key, size_t size, int shmflg) {
     return scopelibc_shmget(key, size, shmflg);
+}
+
+int
+scope_sched_getcpu(void) {
+    return scopelibc_sched_getcpu();
 }
 
 int

--- a/src/scopestdlib.c
+++ b/src/scopestdlib.c
@@ -153,7 +153,6 @@ extern struct tm*    scopelibc_gmtime_r(const time_t *, struct tm *);
 extern unsigned int  scopelibc_sleep(unsigned int);
 extern int           scopelibc_usleep(useconds_t);
 extern int           scopelibc_nanosleep(const struct timespec *, struct timespec *);
-extern int           scopelibc___xstat(int, const char *, struct stat *);
 extern int           scopelibc_sigaction(int, const struct sigaction *, struct sigaction *);
 extern int           scopelibc_sigemptyset(sigset_t *);
 extern int           scopelibc_pthread_create(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
@@ -870,11 +869,6 @@ scope_usleep(useconds_t usec) {
 int
 scope_nanosleep(const struct timespec *req, struct timespec *rem) {
     return scopelibc_nanosleep(req, rem);
-}
-
-int
-scope___xstat(int ver, const char *path, struct stat *buf) {
-    return scopelibc___xstat(ver, path, buf);
 }
 
 int

--- a/src/scopestdlib.h
+++ b/src/scopestdlib.h
@@ -200,7 +200,6 @@ struct tm*    scope_gmtime_r(const time_t *, struct tm *);
 unsigned int  scope_sleep(unsigned int);
 int           scope_usleep(useconds_t);
 int           scope_nanosleep(const struct timespec *, struct timespec *);
-int           scope___xstat(int, const char *, struct stat *);
 int           scope_sigaction(int, const struct sigaction *, struct sigaction *);
 int           scope_sigemptyset(sigset_t *);
 int           scope_pthread_create(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);

--- a/src/scopestdlib.h
+++ b/src/scopestdlib.h
@@ -7,6 +7,7 @@
 #include <grp.h>
 #include <link.h>
 #include <locale.h>
+#include <sys/auxv.h>
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
@@ -56,6 +57,7 @@ extern FILE scopelibc___stderr_FILE;
 #define scope_stdout   (&scopelibc___stdout_FILE)
 #define scope_stderr   (&scopelibc___stderr_FILE)
 
+void  scope_init_vdso_ehdr(void);
 void  scope_op_before_fork(void);
 void  scope_op_after_fork(int);
 
@@ -236,5 +238,6 @@ int           scope_tcgetattr(int, struct termios *);
 void*         scope_shmat(int, const void *, int);
 int           scope_shmdt(const void *);
 int           scope_shmget(key_t, size_t, int);
+int           scope_sched_getcpu(void);
 
 #endif // __SCOPE_STDLIB_H__

--- a/src/state.c
+++ b/src/state.c
@@ -2420,7 +2420,7 @@ doOpen(int fd, const char *path, fs_type_t type, const char *func)
             struct stat sbuf;
             int errsave = scope_errno;
 
-            if (scope___xstat(1, g_fsinfo[fd].path, &sbuf) == 0) {
+            if (scope_stat(g_fsinfo[fd].path, &sbuf) == 0) {
                 g_fsinfo[fd].fuid = sbuf.st_uid;
                 g_fsinfo[fd].fgid = sbuf.st_gid;
                 g_fsinfo[fd].mode = sbuf.st_mode;

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -1562,7 +1562,7 @@ initEnv(int *attachedFlag)
 __attribute__((constructor)) void
 init(void)
 {
-
+    scope_init_vdso_ehdr();
     // Bootstrapping...  we need to know if we're in musl so we can
     // call the right initFn function...
     {

--- a/test/execute.sh
+++ b/test/execute.sh
@@ -62,6 +62,7 @@ fi
 # if any errors occurred.  ERR maintains this state.
 declare -i ERR=0
 
+run_test test/${OS}/vdsotest
 run_test test/${OS}/strsettest
 run_test test/${OS}/cfgutilstest
 run_test test/${OS}/cfgtest

--- a/test/vdsotest.c
+++ b/test/vdsotest.c
@@ -1,0 +1,36 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "test.h"
+#include "scopestdlib.h"
+
+static void
+vdso_functions_before_init(void **state)
+{
+    struct timespec ts;
+    scope_clock_gettime(CLOCK_MONOTONIC, &ts);
+    scope_sched_getcpu();
+}
+
+static void
+vdso_functions_after_init(void **state)
+{
+    scope_init_vdso_ehdr();
+    struct timespec ts;
+    scope_clock_gettime(CLOCK_MONOTONIC, &ts);
+    scope_sched_getcpu();
+}
+
+int
+main(int argc, char* argv[])
+{
+    printf("running %s\n", argv[0]);
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(vdso_functions_before_init),
+        cmocka_unit_test(vdso_functions_after_init),
+        cmocka_unit_test(dbgHasNoUnexpectedFailures),
+    };
+    return cmocka_run_group_tests(tests, groupSetup, groupTeardown);
+}


### PR DESCRIPTION
This Pull Request contains two changes:
- Replace __xstat with stat:  remove `_STAT_VER` usage closes #307

- Improve the performance of time related functions - see details [here](https://github.com/criblio/appscope/pull/860#issuecomment-1106524685)

Below are comparison results 
```
    #define IT_MAX (1000000)
    struct timeval tv;
    size_t i = 0;
    for (; i<IT_MAX; i++) {
        //scope_init_vdso_ehdr();
        scope_gettimeofday(&tv,NULL);
    }
```
```
Time elapsed: 0.151822 s (using syscall variant)
Time elapsed: 0.024110 s (using VDSO variant)
```