### PR TITLE
Splunk test Fix bootstrap Python 3.6 build error

### DIFF
--- a/test/integration/splunk/Dockerfile
+++ b/test/integration/splunk/Dockerfile
@@ -21,7 +21,7 @@ RUN cd Python-3.6.5 && \
     make altinstall && \
     cd .. && \
     rm -r Python-3.6.5
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+RUN curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py && \
     python3.6 get-pip.py && \
     rm -f get-pip.py
 


### PR DESCRIPTION
In pip install version 22.0 - Python 3.6 support was dropped [1]
Use alternative link including Python version for install pip

Avoid following error:
ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.

Ref: [1]https://github.com/pypa/pip/pull/10641