### PR TITLE
Cache `secret` value in `get_random_secret`

### DIFF
--- a/contrib/musl/src/malloc/mallocng/glue.h
+++ b/contrib/musl/src/malloc/mallocng/glue.h
@@ -49,8 +49,8 @@ extern int getentropy(void *, size_t);
 
 static inline uint64_t get_random_secret()
 {
-	uint64_t secret;
-	getentropy(&secret, sizeof secret);
+	static uint64_t secret;
+	if (secret == 0) getentropy(&secret, sizeof secret);
 	return secret;
 }
 


### PR DESCRIPTION
This Pull request introduce optimization:

- Original musl implementation is based on `libc.auxv` and `AT_RANDOM`:
```
static inline uint64_t get_random_secret()
{
  uint64_t secret = (uintptr_t)&secret * 1103515245;
  for (size_t i=0; libc.auxv[i]; i+=2)
    if (libc.auxv[i]==AT_RANDOM)
      memcpy(&secret, (char *)libc.auxv[i+1]+8, sizeof secret);
  return secret;
}
```

We can avoid calling syscall each time `get_random_secret`
is called. We can cache `secret` value which was called
for first time with `getentropy` call
`secret` is used for validation check value in the corresponding meta
area header see following [commit](https://github.com/richfelker/mallocng-draft/commit/f0524114a07eb4b16e071a5b004e0504095cc13d) for details