### PR TITLE
Fix pathname in go 16 events

### DIFF
--- a/src/wrap_go.c
+++ b/src/wrap_go.c
@@ -224,12 +224,26 @@ devnull(const char* fmt, ...)
 }
 #endif
 
+void
+free_str(char* str) {
+    // Go 17 and higher use null terminated strings instead of a string and a length
+    if (g_go_major_ver > 16) {
+        return;
+    }
+    if(str) scope_free(str);
+}
+
 // c_str() is provided to convert a go-style string to a c-style string.
 // The resulting c_str will need to be passed to free() when it is no
 // longer needed.
 static char *
 c_str(gostring_t *go_str)
 {
+    // Go 17 and higher use null terminated strings instead of a string and a length
+    if (g_go_major_ver > 16) {
+        return (char *)go_str;
+    }
+
     if (!go_str || go_str->len <= 0) return NULL;
 
     char *path;
@@ -877,7 +891,7 @@ c_write(char *stackaddr)
     funcprint("Scope: write fd %ld rc %ld buf %s\n", fd, rc, buf);
     doWrite(fd, initialTime, (rc != -1), buf, rc, "go_write", BUF, 0);
 
-    if (buf) scope_free(buf);
+    free_str(buf);
 }
 
 EXPORTON void *
@@ -930,7 +944,7 @@ c_unlinkat(char *stackaddr)
     funcprint("Scope: unlinkat dirfd %ld pathname %s flags %ld\n", dirfd, pathname, flags);
     doDelete(pathname, "go_unlinkat");
 
-    if (pathname) scope_free(pathname);
+    free_str(pathname);
 }
 
 EXPORTON void *
@@ -961,7 +975,7 @@ c_open(char *stackaddr)
     funcprint("Scope: open of %ld\n", fd);
     doOpen(fd, path, FD, "open");
 
-    if (path) scope_free(path);
+    free_str(path);
 }
 
 EXPORTON void *
@@ -1011,7 +1025,7 @@ c_read(char *stackaddr)
     funcprint("Scope: read of %ld rc %ld\n", fd, rc);
     doRead(fd, initialTime, (rc != -1), buf, rc, "go_read", BUF, 0);
 
-    if(buf) scope_free(buf);
+    free_str(buf);
 }
 
 EXPORTON void *
@@ -1144,7 +1158,7 @@ c_http_server_read(char *stackaddr)
         }
     }
 
-    if (buf) scope_free(buf);
+    free_str(buf);
 }
 
 EXPORTON void *
@@ -1199,7 +1213,7 @@ c_http_server_write(char *stackaddr)
         }
     }
 
-    if (buf) scope_free(buf);
+    free_str(buf);
 }
 
 EXPORTON void *
@@ -1260,7 +1274,7 @@ c_http_client_write(char *stackaddr)
         funcprint("Scope: c_http_client_write of %d\n", fd);
     }
 
-    if (buf) scope_free(buf);
+    free_str(buf);
 }
 
 EXPORTON void *
@@ -1327,7 +1341,7 @@ c_http_client_read(char *stackaddr)
             funcprint("Scope: c_http_client_read of %d\n", fd);
         }
 
-        if (buf) scope_free(buf);
+        free_str(buf);
     }
 }
 


### PR DESCRIPTION
Closes: #908 

Current state - Getting a seg fault. As seen in GDB when scoping `tlsClient18`:
```
Thread 2.6 "tlsClient18" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffcdcb5640 (LWP 1343130)]
0x00007ffff76ef86e in scopelibc_memcpy () from /tmp/libscope-1.0.3/libscope.so
```
Backtrace
```
(gdb) bt
#0  0x00007ffff76ef86e in scopelibc_memcpy () from /tmp/libscope-1.0.3/libscope.so
#1  0x00007ffff76d8756 in scope_memmove (dest=0x7ffff64c4690, src=0xc00038e060, n=524288) at src/scopestdlib.c:254
#2  0x00007ffff76dd696 in c_str (go_str=0xc00014f288) at src/wrap_go.c:237
#3  0x00007ffff76df206 in c_open (stackaddr=0xc00014f278 "\001\001") at src/wrap_go.c:952
#4  0x00007ffff76dee67 in do_cfunc (stackptr=0xc00014f278 "\001\001", cfunc=0x7ffff76df1c3 <c_open>,
    gfunc=0x7ffff76dbddc <go_hook_reg_open>) at src/wrap_go.c:827
#5  0x00007ffff76df2c0 in go_open (stackptr=0xc00014f278 "\001\001") at src/wrap_go.c:971
#6  0x00000000004625c4 in runtime.asmcgocall () at /usr/local/go/src/runtime/asm_amd64.s:821
#7  0x0000000000000001 in ?? ()
#8  0x0000000000400b00 in ?? ()
#9  0x0000000000001018 in ?? ()
#10 0x00007fffcdcb4dc0 in ?? ()
#11 0x000000000087c1f8 in runtime.memstats ()
#12 0x0000000000000dc0 in ?? ()
#13 0x000000c0001036c0 in ?? ()
#14 0x0000000000460749 in runtime.systemstack () at /usr/local/go/src/runtime/asm_amd64.s:469
#15 0x00007fffcecb68df in ?? ()
#16 0x0000000000800000 in runtime.pclntab ()
#17 0x0000000000000000 in ?? ()
```

After breaking on `c_str()` and inspecting the len, it's often a really high number.
My guess is that the offset for the len in a go string has changed in go 17 and 18.
If this is the case, we could add the offset to the schema and reference that where needed.