### PR TITLE
change menus and links per PM

### DIFF
--- a/website/src/data/corpSiteNav.yaml
+++ b/website/src/data/corpSiteNav.yaml
@@ -1,13 +1,13 @@
 - navigationLeft:
   - parent: Products
     child: 
-      - link: LogStream
-        url: https://cribl.io/product/
-      - link: LogStream Cloud
-        url: https://cribl.io/logstream-cloud/
-      - link: Pricing
-        url: https://cribl.io/cribl-logstream-pricing/
-      - link: Download Logstream
-        url: https://cribl.io/download/
+      - link: Cribl Stream
+        url: https://cribl.io/stream/
+      - link: Cribl Edge
+        url: https://cribl.io/edge/
+      - link: Cribl.Cloud
+        url: https://cribl.io/cribl-cloud/
+      - link: AppScope
+        url: https://cribl.io/appscope/
   - parent: About Cribl
     link: https://cribl.io/about-us

--- a/website/src/data/documentationNav.yaml
+++ b/website/src/data/documentationNav.yaml
@@ -63,7 +63,7 @@
     - name: Known Issues
       path: /docs/known-issues
 
-- name: Community
+- name: Participate
   child: 
     - name: Community
       path: /docs/community      

--- a/website/src/data/documentationNav.yaml
+++ b/website/src/data/documentationNav.yaml
@@ -63,7 +63,7 @@
     - name: Known Issues
       path: /docs/known-issues
 
-- name: Participate
+- name: Join
   child: 
     - name: Community
       path: /docs/community      

--- a/website/src/data/header.yaml
+++ b/website/src/data/header.yaml
@@ -1,6 +1,3 @@
-- name: Overview
-  path: /
-
 - name: Docs
   path: /docs/overview
 
@@ -13,4 +10,5 @@
   #     path: /resources/level2
 
 - name: Community
-  path: https://cribl.io/community?utm_source=appscope&utm_medium=footer&utm_campaign=appscope
+  path: /docs/community
+

--- a/website/src/data/readyGetStarted.yaml
+++ b/website/src/data/readyGetStarted.yaml
@@ -1,9 +1,9 @@
 - title: Want to Contribute?
-  description: We’re proud to make AppScope available as open source under the Apache Software License v2.0. You can join the AppScope development by contributing code and documentation on Github, and by joining our Slack community.
+  description: We’re proud to make AppScope available as open source under the Apache Software License v2.0. You can join the AppScope development effort by contributing code and documentation on Github, and by joining our Slack community.
   items:
     - icon: github
       url: https://github.com/criblio/appscope
       buttonText: Fork On Github
     - icon:
-      url: https://cribl.io/community?utm_source=appscope&utm_medium=footer&utm_campaign=appscope
+      url: https://cribl.io/community/#form?utm_source=appscope&utm_medium=footer&utm_campaign=appscope
       buttonText: Join Our Community

--- a/website/src/pages/docs/community.md
+++ b/website/src/pages/docs/community.md
@@ -4,12 +4,10 @@ title: Community
 
 # Community
 
-## Join Our Community
-
 To connect with other AppScope users and developers:
 
 - Visit Cribl's [Q&A site](https://curious.cribl.io/).
-- Visit our [Community Slack](https://cribl-community.slack.com/).
+- Join Cribl's [Community Slack](https://cribl.io/community/#form) and check out the `#appscope` channel.
 - Check out learning and other resources in [Cribl Community](https://cribl.io/community?utm_source=appscope&utm_medium=footer&utm_campaign=appscope).
 
 ## How to Contribute


### PR DESCRIPTION
1.
The `corpSiteNav.yaml` was still talking about LogStream etc, fixed that.

2.
The `documentationNav.yaml` had a cateogory of **COMMUNITY** for a single page called **Community**. Changed the category to **PARTICIPATE** ... not 100% happy with that, if someone has a better suggestion.

3.
a.
The `header.yaml` had an "Overview" link which was not needed per PM (and also confusing because it didn't link to the Overview page). Deleted that.

b.
The same header's Community link now links to the AppScope Community page in the docs, per PM.

4.
The `readyGetStarted.yaml` link to Community now links to the sign-up for Cribl Slack.

5.
The "Community" page in docs also now has a Join our Slack link that links to the sign-up and mentions the `#appscope` channel.




