### PR TITLE
[Readme] Fix local development website link reference

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -8,6 +8,6 @@ See the Gatsby docs for complete details but to spin up a local environment for 
 1. Install `node` with `brew install node` on MacOS or `apt install nodejs` on Ubuntu. Keep it updated running `brew upgrade node` or `apt update`/`apt upgrade` occasionally.
 2. Install local dependencies in the project with `npm install`.
 3. Run the local development server with `npm run develop`.
-4. Access the local development version of the website at [`http://127.0.0.1:8000/`](https://127.0.0.1:8000/).
+4. Access the local development version of the website at [`http://127.0.0.1:8000/`](http://127.0.0.1:8000/).
 
 > Using Node 16 or higher breaks some of this. It works with 14.


### PR DESCRIPTION
- the local development server runs on
  `http://localhost:8000` not `https://localhost:8000`:

npm run develop

results with following message

```
You can now view appscope in the browser.
⠀
  http://localhost:8000/
```

ref: https://www.gatsbyjs.com/docs/quick-start/