### PR TITLE
[Integration test] Update http-test to use latest cribl version

### DIFF
--- a/test/integration/http/Dockerfile
+++ b/test/integration/http/Dockerfile
@@ -1,5 +1,6 @@
-FROM cribl/cribl:3.1.0-RC4
+FROM cribl/cribl:3.4.1
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y \
   curl \
   emacs \

--- a/test/integration/logstream/Dockerfile
+++ b/test/integration/logstream/Dockerfile
@@ -1,4 +1,4 @@
-FROM cribl/cribl:latest
+FROM cribl/cribl:3.4.1
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/test/integration/transport/Dockerfile
+++ b/test/integration/transport/Dockerfile
@@ -1,4 +1,4 @@
-FROM cribl/cribl:latest
+FROM cribl/cribl:3.4.1
 
 RUN apt update && apt install -y \
   curl \


### PR DESCRIPTION
Not sure if this can be related to stability/flakiness with the http test as mentioned [here](https://github.com/criblio/appscope/issues/865) but it is still to worth test latest version instead of RC.

- add `DEBIAN_FRONTEND=noninteractive` to avoid
  configuring `tzdata`
- comment regarding version below doesn't apply anymore
- ref: 6856c69