### PR TITLE
Go code improvements

### DIFF
--- a/src/wrap_go.c
+++ b/src/wrap_go.c
@@ -409,6 +409,14 @@ getGoSymbol(const char *buf, char *sname, char *altname, char *mnemonic)
                         break;
                     }
 
+                    // In go 1.17+ we need to ensure we find the correct symbol in the case of ambiguity
+                    if (altname && mnemonic &&
+                        (scope_strcmp(altname, func_name) == 0) &&
+                        (match_assy_instruction((void *)sym_addr, mnemonic) == TRUE)) {
+                        symaddr = sym_addr;
+                        break;
+                    }
+
                     symtab_addr += 16;
                 }
             } else if (magic == GOPCLNTAB_MAGIC_118) {
@@ -432,7 +440,7 @@ getGoSymbol(const char *buf, char *sname, char *altname, char *mnemonic)
                         break;
                     }
 
-                    // In go 1.18 we need to ensure we find the correct symbol in the case of ambiguity
+                    // In go 1.17+ we need to ensure we find the correct symbol in the case of ambiguity
                     if (altname && mnemonic &&
                         (scope_strcmp(altname, func_name) == 0) &&
                         (match_assy_instruction((void *)sym_addr, mnemonic) == TRUE)) {

--- a/src/wrap_go.c
+++ b/src/wrap_go.c
@@ -3,7 +3,6 @@
 #include <asm/prctl.h>
 #include <sys/prctl.h>
 #include <signal.h>
-#include <pthread.h>
 
 #include "com.h"
 #include "dbg.h"
@@ -211,7 +210,6 @@ go_schema_t go_17_schema = {
         [INDEX_HOOK_TLS_SERVER_WRITE] = {"net/http.checkConnErrorWriter.Write",  go_hook_reg_tls_write,        NULL, 0}, // tls server write
         [INDEX_HOOK_TLS_CLIENT_READ]  = {"net/http.(*persistConn).readResponse", go_hook_reg_readResponse,     NULL, 0}, // tls client read
         [INDEX_HOOK_TLS_CLIENT_WRITE] = {"net/http.persistConnWriter.Write",     go_hook_reg_pc_write,         NULL, 0}, // tls client write
-//        [INDEX_HOOK_EXIT]             = {"runtime.exit.abi0",                    go_hook_exit,                 NULL, 0},
         [INDEX_HOOK_EXIT]             = {"runtime.exit",                         go_hook_exit,                 NULL, 0},
         [INDEX_HOOK_DIE]              = {"runtime.dieFromSignal",                go_hook_die,                  NULL, 0},
         [INDEX_HOOK_MAX]              = {"TAP_TABLE_END",                        NULL,                         NULL, 0}
@@ -219,25 +217,7 @@ go_schema_t go_17_schema = {
 };
 
 go_schema_t *g_go_schema = &go_16_schema; // overridden if later version
-
-
-#define GO_HOOK_WRITE            (g_go_schema->tap[INDEX_HOOK_WRITE].assembly_fn)
-#define GO_HOOK_OPEN             (g_go_schema->tap[INDEX_HOOK_OPEN].assembly_fn)
-#define GO_HOOK_UNLINKAT         (g_go_schema->tap[INDEX_HOOK_UNLINKAT].assembly_fn)
-#define GO_HOOK_GETDENTS         (g_go_schema->tap[INDEX_HOOK_GETDENTS].assembly_fn)
-#define GO_HOOK_SOCKET           (g_go_schema->tap[INDEX_HOOK_SOCKET].assembly_fn)
-#define GO_HOOK_ACCEPT           (g_go_schema->tap[INDEX_HOOK_ACCEPT].assembly_fn)
-#define GO_HOOK_READ             (g_go_schema->tap[INDEX_HOOK_READ].assembly_fn)
-#define GO_HOOK_CLOSE            (g_go_schema->tap[INDEX_HOOK_CLOSE].assembly_fn)
-#define GO_HOOK_TLS_SERVER_READ  (g_go_schema->tap[INDEX_HOOK_TLS_SERVER_READ].assembly_fn)
-#define GO_HOOK_TLS_SERVER_WRITE (g_go_schema->tap[INDEX_HOOK_TLS_SERVER_WRITE].assembly_fn)
-#define GO_HOOK_TLS_CLIENT_READ  (g_go_schema->tap[INDEX_HOOK_TLS_CLIENT_READ].assembly_fn)
-#define GO_HOOK_TLS_CLIENT_WRITE (g_go_schema->tap[INDEX_HOOK_TLS_CLIENT_WRITE].assembly_fn)
-#define GO_HOOK_EXIT             (g_go_schema->tap[INDEX_HOOK_EXIT].assembly_fn)
-#define GO_HOOK_DIE              (g_go_schema->tap[INDEX_HOOK_DIE].assembly_fn)
-
 uint64_t g_glibc_guard = 0LL;
-
 void (*go_runtime_cgocall)(void);
 
 #if NEEDEVNULL > 0
@@ -388,7 +368,7 @@ getGoSymbol(const char *buf, char *sname, char *altname, char *mnemonic)
 
     for (i = 0; i < ehdr->e_shnum; i++) {
         sec_name = section_strtab + sections[i].sh_name;
-        if (scope_strcmp(".gopclntab", sec_name) == 0) {
+        if (scope_strstr(sec_name, ".gopclntab")) {
             const void *pclntab_addr = buf + sections[i].sh_offset;
             /*
             Go symbol table is stored in the .gopclntab section
@@ -411,13 +391,6 @@ getGoSymbol(const char *buf, char *sname, char *altname, char *mnemonic)
                         break;
                     }
 
-                    if (altname && mnemonic &&
-                        (scope_strcmp(altname, func_name) == 0) &&
-                        (match_assy_instruction((void *)sym_addr, mnemonic) == TRUE)) {
-                        symaddr = sym_addr;
-                        break;
-                    }
-
                     symtab_addr += 16;
                 }
             } else if (magic == GOPCLNTAB_MAGIC_116) {
@@ -433,13 +406,6 @@ getGoSymbol(const char *buf, char *sname, char *altname, char *mnemonic)
                     if (scope_strcmp(sname, func_name) == 0) {
                         symaddr = sym_addr;
                         scopeLog(CFG_LOG_TRACE, "symbol found %s = 0x%08lx\n", func_name, sym_addr);
-                        break;
-                    }
-
-                    if (altname && mnemonic &&
-                        (scope_strcmp(altname, func_name) == 0) &&
-                        (match_assy_instruction((void *)sym_addr, mnemonic) == TRUE)) {
-                        symaddr = sym_addr;
                         break;
                     }
 
@@ -466,6 +432,7 @@ getGoSymbol(const char *buf, char *sname, char *altname, char *mnemonic)
                         break;
                     }
 
+                    // In go 1.18 we need to ensure we find the correct symbol in the case of ambiguity
                     if (altname && mnemonic &&
                         (scope_strcmp(altname, func_name) == 0) &&
                         (match_assy_instruction((void *)sym_addr, mnemonic) == TRUE)) {
@@ -881,7 +848,7 @@ initGoHook(elf_buf_t *ebuf)
         // if it is not set, we know we're dealing with a "go string"
         void *ver_addr = getGoVersionAddr(ebuf->buf);
         if (g_go_build_ver[0] != '\0') {
-            go_ver = (char *)((uint64_t)ver_addr + base);
+            go_ver = (char *)((uint64_t)ver_addr);
         } else {
             go_ver = go_str((void *)((uint64_t)ver_addr + base));
         }
@@ -1096,18 +1063,9 @@ do_cfunc(char *stackptr, void *cfunc, void *gfunc)
  * stack and the fs register points to an 'm' TLS
  * base address.
  *
- * We need to switch from a 'g' context to a
- * libc context in order to execute 'C' code that
- * calls libc functions. The go_switch() function
- * handles all of that. The address of a specific
- * handler is passed to go_swtich which calls the
- * handler when the appropriate switch has been
- * accopmlished.
- * 
  * Specific handlers are defined as the c_xxx functions.
  * Example, there is a c_write() that handles extracting
- * details for write operations. The address of c_write
- * is passed to go_switch.
+ * details for write operations. 
  *
  * All handlers take a single parameter, the stack address
  * from the interposed Go function. All params are passed
@@ -1134,7 +1092,7 @@ c_write(char *stackaddr)
 EXPORTON void *
 go_write(char *stackptr)
 {
-    return do_cfunc(stackptr, c_write, GO_HOOK_WRITE);
+    return do_cfunc(stackptr, c_write, g_go_schema->tap[INDEX_HOOK_WRITE].assembly_fn);
 }
 
 // Extract data from syscall.Getdents (read dir)
@@ -1152,7 +1110,7 @@ c_getdents(char *stackaddr)
 EXPORTON void *
 go_getdents(char *stackptr)
 {
-    return do_cfunc(stackptr, c_getdents, GO_HOOK_GETDENTS);
+    return do_cfunc(stackptr, c_getdents, g_go_schema->tap[INDEX_HOOK_GETDENTS].assembly_fn);
 }
 
 // Extract data from syscall.unlinkat (delete file)
@@ -1179,7 +1137,7 @@ c_unlinkat(char *stackaddr)
 EXPORTON void *
 go_unlinkat(char *stackptr)
 {
-    return do_cfunc(stackptr, c_unlinkat, GO_HOOK_UNLINKAT);
+    return do_cfunc(stackptr, c_unlinkat, g_go_schema->tap[INDEX_HOOK_UNLINKAT].assembly_fn);
 }
 
 // Extract data from syscall.openat (file open)
@@ -1206,7 +1164,7 @@ c_open(char *stackaddr)
 EXPORTON void *
 go_open(char *stackptr)
 {
-    return do_cfunc(stackptr, c_open, GO_HOOK_OPEN);
+    return do_cfunc(stackptr, c_open, g_go_schema->tap[INDEX_HOOK_OPEN].assembly_fn);
 }
 
 // Extract data from syscall.Close (close)
@@ -1225,7 +1183,7 @@ c_close(char *stackaddr)
 EXPORTON void *
 go_close(char *stackptr)
 {
-    return do_cfunc(stackptr, c_close, GO_HOOK_CLOSE);
+    return do_cfunc(stackptr, c_close, g_go_schema->tap[INDEX_HOOK_CLOSE].assembly_fn);
 }
 
 // Extract data from syscall.read (read)
@@ -1246,7 +1204,7 @@ c_read(char *stackaddr)
 EXPORTON void *
 go_read(char *stackptr)
 {
-    return do_cfunc(stackptr, c_read, GO_HOOK_READ);
+    return do_cfunc(stackptr, c_read, g_go_schema->tap[INDEX_HOOK_READ].assembly_fn);
 }
 
 // Extract data from syscall.socket (net open)
@@ -1268,7 +1226,7 @@ c_socket(char *stackaddr)
 EXPORTON void *
 go_socket(char *stackptr)
 {
-    return do_cfunc(stackptr, c_socket, GO_HOOK_SOCKET);
+    return do_cfunc(stackptr, c_socket, g_go_schema->tap[INDEX_HOOK_SOCKET].assembly_fn);
 }
 
 // Extract data from syscall.accept4 (plain server accept)
@@ -1289,7 +1247,7 @@ c_accept4(char *stackaddr)
 EXPORTON void *
 go_accept4(char *stackptr)
 {
-    return do_cfunc(stackptr, c_accept4, GO_HOOK_ACCEPT);
+    return do_cfunc(stackptr, c_accept4, g_go_schema->tap[INDEX_HOOK_ACCEPT].assembly_fn);
 }
 
 /*
@@ -1365,7 +1323,7 @@ c_http_server_read(char *stackaddr)
 EXPORTON void *
 go_tls_read(char *stackptr)
 {
-    return do_cfunc(stackptr, c_http_server_read, GO_HOOK_TLS_SERVER_READ);
+    return do_cfunc(stackptr, c_http_server_read, g_go_schema->tap[INDEX_HOOK_TLS_SERVER_READ].assembly_fn);
 }
 
 /*
@@ -1414,7 +1372,7 @@ c_http_server_write(char *stackaddr)
 EXPORTON void *
 go_tls_write(char *stackptr)
 {
-    return do_cfunc(stackptr, c_http_server_write, GO_HOOK_TLS_SERVER_WRITE);
+    return do_cfunc(stackptr, c_http_server_write, g_go_schema->tap[INDEX_HOOK_TLS_SERVER_WRITE].assembly_fn);
 }
 
 /*
@@ -1469,7 +1427,7 @@ c_http_client_write(char *stackaddr)
 EXPORTON void *
 go_pc_write(char *stackptr)
 {
-    return do_cfunc(stackptr, c_http_client_write, GO_HOOK_TLS_CLIENT_WRITE);
+    return do_cfunc(stackptr, c_http_client_write, g_go_schema->tap[INDEX_HOOK_TLS_CLIENT_WRITE].assembly_fn);
 }
 
 /*
@@ -1531,7 +1489,7 @@ c_http_client_read(char *stackaddr)
 EXPORTON void *
 go_readResponse(char *stackptr)
 {
-    return do_cfunc(stackptr, c_http_client_read, GO_HOOK_TLS_CLIENT_READ);
+    return do_cfunc(stackptr, c_http_client_read, g_go_schema->tap[INDEX_HOOK_TLS_CLIENT_READ].assembly_fn);
 }
 
 extern void handleExit(void);
@@ -1590,11 +1548,11 @@ c_exit(char *stackaddr)
 EXPORTON void *
 go_exit(char *stackptr)
 {
-    return do_cfunc(stackptr, c_exit, GO_HOOK_EXIT);
+    return do_cfunc(stackptr, c_exit, g_go_schema->tap[INDEX_HOOK_EXIT].assembly_fn);
 }
 
 EXPORTON void *
 go_die(char *stackptr)
 {
-    return do_cfunc(stackptr, c_exit, GO_HOOK_DIE);
+    return do_cfunc(stackptr, c_exit, g_go_schema->tap[INDEX_HOOK_DIE].assembly_fn);
 }


### PR DESCRIPTION
- remove unnecessary reference to `pthread.h`
- remove macro for indexed `.assembly_fn` definitions to make code more readable
- remove commented out `runtime.exit.abi0` hook. We now resolve the native symbol `runtime.exit`, and understand why.
- change the lookup for `.gopclntab` to a find a submatch instead of an exact match (in pie executables, the name of the .pclntab section is prefixed).
- remove the search for an alternate symbol in go12-17 symbol lookup.
- update a comment that referenced the legacy go_switch function/s.
- don't add a base offset to our internal symbol address of go version in stripped pie executables.