### PR TITLE
Enable bash test for `aarch64`

### DIFF
--- a/test/integration/docker-compose.x86_64.yml
+++ b/test/integration/docker-compose.x86_64.yml
@@ -48,16 +48,6 @@ services:
       - 8000:8000
     <<: *scope-common
 
-  # skipped on ARM - not supported yet
-  bash:
-    image: ghcr.io/criblio/appscope-test-bash:${TAG:?Missing TAG environment variable}
-    build:
-      cache_from:
-        - ghcr.io/criblio/appscope-test-bash:${TAG:?Missing TAG environment variable}
-      context: .
-      dockerfile: ./bash/Dockerfile
-    <<: *scope-common
-
   # There are no arm64 golang images at Docker Hub for these versions of Go
   go_2:
     image: ghcr.io/criblio/appscope-test-go_2:${TAG:?Missing TAG environment variable}

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -19,6 +19,15 @@ services:
       dockerfile: ./alpine/Dockerfile
     <<: *scope-common
 
+  bash:
+    image: ghcr.io/criblio/appscope-test-bash:${TAG:?Missing TAG environment variable}
+    build:
+      cache_from:
+        - ghcr.io/criblio/appscope-test-bash:${TAG:?Missing TAG environment variable}
+      context: .
+      dockerfile: ./bash/Dockerfile
+    <<: *scope-common
+
   syscalls:
     image: ghcr.io/criblio/appscope-test-syscalls:${TAG:?Missing TAG environment variable}
     build:


### PR DESCRIPTION
- bash memory fix requirement was removed with aa710bb

Closes #427