### PR TITLE
Print `libscope.so`,`ldscope` and `scope` size in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -362,7 +362,7 @@ jobs:
       - name: Chmod Binaries
         run: chmod +x lib/linux/*/* bin/linux/*/*
 
-      # Depoly to the CDN
+      # Deploy to the CDN
       - name: Deploy
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,6 +316,18 @@ jobs:
         id: tests
         run: echo "::set-output name=tests-${{ steps.env.outputs.arch }}::$(make -s -C test/integration tests | egrep -v '.*java(9|1[023456])$' | sort -V | jq -ncR '[inputs]')"
 
+      - name: Print size of Binaries
+        run: |
+          echo "::group::libscope.so"
+          stat -c %s lib/linux/${{ steps.env.outputs.arch }}/libscope.so
+          echo "::endgroup::"
+          echo "::group::scope"
+          stat -c %s bin/linux/${{ steps.env.outputs.arch }}/scope
+          echo "::endgroup::"
+          echo "::group::ldscope"
+          stat -c %s bin/linux/${{ steps.env.outputs.arch }}/ldscope
+          echo "::endgroup::"
+
       # Upload the built binaries for use by later stages. We specify the same
       # artifact name for this job as well as the other job for ARM. The result
       # is a single artifact with binaries from both jobs.


### PR DESCRIPTION
Minor improvement, I found this useful while working on following issues:

- #938 
- #909

- While working on the issues above I have extracted the information about size of generated files manually. With this PR I could just copy&paste it from log.
- Additional improvement is:  we will have the information about size impact in Opening Pull Request stage, e.g.  it can be useful in case of future extending the 3rd party libraries

Example step output:
```
Run echo "::group::libscope.so"
libscope.so
  7687144
scope
  51474285
ldscope
  90373
```