### PR TITLE
Fix failing alpine based integration tests - dependency issue with python

### DIFF
--- a/test/integration/alpine/Dockerfile
+++ b/test/integration/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.15
 
 RUN apk add go openssl make file bash curl autoconf automake libtool openssl-dev rust nodejs ruby python3 php php-openssl apache2 apache2-ssl python3-dev py3-pip libffi-dev cargo && \
     go clean -cache

--- a/test/integration/alpine/Dockerfile
+++ b/test/integration/alpine/Dockerfile
@@ -37,21 +37,21 @@ RUN mkdir -p /opt/test && \
     cd /opt/test/curlssl && \
       ./buildconf && \
       ./configure --with-ssl --without-gnutls --without-nss && \
-      make -j8 && \
+      make -j"$(nproc)" && \
     cd /opt/test && \
       tar xvzf curl-7.69.1.tar.gz && \
       mv curl-7.69.1 curltls && \
     cd /opt/test/curltls && \
       ./buildconf && \
       ./configure --without-ssl --with-gnutls --without-nss && \
-      make -j8 && \
+      make -j"$(nproc)" && \
     cd /opt/test && \
       tar xvzf curl-7.69.1.tar.gz && \
       mv curl-7.69.1 curlnss && \
     cd /opt/test/curlnss && \
       ./buildconf && \
       ./configure --without-ssl --without-gnutls --with-nss && \
-      make -j8 && \
+      make -j"$(nproc)" && \
     cd /opt/test && \
       cp curlssl/src/.libs/curl curl-ssl && \
       cp curltls/src/.libs/curl curl-tls && \

--- a/test/integration/syscalls/Dockerfile
+++ b/test/integration/syscalls/Dockerfile
@@ -10,11 +10,12 @@ RUN yum -y update && \
 RUN mkdir -p /opt/test-runner/logs/ /opt/test
 COPY ./syscalls/ltp_p1.patch /opt/test/
 
+ARG LTP_VERSION=20210524
 RUN cd /opt/test && \
-      wget https://github.com/linux-test-project/ltp/archive/refs/tags/20210524.zip && \
-      unzip 20210524.zip && \
-      rm -f 20210524.zip && \
-      mv ltp-20210524 ltp && \
+      wget https://github.com/linux-test-project/ltp/archive/refs/tags/${LTP_VERSION}.zip && \
+      unzip ${LTP_VERSION}.zip && \
+      rm -f ${LTP_VERSION}.zip && \
+      mv ltp-${LTP_VERSION} ltp && \
       cd /opt/test/ltp && \
       patch -p1 < /opt/test/ltp_p1.patch && \
       make autotools && \

--- a/test/integration/syscalls/Dockerfile.alpine
+++ b/test/integration/syscalls/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.15
 
 RUN apk add bash python3 py3-pip wget patch
 RUN pip3 install virtualenv

--- a/test/integration/syscalls/Dockerfile.alpine
+++ b/test/integration/syscalls/Dockerfile.alpine
@@ -6,11 +6,12 @@ RUN pip3 install virtualenv
 RUN mkdir -p /opt/test-runner/logs/ /opt/test
 COPY ./syscalls/ltp_p1.patch /opt/test/
 
+ARG LTP_VERSION=20210927
 RUN cd /opt/test && \
-      wget https://github.com/linux-test-project/ltp/archive/refs/tags/20210927.zip && \
-      unzip 20210927.zip && \
-      rm -f 20210927.zip && \
-      mv ltp-20210927 ltp && \
+      wget https://github.com/linux-test-project/ltp/archive/refs/tags/${LTP_VERSION}.zip && \
+      unzip ${LTP_VERSION}.zip && \
+      rm -f ${LTP_VERSION}.zip && \
+      mv ltp-${LTP_VERSION} ltp && \
       cd /opt/test/ltp && \
       ./ci/alpine.sh && \
       patch -p1 < /opt/test/ltp_p1.patch && \


### PR DESCRIPTION
- Alpine latest points to `3.16.0` [1]
- default Python version is 3.10 there [2]

Link: https://github.com/docker-library/official-images/commit/6675d08 [1]
Link: https://github.com/docker-library/python/commit/1a63123 [2]

The other commit is just a cosmetic change to store used version of LTP in single variable via Docker ARG