### PR TITLE
Set console events to `allowbinary=false` in cli defaults

### DIFF
--- a/cli/libscope/config.go
+++ b/cli/libscope/config.go
@@ -1,5 +1,37 @@
 package libscope
 
+import (
+	"errors"
+	"fmt"
+)
+
+type BoolString string
+
+func (b BoolString) MarshalYAML() (interface{}, error) {
+	switch BoolString(b) {
+	case "":
+		return nil, nil
+	case "false":
+		return false, nil
+	case "true":
+		return true, nil
+	default:
+		return nil, errors.New(fmt.Sprintf("Boolean Marshal error: invalid input %s", string(b)))
+	}
+}
+
+func (bit *BoolString) UnmarshalJSON(data []byte) error {
+	asString := string(data)
+	if asString == "1" || asString == "true" || asString == `"true"` {
+		*bit = "true"
+	} else if asString == "0" || asString == "false" || asString == `"false"` {
+		*bit = "false"
+	} else {
+		return errors.New(fmt.Sprintf("Boolean unmarshal error: invalid input %s", asString))
+	}
+	return nil
+}
+
 // ScopeConfig represents our current running configuration
 type ScopeConfig struct {
 	Cribl    ScopeCriblConfig    `mapstructure:"cribl,omitempty" json:"cribl,omitempty" yaml:"cribl"`
@@ -45,11 +77,11 @@ type ScopeMetricWatchConfig struct {
 
 // ScopeEventWatchConfig represents a event watch configuration
 type ScopeEventWatchConfig struct {
-	WatchType string `mapstructure:"type" json:"type" yaml:"type"`
-	Name      string `mapstructure:"name" json:"name" yaml:"name"`
-	Field     string `mapstructure:"field,omitempty" json:"field,omitempty" yaml:"field,omitempty"`
-	Value     string `mapstructure:"value" json:"value" yaml:"value"`
-	AllowBinary bool   `mapstructure:"allowbinary,omitempty" json:"allowbinary,omitempty" yaml:"allowbinary,omitempty"`
+	WatchType   string     `mapstructure:"type" json:"type" yaml:"type"`
+	Name        string     `mapstructure:"name" json:"name" yaml:"name"`
+	Field       string     `mapstructure:"field,omitempty" json:"field,omitempty" yaml:"field,omitempty"`
+	Value       string     `mapstructure:"value" json:"value" yaml:"value"`
+	AllowBinary BoolString `mapstructure:"allowbinary,omitempty" json:"allowbinary,omitempty" yaml:"allowbinary,omitempty"`
 }
 
 // ScopeLibscopeConfig represents how to configure libscope

--- a/cli/run/scopeconfig.go
+++ b/cli/run/scopeconfig.go
@@ -72,7 +72,7 @@ func (c *Config) SetDefault() error {
 					WatchType:   "console",
 					Name:        "(stdout|stderr)",
 					Value:       ".*",
-					AllowBinary: true,
+					AllowBinary: "false",
 				},
 				{
 					WatchType: "net",

--- a/cli/run/setup_test.go
+++ b/cli/run/setup_test.go
@@ -177,7 +177,7 @@ event:
   - type: console
     name: (stdout|stderr)
     value: .*
-    allowbinary: true
+    allowbinary: false
   - type: net
     name: .*
     field: .*

--- a/test/integration/cli/expected.yml
+++ b/test/integration/cli/expected.yml
@@ -46,7 +46,7 @@ event:
   - type: console
     name: (stdout|stderr)
     value: .*
-    allowbinary: true
+    allowbinary: false
   - type: net
     name: .*
     field: .*


### PR DESCRIPTION
We wanted to set `allowbinary` to false by default when the cli is used so that the cli can be used to display events without binary data appearing.

First we tried to explicitly set the `allowbinary` field to false, but by doing so this meant it was omitted in scope.yml output.

We then tried to disable the `omitempty` setting for that field, but that meant that the `allowbinary` field was included and set to false for _all_ event watchtypes. This was not a good solution since the `allowbinary` setting only applies to console events at this time.

I changed the `allowbinary` field to a string. Strings are included in the yml file directly without quotations... usually. It turns out that only for string values “on/off/true/false”, the quote marks remain in the yml output. The marshaller thinks you wanted to display these in quotes.

I added a custom yaml marshaller (and json unmarshaller) that would allow “false” to be output in yml without quotes (and input from json with quotes).

**Testing**
There is a unit test and integration test that checks the expected yml against what was produced as a default. These tests were both updated.

QA Instructions: #988
Closes: #988 
