### PR TITLE
(#1013) Update URL links in http integration test

### DIFF
--- a/test/integration/http/scope-test
+++ b/test/integration/http/scope-test
@@ -4,7 +4,7 @@
 
 # This is the URL for a file on a server that supports various HTTP/1.x and
 # HTTP/2 requests. We found it in the tests for WireShark.
-URL=http://nghttp2.org/robots.txt
+URL=http://gnu.org/robots.txt
 URL_HTTPS=https://nghttp2.org/robots.txt
 
 # LogStream will be configured to dump NDJSON output files here.


### PR DESCRIPTION
- http://nghttp2.org/robots.txt is not valid link