### PR TITLE
Docs/commits from Jakub

### DIFF
--- a/docker/docs/schema2md.js
+++ b/docker/docs/schema2md.js
@@ -50,7 +50,7 @@ function parseProperties({ name, properties = {}, required = [], baseProps = fal
     ];
     if (value.enum) {
       description.push(
-        '**Possible values:**<ul>' + value.enum.map(v => `<li>\`${v}\`</li>`).join('') + '</ul>'
+        `**Possible values:**<ul style="column-count: ${Math.ceil(value.enum.length / 20)};">${value.enum.map(v => `<li>\`${v}\`</li>`).join('')}</ul>`
       );
     }
     if (value.const) {

--- a/website/src/components/layouts/documentationLayout.js
+++ b/website/src/components/layouts/documentationLayout.js
@@ -3,12 +3,16 @@ import { Container, Row, Col } from "react-bootstrap";
 import DocsNav from "../DocsNav";
 import Header from "../Header";
 import MobileHeader from "../MobileHeader";
+import { Helmet } from "react-helmet";
 
 import "../../scss/_documentation.scss";
 import Footer from "../Footer";
 export default function Layout({ children }) {
   return (
     <>
+      <Helmet>
+        <meta name="og:image" content={'https://cribl.io/wp-content/uploads/2022/01/thumb.appScope.fullColorWhiteAlt.png'} />
+      </Helmet>
       <div className="display-xs">
         <MobileHeader />
       </div>


### PR DESCRIPTION
This PR contains two tiny unrelated fixes.

- One adds an OpenGraph meta image tag so that if somebody posts a link to our docs on Twitter or LinkedIn, the correct image will appear in the tweet/post. 

- The other improves readability the schema reference by breaking long lists into columns.

Thanks to @jakub-cribl for these fixes!