### PR TITLE
Fix `pip3 install virtualenv`

### DIFF
--- a/test/integration/syscalls/Dockerfile.alpine
+++ b/test/integration/syscalls/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16.1
 
 RUN apk add bash python3 py3-pip wget patch
 RUN pip3 install virtualenv
@@ -40,7 +40,7 @@ COPY ./test_runner /opt/test-runner/
 COPY ./syscalls/syscall_tests_conf.json /opt/test-runner/syscall_tests_conf.json
 
 # # # Switching to Python 3.8 required this hack. Not sure where the kafka packages are coming from.
-RUN sed -i 's/\basync\b/is_async/g' /opt/test-runner/lib/python3.9/site-packages/kafka/producer/*.py
+RUN sed -i 's/\basync\b/is_async/g' /opt/test-runner/lib/python3.10/site-packages/kafka/producer/*.py
 
 ENV PATH="/usr/local/scope:/usr/local/scope/bin:${PATH}"
 COPY scope-profile.sh /etc/profile.d/scope.sh


### PR DESCRIPTION
It looks like legacy version of `pip3` poorly manage situation when
distutils is already present in OS.

`pip3` in `Alpine 3.15` is 20.3.4
`pip3` in `Alpine 3.16.1` is 22.1.1

Ref: https://github.com/pypa/pip/commit/b728bdad2a4fe29f2eedb8f37bdeefc1f60e756d