### PR TITLE
(#1067) Fix attach process by name error: index out of range

### DIFF
--- a/cli/run/attach.go
+++ b/cli/run/attach.go
@@ -111,9 +111,9 @@ func choosePid(procs util.Processes) int {
 	fmt.Println("Select an ID from the list:")
 	var selection string
 	fmt.Scanln(&selection)
-	i, err := strconv.Atoi(selection)
+	i, err := strconv.ParseUint(selection, 10, 32)
 	i--
-	if err != nil || i < 0 || i > len(procs) {
+	if err != nil || i >= uint64(len(procs)) {
 		util.ErrAndExit("Invalid Selection")
 	}
 	return procs[i].Pid


### PR DESCRIPTION
- provide exit status message without panic

Closes #1067

### Test instructions:
```
docker run --privileged --rm -it cribl/scope:dev-x86_64
top &
top &
scope attach top
Found multiple processes matching that name...
ID	PID	USER	SCOPED	COMMAND
1 	16 	root	false 	top
2 	17 	root	false 	top
Select an ID from the list:
```
When choosing `3`, you should see:
```
Invalid Selection
```
Instead of panic described in #1067 