### PR TITLE
Add input version validation to .github/workflows/update_latest.yml 

### DIFF
--- a/.github/workflows/update_latest.yml
+++ b/.github/workflows/update_latest.yml
@@ -48,7 +48,7 @@ jobs:
     name: Update CDN Latest
     runs-on: ubuntu-latest
     needs: info
-    if: ${{ needs.info.outputs.tag != "" && needs.info.outputs.prerelease = "" }}
+    if: ${{ needs.info.outputs.tag != "" && needs.info.outputs.prerelease == "" }}
     steps:
       - name: Update dl/scope/latest
         env:
@@ -73,7 +73,7 @@ jobs:
     name: Update Latest Tag in Dockerhub
     runs-on: ubuntu-latest
     needs: [info,update-cdn-latest]
-    if: ${{ needs.info.outputs.tag != "" && needs.info.outputs.prerelease = "" }}
+    if: ${{ needs.info.outputs.tag != "" && needs.info.outputs.prerelease == "" }}
     steps:
       - name: Login to Dockerhub
         uses: docker/login-action@v2
@@ -89,6 +89,7 @@ jobs:
           crane tag cribl/scope:${{ needs.info.outputs.tag }} latest
 
       - name: Print Digest/Manifest Information
+        run: |
           echo "digest and manifest for cribl/scope:${{ needs.info.outputs.tag }}"
           crane digest cribl/scope:${{ needs.info.outputs.tag }}
           crane manifest cribl/scope:${{ needs.info.outputs.tag }} | jq .

--- a/.github/workflows/update_latest.yml
+++ b/.github/workflows/update_latest.yml
@@ -48,7 +48,7 @@ jobs:
     name: Update CDN Latest
     runs-on: ubuntu-latest
     needs: info
-    if: ${{ needs.info.outputs.tag != "" && needs.info.outputs.prerelease == "" }}
+    if: ${{ needs.info.outputs.tag != '' && needs.info.outputs.prerelease == '' }}
     steps:
       - name: Update dl/scope/latest
         env:
@@ -73,7 +73,7 @@ jobs:
     name: Update Latest Tag in Dockerhub
     runs-on: ubuntu-latest
     needs: [info,update-cdn-latest]
-    if: ${{ needs.info.outputs.tag != "" && needs.info.outputs.prerelease == "" }}
+    if: ${{ needs.info.outputs.tag != '' && needs.info.outputs.prerelease == '' }}
     steps:
       - name: Login to Dockerhub
         uses: docker/login-action@v2

--- a/.github/workflows/update_latest.yml
+++ b/.github/workflows/update_latest.yml
@@ -42,9 +42,14 @@ jobs:
 
       - name: Check Tag
         run: |
-          if [[ ${{ steps.tag.outputs.tag }} == '' || ${{ steps.version.outputs.prerelease }} != '' ]]; then
+          if [ "${{ steps.tag.outputs.tag }}" == '' ]; then
               echo "The git version ${{ steps.version.outputs.version }} is not usable..."
-              echo "  It must start with a v, be a valid semantic version, and not be a prerelease"
+              echo "  It must start with a v, and be a valid semantic version"
+              exit 1
+          fi
+          if [ "${{ steps.version.outputs.prerelease }}" != '' ]; then
+              echo "The git version ${{ steps.version.outputs.version }} is not usable..."
+              echo "  It must not be a prerelease"
               exit 1
           fi
 

--- a/.github/workflows/update_latest.yml
+++ b/.github/workflows/update_latest.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   info:
-    name: Validate Input Version
+    name: Validate Git Tag
     runs-on: ubuntu-latest
     steps:
       - name: Get Version
@@ -29,7 +29,7 @@ jobs:
               echo "::set-output name=tag::${{ steps.version.outputs.version-without-v }}"
           fi
 
-      - name: Version/Tag Outputs
+      - name: Echo Outputs
         run: |
           echo "version=\"${{ steps.version.outputs.version }}\""
           echo "major=\"${{ steps.version.outputs.major }}\""
@@ -40,6 +40,14 @@ jobs:
           echo "is-semver=\"${{ steps.version.outputs.is-semver }}\""
           echo "tag=\"${{ steps.tag.outputs.tag }}\""
 
+      - name: Check Tag
+        run: |
+          if [[ ${{needs.info.outputs.tag}} == '' || ${{needs.info.outputs.prerelease}} != '' ]]; then
+              echo "The git version ${{ steps.version.outputs.version }} is not usable..."
+              echo "  It must start with a v, be a valid semantic version, and not be a prerelease"
+              exit 1
+          fi
+
     outputs:
       prerelease: ${{ steps.version.outputs.prerelease }}
       tag: ${{ steps.tag.outputs.tag }}
@@ -48,7 +56,6 @@ jobs:
     name: Update CDN Latest
     runs-on: ubuntu-latest
     needs: info
-    if: ${{ needs.info.outputs.tag != '' && needs.info.outputs.prerelease == '' }}
     steps:
       - name: Update dl/scope/latest
         env:
@@ -73,7 +80,6 @@ jobs:
     name: Update Latest Tag in Dockerhub
     runs-on: ubuntu-latest
     needs: [info,update-cdn-latest]
-    if: ${{ needs.info.outputs.tag != '' && needs.info.outputs.prerelease == '' }}
     steps:
       - name: Login to Dockerhub
         uses: docker/login-action@v2

--- a/.github/workflows/update_latest.yml
+++ b/.github/workflows/update_latest.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Check Tag
         run: |
-          if [[ ${{needs.info.outputs.tag}} == '' || ${{needs.info.outputs.prerelease}} != '' ]]; then
+          if [[ ${{ steps.tag.outputs.tag }} == '' || ${{ steps.version.outputs.prerelease }} != '' ]]; then
               echo "The git version ${{ steps.version.outputs.version }} is not usable..."
               echo "  It must start with a v, be a valid semantic version, and not be a prerelease"
               exit 1

--- a/.github/workflows/update_latest.yml
+++ b/.github/workflows/update_latest.yml
@@ -12,15 +12,43 @@
 name: Update Latest
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: New Latest Version (example value "1.1.2")
-        default: ""
-        required: true
+
 jobs:
+  info:
+    name: Validate Input Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Version
+        id: version
+        uses: battila7/get-version-action@v2
+
+      - name: Get Tag
+        id: tag
+        run: |
+          if [ -z "${GITHUB_REF%%refs/tags/v*}" -a "true" = "${{ steps.version.outputs.is-semver }}" ]; then
+              echo "::set-output name=tag::${{ steps.version.outputs.version-without-v }}"
+          fi
+
+      - name: Version/Tag Outputs
+        run: |
+          echo "version=\"${{ steps.version.outputs.version }}\""
+          echo "major=\"${{ steps.version.outputs.major }}\""
+          echo "minor=\"${{ steps.version.outputs.minor }}\""
+          echo "maintenance=\"${{ steps.version.outputs.patch }}\""
+          echo "prerelease=\"${{ steps.version.outputs.prerelease }}\""
+          echo "build=\"${{ steps.version.outputs.build }}\""
+          echo "is-semver=\"${{ steps.version.outputs.is-semver }}\""
+          echo "tag=\"${{ steps.tag.outputs.tag }}\""
+
+    outputs:
+      prerelease: ${{ steps.version.outputs.prerelease }}
+      tag: ${{ steps.tag.outputs.tag }}
+
   update-cdn-latest:
     name: Update CDN Latest
     runs-on: ubuntu-latest
+    needs: info
+    if: ${{ needs.info.outputs.tag != "" && needs.info.outputs.prerelease = "" }}
     steps:
       - name: Update dl/scope/latest
         env:
@@ -30,12 +58,12 @@ jobs:
           CF_DISTRIBUTION_ID: ${{ secrets.CF_DISTRIBUTION_ID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::group::Updating https://cdn.cribl.io/dl/scope/latest to ${{ github.event.inputs.version }}"
+          echo "::group::Updating https://cdn.cribl.io/dl/scope/latest to ${{ needs.info.outputs.tag }}"
           S3_SCOPE=s3://io.cribl.cdn/dl/scope
           TMPDIR=${RUNNER_TEMP}
 
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            echo "${{ github.event.inputs.version }}" > ${TMPDIR}/latest
+          if [ -n "${{ needs.info.outputs.tag }}" ]; then
+            echo "${{ needs.info.outputs.tag }}" > ${TMPDIR}/latest
             aws s3 cp ${TMPDIR}/latest ${S3_SCOPE}/latest
             aws cloudfront create-invalidation --distribution-id ${CF_DISTRIBUTION_ID} --paths '/dl/scope/latest'
           fi
@@ -44,7 +72,8 @@ jobs:
   update-dockerhub-latest:
     name: Update Latest Tag in Dockerhub
     runs-on: ubuntu-latest
-    needs: update-cdn-latest
+    needs: [info,update-cdn-latest]
+    if: ${{ needs.info.outputs.tag != "" && needs.info.outputs.prerelease = "" }}
     steps:
       - name: Login to Dockerhub
         uses: docker/login-action@v2
@@ -57,8 +86,12 @@ jobs:
 
       - name: Update the Latest Tag
         run: |
-          crane digest cribl/scope:${{ github.event.inputs.version }}
-          crane tag cribl/scope:${{ github.event.inputs.version }} latest
+          crane tag cribl/scope:${{ needs.info.outputs.tag }} latest
+
+      - name: Print Digest/Manifest Information
+          echo "digest and manifest for cribl/scope:${{ needs.info.outputs.tag }}"
+          crane digest cribl/scope:${{ needs.info.outputs.tag }}
+          crane manifest cribl/scope:${{ needs.info.outputs.tag }} | jq .
+          echo "digest and manifest for cribl/scope:latest"
           crane digest cribl/scope:latest
-          crane manifest cribl/scope:${{ github.event.inputs.version }} | jq .
           crane manifest cribl/scope:latest | jq .

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -77,12 +77,12 @@ additional steps are taken depending on the trigger.
 The [`website`](../.github/workflows/website.yml) workflow handles building and
 deploying the [`website/`](../website/) content to <https://staging.appscope.dev/>
 and <https://appscope.dev/>. The staging website is intended to always reflect
-the master branch.  The production website is updated only when a "web" tag
-has been applied and pushed.  See the build script in that folder for details.
+the master branch. The production website is updated only when a "web" tag
+has been applied and pushed. See the build script in that folder for details.
 
 The [`update_latest`](../.github/workflows/update_latest.yml) workflow updates
 the value returned by `https://cdn.cribl.io/dl/scope/latest`, and updates
-the `latest` tag at `https://hub.docker.com/r/cribl/scope/tags`.  This workflow
+the `latest` tag at `https://hub.docker.com/r/cribl/scope/tags`. This workflow
 is run manually, and does not have any automatic triggers.
 
 ## CDN

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -50,9 +50,10 @@ to a minimum.
   prior minor release and provides a starting point for maintenance releases
   to the new minor release.
 
-* We have a `staging` branch for the website content. The
-  documentation team updates the website content on that branch, then
-  creates PRs to merge their changes into the default branch.
+* For website content, the staging website always reflects what is on the
+  master branch. The documentation team provides PRs that target the master
+  branch. When they are merged, the website workflow runs, causing the
+  staging website content to be updated.
 
 ## Workflows
 
@@ -74,9 +75,15 @@ additional steps are taken depending on the trigger.
   these tests use up to Docker Hub on pushes to the default branch.
 
 The [`website`](../.github/workflows/website.yml) workflow handles building and
-deploying the [`website/`](../website/) content to <https://appscope.dev/> from
-the default branch and <https://staging.appscope.dev/> from `staging`. See the
-build script in that folder for details.
+deploying the [`website/`](../website/) content to <https://staging.appscope.dev/>
+and <https://appscope.dev/>. The staging website is intended to always reflect
+the master branch.  The production website is updated only when a "web" tag
+has been applied and pushed.  See the build script in that folder for details.
+
+The [`update_latest`](../.github/workflows/update_latest.yml) workflow updates
+the value returned by `https://cdn.cribl.io/dl/scope/latest`, and updates
+the `latest` tag at `https://hub.docker.com/r/cribl/scope/tags`.  This workflow
+is run manually, and does not have any automatic triggers.
 
 ## CDN
 
@@ -84,14 +91,10 @@ We push the built and tested `scope` binary and a TGZ package to an AWS S3
 container exposed at `https://cdn.cribl.io/dl/scope/`. Below
 that base URL we have:
 
-* `latest` - text file with the latest release number in it; e.g., `0.6.1`
 * `$VERSION/linux/scope`
 * `$VERSION/linux/scope.md5`
 * `$VERSION/linux/scope.tgz`
 * `$VERSION/linux/scope.tgz.md5`
-
-The `latest` file is updated only for builds of `v*` tags without `-rc` in
-them. 
 
 Starting with the `v0.7.2` release, we are building separate x86 and ARM
 versions of AppScope. The links described above still lead to the x86 files.
@@ -133,8 +136,7 @@ repositories at Docker Hub. See [`docker/`](../docker/) for details on how
 those images are built.
 
 We currently build these for release `v*` tags and tag the images to match with
-the leading `v` stripped off. If the git tag isn't a preprelease tag and is the
-last one then we apply the `:latest` tag to the image too.
+the leading `v` stripped off.
 
 ```text
 docker run --rm -it cribl/scope:latest


### PR DESCRIPTION
Resolves #1003 

This is a follow-on of sorts to https://github.com/criblio/appscope/pull/1077.  We merged 1077, then made a set of commits directly to master until it ran successfully in d517617c66bb7a07054abb53004e52268b9cca31.

As you can see here: https://github.com/criblio/appscope/actions/runs/2848753162
 d517617c66bb7a07054abb53004e52268b9cca31 ran successfully, with the manual input of "1.1.2".  By "successfully", I mean that both the cdn and dockerhub have the desired latest tag of 1.1.2 after this manual run of the update_latest github workflow.

So, the goal of this PR is to remove the need to manually input the tag as a text string, and make sure that the tag passes some basic validation before we update the cdn and dockerhub.
When this is merged, I'm hoping that we can run the workflow manually, selecting the "v1.1.3" tag from the "User workflow from" dropdown, and have it work as well as it did with the manual entry of "1.1.2" above.
There are two caveats to this...
1) As part of the validation, the tag selected has to be a semantic version that is not a prerelease.
2) We'll actually have to merge this to master, do a build of v1.1.3, and then try this with v1.1.3 to be able to test the successful case, because this will be the first time this new workflow will be there, and meet the criteria for 1) too.
