### PR TITLE
(#1061) Use `SCOPE_CONF_PATH` during attach from host to container

### DIFF
--- a/src/ns.c
+++ b/src/ns.c
@@ -24,13 +24,13 @@ loadFileIntoMem(size_t *size, char* path)
 {
     // Load file into memory
     char *resMem = NULL;
+    int fd;
 
     if (path == NULL) {
         return resMem;
     }
 
-    int fd = scope_open(path, O_RDONLY);
-    if (!fd) {
+    if ((fd = scope_open(path, O_RDONLY)) == -1) {
         scope_perror("scope_open failed");
         goto closeFd;
     }
@@ -64,9 +64,9 @@ static bool
 extractMemToChildNamespace(char* inputMem, size_t inputSize, const char *outFile, mode_t outPermFlag)
 {
     bool status = FALSE;
+    int outFd;
 
-    int outFd = scope_open(outFile, O_RDWR | O_CREAT, outPermFlag);
-    if (!outFd) {
+    if ((outFd = scope_open(outFile, O_RDWR | O_CREAT, outPermFlag)) == -1) {
         scope_perror("scope_open failed");
         return status;
     }
@@ -126,12 +126,14 @@ join_namespace(pid_t hostPid)
 
     for (int i = 0; i < (sizeof(nsType)/sizeof(nsType[0])); ++i) {
         char nsPath[PATH_MAX] = {0};
+        int nsFd;
+
         if (scope_snprintf(nsPath, sizeof(nsPath), "/proc/%d/ns/%s", hostPid, nsType[i]) < 0) {
             scope_perror("scope_snprintf failed");
             goto cleanupMem;
         }
-        int nsFd = scope_open(nsPath, O_RDONLY);
-        if (!nsFd) {
+
+        if ((nsFd = scope_open(nsPath, O_RDONLY)) == -1) {
             scope_perror("scope_open failed");
             goto cleanupMem;
         }

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -1084,15 +1084,17 @@ main(int argc, char **argv, char **env)
             return EXIT_FAILURE;
         }
 
-        int nsAttachPid = 0;
+        pid_t nsAttachPid = 0;
 
 
         /*
         * If the expected process exists in different namespace (container)
         * we do a following switch context sequence:
         * - load static loader file into memory
+        * - [optionally] save the configuration file pointed by SCOPE_CONF_PATH into memory
         * - switch the namespace from parent
         * - save previously loaded static loader into new namespace
+        * - [optionally] save previously loaded configuration file into new namespace
         * - fork & execute static loader attach one more time with update PID
         */
         if (nsIsPidInChildNs(pid, &nsAttachPid) == TRUE) {


### PR DESCRIPTION
Test instructions:

### Start example container

```
docker run --name redis_test -d redis:latest
```

### On host side
```
# Find `Redis` process on the host side
pgrep redis
### copy & modify default scope.yml file
copy scope.yml scope_modified.yml
### modify following section in scope_modified.yml file
```
From:
```
cribl:

  # Enable the `cribl` backend
  #   Type:     boolean
  #   Values:   true, false
  #   Default:  true
  #   Override: $SCOPE_CRIBL_ENABLE
  #
  enable: true
```
To:
```
cribl:

  # Enable the `cribl` backend
  #   Type:     boolean
  #   Values:   true, false
  #   Default:  true
  #   Override: $SCOPE_CRIBL_ENABLE
  #
  enable: false
```
```
### Run the attach command with passing configuration path
sudo SCOPE_CONF_PATH=<path_to_scope_modified.yml> ./ldscope -a <redis_pid>
````

### See if we really attach to the container

```
docker exec -it redis_test bash
apt update -y && apt install netcat -y
nc -l -p 9109
```
You should see data on the screen