### PR TITLE
Don't emit console events in a musl libc distro when detached. 

### DIFF
--- a/src/wrap.c
+++ b/src/wrap.c
@@ -872,6 +872,8 @@ doReset()
 static void
 reportPeriodicStuff(void)
 {
+    if (g_cfg.funcs_attached == FALSE) return;
+
     // aggregate and send http metrics
     doHttpAgg();
 
@@ -3938,8 +3940,10 @@ __stdio_write(struct MUSL_IO_FILE *stream, const unsigned char *buf, size_t len)
         }
     }
 
-    if (dothis == 1) doWrite(stream->fd, initialTime, (rc != -1),
-                             iov, rc, "__stdio_write", IOV, iovcnt);
+    if ((dothis == 1) && (g_cfg.funcs_attached == TRUE)) {
+        doWrite(stream->fd, initialTime, (rc != -1), iov, rc, "__stdio_write", IOV, iovcnt);
+    }
+
     return rc;
 }
 


### PR DESCRIPTION
close #1089 