### PR TITLE
SCOPE_FILTER extend support

### DIFF
--- a/src/scopetypes.h
+++ b/src/scopetypes.h
@@ -193,7 +193,7 @@ typedef struct
 //    SCOPE_APP_TYPE                 internal use only
 //    SCOPE_EXEC_TYPE                internal use only
 //    SCOPE_FILTER                   "false" disables handling the filter file
-//                                   TODO: add handling other values as a path to a filter file
+//                                   other values are interpreted a path to a filter file
 //    SCOPE_EXECVE                   "false" disables scope of child procs
 //    SCOPE_EXEC_PATH                specifies path to ldscope executable
 //    SCOPE_CRIBL_NO_BREAKER         adds breaker property to process start message


### PR DESCRIPTION
Add support for file interpretation in  SCOPE_FILTER
- SCOPE_FILTER=false - disables the handling the filter file
- SCOPE_FILTER=/tmp/myfile - will cause that `/tmp/myfile` will be interpreted as a filter file

Testing:
create `/tmp/myfile`
```
deny:
- arg: htop

```
1. Run ldscope without filter file in `/tmp/scope_filter` or `/usr/lib/appscope/scope_filter`
```
./bin/ldscope htop
ls -la /proc/<htop_pid>/fd
```
Observe that there is no "deleted" file there. The application is scoped.

1. Run ldscope with custom path filter
```
SCOPE_FILTER=/tmp/myfile ./bin/ldscope htop
ls -la /proc/<htop_pid>/fd
```
Observe that there is  "deleted" file there. The application is not scoped. Our library is loaded but we are in the state that the application was never scoped during it's lifetime