### PR TITLE
(#1133) Replace action step `set output` with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,15 +54,15 @@ jobs:
         id: tag
         run: |
           if [ -z "${GITHUB_REF%%refs/tags/v*}" -a "true" = "${{ steps.version.outputs.is-semver }}" ]; then
-              echo "::set-output name=tag::${{ steps.version.outputs.version-without-v }}"
-              echo "::set-output name=push::true"
+              echo "tag=${{ steps.version.outputs.version-without-v }}" >> $GITHUB_OUTPUT
+              echo "push=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "::set-output name=branch::${GITHUB_REF#*refs/heads/}"
+            echo "branch=${GITHUB_REF#*refs/heads/}"
             if [ "refs/heads/main" = "${GITHUB_REF}" -o "refs/heads/master" = "${GITHUB_REF}" ]; then
-              echo "::set-output name=tag::next"
-              echo "::set-output name=push::true"
+              echo "tag=next" >> "${GITHUB_OUTPUT}"
+              echo "push=true" >> "${GITHUB_OUTPUT}"
             else
-              echo "::set-output name=tag::unreleased"
+              echo "tag=unreleased" >> "${GITHUB_OUTPUT}"
             fi
           fi
 
@@ -168,7 +168,7 @@ jobs:
             echo "::group::home"
             ls -la $HOME
             echo "::endgroup::"
-            echo "::set-output name=arch::$(uname -m)"
+            echo "arch=$(uname -m)" >> "${GITHUB_OUTPUT}"
 
       # Clone the repos
       - name: Checkout Repository
@@ -316,7 +316,7 @@ jobs:
       # This is just being done to reduce the workflow time duration.
       - name: List Integration Tests
         id: tests
-        run: echo "::set-output name=tests-${{ steps.env.outputs.arch }}::$(make -s -C test/integration tests | egrep -v '.*java(9|1[023456])$' | sort -V | jq -ncR '[inputs]')"
+        run: echo "tests-${{ steps.env.outputs.arch }}=$(make -s -C test/integration tests | egrep -v '.*java(9|1[023456])$' | sort -V | jq -ncR '[inputs]')" >> "${GITHUB_OUTPUT}"
 
       - name: Print size of Binaries
         run: |

--- a/.github/workflows/update_latest.yml
+++ b/.github/workflows/update_latest.yml
@@ -26,7 +26,7 @@ jobs:
         id: tag
         run: |
           if [ -z "${GITHUB_REF%%refs/tags/v*}" -a "true" = "${{ steps.version.outputs.is-semver }}" ]; then
-              echo "::set-output name=tag::${{ steps.version.outputs.version-without-v }}"
+              echo "tag=${{ steps.version.outputs.version-without-v }}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Echo Outputs


### PR DESCRIPTION
Fix GitHub Actions warning:
```
Warning: The `save-state` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files.
For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Ref: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

Action Required:
- updating the GitHub runner software version used in self-hosted runners is necessary, because on self-hosted runners are we missing the `GITHUB_OUTPUT` environment file commands
- The version used by the self-hosted runners is 2.287.1
- The version containing support for `GITHUB_OUTPUT` is [2.297.0 ](https://github.com/actions/runner/releases/tag/v2.297.0)