### PR TITLE
[RFC] Add option to disable setup `/etc/profile.d/scope.sh` on host

### DIFF
--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -44,7 +44,8 @@ var startCmd = &cobra.Command{
 			fmt.Println("\nIf you wish to proceed, run again with the -f flag.")
 			os.Exit(0)
 		}
-		if err := start.Start(); err != nil {
+		noProfile, _ := cmd.Flags().GetBool("noprofile")
+		if err := start.Start(noProfile); err != nil {
 			util.ErrAndExit("Exiting due to start failure: %v", err)
 		}
 	},
@@ -52,6 +53,7 @@ var startCmd = &cobra.Command{
 
 func init() {
 	startCmd.Flags().BoolP("force", "f", false, "Use this flag when you're sure you want to run scope start")
+	startCmd.Flags().BoolP("noprofile", "n", false, "Skip install preload script in etc/profile.d/scope.sh")
 
 	RootCmd.AddCommand(startCmd)
 }

--- a/cli/loader/loader.go
+++ b/cli/loader/loader.go
@@ -12,11 +12,15 @@ type ScopeLoader struct {
 	Path string
 }
 
-// - Setup /etc/profile.d/scope.sh on host
+// - Setup /etc/profile.d/scope.sh on host (depending on noProfile arg)
 // - Extract libscope.so to /usr/lib/appscope/<version>/libscope.so /tmp/appscope/<version>/libscope.so on host
 // - Extract filter input to /usr/lib/appscope/scope_filter or /tmp/appscope/scope_filter on host
-func (sL *ScopeLoader) ConfigureHost(filterFilePath string) (string, error) {
-	return sL.RunSubProc([]string{"--configure", filterFilePath}, os.Environ())
+func (sL *ScopeLoader) ConfigureHost(filterFilePath string, noProfile bool) (string, error) {
+	cfgArgs := []string{"--configure", filterFilePath}
+	if noProfile {
+		cfgArgs = append(cfgArgs, "--noprofile")
+	}
+	return sL.RunSubProc(cfgArgs, os.Environ())
 }
 
 // - Setup /etc/profile.d/scope.sh in containers
@@ -51,8 +55,12 @@ func (sL *ScopeLoader) AttachSubProc(args []string, env []string) (string, error
 
 // Used when scope has detected that we are running the `scope start` command inside a container
 // Tell ldscope to run the `scope start` command on the host instead
-func (sL *ScopeLoader) StartHost() (string, error) {
-	return sL.RunSubProc([]string{"--starthost"}, os.Environ())
+func (sL *ScopeLoader) StartHost(noProfile bool) (string, error) {
+	startHostArgs := []string{"--starthost"}
+	if noProfile {
+		startHostArgs = append(startHostArgs, "--noprofile")
+	}
+	return sL.RunSubProc(startHostArgs, os.Environ())
 }
 
 func (sL *ScopeLoader) Run(args []string, env []string) error {

--- a/cli/start/start.go
+++ b/cli/start/start.go
@@ -153,9 +153,9 @@ func startAttach(allowProcs []allowProcConfig) error {
 }
 
 // for the host
-func startConfigureHost(filename string) error {
+func startConfigureHost(filename string, noProfile bool) error {
 	sL := loader.ScopeLoader{Path: run.LdscopePath()}
-	stdoutStderr, err := sL.ConfigureHost(filename)
+	stdoutStderr, err := sL.ConfigureHost(filename, noProfile)
 	if err != nil {
 		log.Warn().
 			Err(err).
@@ -416,7 +416,8 @@ func extractFilterFile(cfgData []byte) (string, error) {
 }
 
 // Start performs setup of scope in the host and containers
-func Start() error {
+// optionally disable setup /etc/profile script
+func Start(noProfile bool) error {
 	// Create a history directory for logs
 	createWorkDir()
 
@@ -465,7 +466,7 @@ func Start() error {
 		}
 
 		ld := loader.ScopeLoader{Path: filepath.Join(scopeDirVersion, "ldscope")}
-		stdoutStderr, err := ld.StartHost()
+		stdoutStderr, err := ld.StartHost(noProfile)
 		if err == nil {
 			log.Info().
 				Msgf("Start host success.")
@@ -493,7 +494,7 @@ func Start() error {
 		return err
 	}
 
-	if err := startConfigureHost(filterPath); err != nil {
+	if err := startConfigureHost(filterPath, noProfile); err != nil {
 		return err
 	}
 

--- a/src/ns.h
+++ b/src/ns.h
@@ -7,6 +7,6 @@ bool nsIsPidInChildNs(pid_t, pid_t *);
 int nsForkAndExec(pid_t, pid_t, char);
 int nsConfigure(pid_t, void *, size_t);
 service_status_t nsService(pid_t, const char *);
-int nsHostStart(void);
+int nsHostStart(bool);
 
 #endif // __NS_H__

--- a/src/setup.c
+++ b/src/setup.c
@@ -531,14 +531,14 @@ closeFd:
 
  /*
  * Configure the environment
- * - setup /etc/profile.d/scope.sh
+ * - setup /etc/profile.d/scope.sh (depending on etcSetup)
  * - extract memory to filter file /usr/lib/appscope/scope_filter or /tmp/appscope/scope_filter
  * - extract libscope.so to /usr/lib/appscope/<version>/libscope.so or /tmp/appscope/<version>/libscope.so if it doesn't exists
  * - patch the library
  * Returns status of operation 0 in case of success, other value otherwise
  */
 int
-setupConfigure(void *filterFileMem, size_t filterSize) {
+setupConfigure(void *filterFileMem, size_t filterSize, bool etcSetup) {
     char path[PATH_MAX] = {0};
 
     // Create destination directory if not exists
@@ -568,7 +568,7 @@ setupConfigure(void *filterFileMem, size_t filterSize) {
     }
 
     // Setup /etc/profile.d/scope.sh
-    if (setupProfile(path) == FALSE) {
+    if (etcSetup && (setupProfile(path) == FALSE)) {
         scope_fprintf(scope_stderr, "setupConfigure: setupProfile failed\n");
         return -1;
     }

--- a/src/setup.h
+++ b/src/setup.h
@@ -7,7 +7,7 @@
 #define SCOPE_FILTER_TMP_PATH ("/tmp/appscope/scope_filter")
 
 service_status_t setupService(const char *);
-int setupConfigure(void *, size_t);
+int setupConfigure(void *, size_t, bool);
 char *setupLoadFileIntoMem(size_t *, const char *);
 
 #endif // __SETUP_H__

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -565,8 +565,9 @@ cat example_filter.json | scope start
 #### Flags
 
 ```
-  -f, --force   Use this flag when you're sure you want to run scope start
-  -h, --help    help for start
+  -f, --force       Use this flag when you're sure you want to run scope start
+  -h, --help        help for start
+  -n, --noprofile   Skip install preload script in etc/profile.d/scope.sh
 ```
 
 ### version


### PR DESCRIPTION
- (cli) extending options in `scope start` with `--noprofile` allows to skip setup `/etc/profile.d/scope.sh` on host
- (loader) the options `--noprofile` disables `/etc/profile.d/scope.sh` in following operations:
  - `ldscope --configure`
  - `ldscope --starthost`