### PR TITLE
Fix `os.Stdin` handling for Edge

### DIFF
--- a/cli/start/start.go
+++ b/cli/start/start.go
@@ -340,8 +340,8 @@ func getStartData() []byte {
 		return startData
 	}
 
-	// Verify size of data for mode other than a pipe
-	if stdinFs.Size() == 0 && stdinFs.Mode()&os.ModeNamedPipe == 0 {
+	// Avoid waiting for input from terminal when no data was provided
+	if stdinFs.Mode()&os.ModeCharDevice != 0 && stdinFs.Size() == 0 {
 		return startData
 	}
 


### PR DESCRIPTION
`os.Stdin` for the following scenarios works in the modes:

scope start -f <empty> -  `fs.ModeCharDevice`, Unix character device cat <file> | scope start -f  -  `fs.ModeNamedPipe`, named pipe (FIFO) Edge -  `fs.ModeSocket`, Unix domain socket`
scope start -f < <file> -  No mode is defined