### PR TITLE
Use noexecstack flag when building libscope

### DIFF
--- a/os/linux/aarch64.mk
+++ b/os/linux/aarch64.mk
@@ -2,7 +2,7 @@ ARCH_LD_FLAGS=-lcapstone
 ARCH_BINARY=elf64-littleaarch64
 ARCH_OBJ=$(ARCH)
 
-LD_FLAGS=$(MUSL_AR) $(UNWIND_AR) $(PCRE2_AR) $(LS_HPACK_AR) $(YAML_AR) $(JSON_AR) -ldl -lpthread -lrt -lresolv -Lcontrib/build/funchook -lfunchook -Lcontrib/build/funchook/capstone_src-prefix/src/capstone_src-build -lcapstone
+LD_FLAGS=$(MUSL_AR) $(UNWIND_AR) $(PCRE2_AR) $(LS_HPACK_AR) $(YAML_AR) $(JSON_AR) -ldl -lpthread -lrt -lresolv -Lcontrib/build/funchook -lfunchook -Lcontrib/build/funchook/capstone_src-prefix/src/capstone_src-build -lcapstone -z noexecstack
 INCLUDES=-I./contrib/libyaml/include -I./contrib/cJSON -I./os/$(OS) -I./contrib/pcre2/src -I./contrib/build/pcre2 -I./contrib/funchook/capstone_src/include/ -I./contrib/jni -I./contrib/jni/linux/ -I./contrib/openssl/include -I./contrib/build/openssl/include -I./contrib/build/libunwind/include  -I./contrib/libunwind/include/
 
 $(LIBSCOPE): src/wrap.c src/state.c src/httpstate.c src/metriccapture.c src/report.c src/httpagg.c src/plattime.c src/fn.c os/$(OS)/os.c src/cfgutils.c src/cfg.c src/transport.c src/log.c src/mtc.c src/circbuf.c src/linklist.c src/evtformat.c src/ctl.c src/mtcformat.c src/com.c src/scopestdlib.c src/dbg.c src/search.c src/scopeelf.c src/utils.c src/strset.c src/javabci.c src/javaagent.c

--- a/os/linux/x86_64.mk
+++ b/os/linux/x86_64.mk
@@ -3,7 +3,7 @@ ARCH_LD_FLAGS=-lcapstone
 ARCH_BINARY=elf64-x86-64
 ARCH_OBJ=i386
 
-LD_FLAGS=$(MUSL_AR) $(UNWIND_AR) $(PCRE2_AR) $(LS_HPACK_AR) $(YAML_AR) $(JSON_AR) -ldl -lpthread -lrt -Lcontrib/build/funchook -lfunchook -Lcontrib/build/funchook/capstone_src-prefix/src/capstone_src-build -lcapstone
+LD_FLAGS=$(MUSL_AR) $(UNWIND_AR) $(PCRE2_AR) $(LS_HPACK_AR) $(YAML_AR) $(JSON_AR) -ldl -lpthread -lrt -Lcontrib/build/funchook -lfunchook -Lcontrib/build/funchook/capstone_src-prefix/src/capstone_src-build -lcapstone -z noexecstack
 INCLUDES=-I./contrib/libyaml/include -I./contrib/cJSON -I./os/$(OS) -I./contrib/pcre2/src -I./contrib/build/pcre2 -I./contrib/funchook/capstone_src/include/ -I./contrib/jni -I./contrib/jni/linux/ -I./contrib/openssl/include -I./contrib/build/openssl/include -I./contrib/build/libunwind/include -I./contrib/libunwind/include/
 
 #ARCH_RM=&& rm ./test/selfinterpose/wrap_go.o


### PR DESCRIPTION
When LD_PRELOAD'ing our library on startup, some services complained:

`Oct 17 12:00:28 vm accounts-daemon[741]: ERROR: ld.so: object '/usr/lib/appscope/dev/libscope.so' from /etc/ld.so.preload cannot be preloaded (cannot enable executable stack as shared object requires): ignored.`

The kernel is not allowing a library with an executable stack to be preloaded. I have updated our Makefiles to build `libscope.so` with the `noexecstack` option.

Before this change, `execstack -q libscope.so` = X
After this change, `execstack -q libscope.co` = -