### PR TITLE
Remove trailing whitespaces in configuration

### DIFF
--- a/conf/example_filter.yml
+++ b/conf/example_filter.yml
@@ -1,6 +1,6 @@
 allow:
 - procname: nginx
-  arg: 
+  arg:
   config:
     metric:
       enable: true
@@ -86,7 +86,7 @@ allow:
           cacertpath: ''
           enable: false
           validateserver: true
-- procname: 
+- procname:
   arg: redis-server
   config:
     metric:

--- a/conf/scope.yml
+++ b/conf/scope.yml
@@ -8,7 +8,7 @@
 # After loading defaults, the library looks for a config in the following
 # places in the order shown. The first readable file found is used and the rest
 # are ignored. Entries in the config file override the defaults.
-# 
+#
 #   1. $SCOPE_CONF_PATH
 #   2. $SCOPE_HOME/conf/scope.yml
 #   3. $SCOPE_HOME/scope.yml
@@ -39,7 +39,7 @@
 # Use the command below to get a stripped-down version of this config.
 #
 #   egrep -v '^ *#.*$' scope.yml | sed '/^$/d' >scope-minimal.yml
-# 
+#
 
 # Settings for metrics
 #
@@ -97,7 +97,7 @@ metric:
     # can be added to provide additional detail on the measurement. The library
     # adds expanded Statsd tags depending on the value of this setting as
     # described below. These affect the cardinality of the metrics data.
-    #   
+    #
     #   0  none
     #   1  adds data and unit
     #   2  adds class and proto
@@ -165,7 +165,7 @@ metric:
     #   Override: $SCOPE_METRIC_HTTP
     #
     - type: http
-  
+
     # Metric dns
     #   Type:     string
     #   Values:   dns
@@ -173,7 +173,7 @@ metric:
     #   Override: $SCOPE_METRIC_DNS
     #
     - type: dns
-  
+
     # Metric process
     #   Type:     string
     #   Values:   process
@@ -288,7 +288,7 @@ metric:
       #
       # Leave this blank when validateserver is set to true and the local
       # OS-provided trusted CA certificates are used to validate the server's
-      # certificate. To use a PEM certificate file instead, specify its 
+      # certificate. To use a PEM certificate file instead, specify its
       # full path; useful with self-signed certificates.
       #
       # Only applies if the connection type is tcp and TLS is enabled.
@@ -571,7 +571,7 @@ event:
       #
       # Leave this blank when validateserver is set to true and the local
       # OS-provided trusted CA certificates are used to validate the server's
-      # certificate. To use a PEM certificate file instead, specify its 
+      # certificate. To use a PEM certificate file instead, specify its
       # full path; useful with self-signed certificates.
       #
       # Only applies if the connection type is tcp and TLS is enabled.
@@ -632,7 +632,7 @@ libscope:
   #
   summaryperiod : 10
 
-  # Command directory 
+  # Command directory
   #   Type:     string
   #   Values:   (directory path)
   #   Default:  /tmp
@@ -682,7 +682,7 @@ libscope:
       #
       # Note: tls:// is not an option here. For TLS/SSL, use tcp://host:port and
       # set the $SCOPE_LOG_TLS_* variables.
-  
+
       # Connection type
       #   Type:     string
       #   Values:   udp, tcp, unix, file, and edge
@@ -697,7 +697,7 @@ libscope:
       #   Default:  (none)
       #   Override: the host token in the $SCOPE_LOG_DEST URL
       #
-      #host: 
+      #host:
 
       # Connection port
       #   Type:     integer or string
@@ -705,7 +705,7 @@ libscope:
       #   Default:  (none)
       #   Override: the port token in the $SCOPE_LOG_DEST URL
       #
-      #port: 
+      #port:
 
       # File path / unix domain socket path
       #   Type:     string
@@ -800,8 +800,8 @@ cribl:
     #   Override: the port token in the $SCOPE_CRIBL or $SCOPE_CRIBL_CLOUD URL
     #
     # Defaults to 10090, which is the TCP port on the AppScope Source
-    # in Cribl Stream or Cribl Edge. If you are using the cloud version, 
-    # 10090 is the TLS port on the client-facing load balancer which is 
+    # in Cribl Stream or Cribl Edge. If you are using the cloud version,
+    # 10090 is the TLS port on the client-facing load balancer which is
     # proxied to the cloud instance's TCP:10090 port, without TLS.
     #
     # Use 10091 here if you need to connect to Cribl.Cloud without TLS and
@@ -855,7 +855,7 @@ cribl:
       #
       # Leave this blank when validateserver is set to true and the local
       # OS-provided trusted CA certificates are used to validate the server's
-      # certificate. To use a PEM certificate file instead, specify its 
+      # certificate. To use a PEM certificate file instead, specify its
       # full path; useful with self-signed certificates.
       #
       # Only applies if the connection type is tcp and TLS is enabled.
@@ -880,7 +880,7 @@ tags:
   #
   #user: $USER
   #service: eg
-  
+
 # Protocol detection and handling
 #
 protocol:
@@ -908,9 +908,9 @@ protocol:
   # options here are ignored.
   #
   # Warning: The `name` value is currently inserted into the JSON header for
-  # payloads sent to Cribl Stream or Cribl Edge, so it cannot contain double 
-  # quotes or backslashes without breaking the JSON. It needs to be kept fairly 
-  # short, too, so the header doesn't exceed the 1k limit. If this becomes a 
+  # payloads sent to Cribl Stream or Cribl Edge, so it cannot contain double
+  # quotes or backslashes without breaking the JSON. It needs to be kept fairly
+  # short, too, so the header doesn't exceed the 1k limit. If this becomes a
   # problem, we'll consider adding logging and validation.
   #
 
@@ -987,12 +987,12 @@ custom:
   #
   #     Matches if the given string value matches the hostname of the machine
   #     where the scoped process is running.
-  #     
+  #
   #   username: string
   #
   #     Matches if the given string value matches the username for the scoped
   #     process's UID.
-  #     
+  #
   #   env: string
   #
   #     The string value is the name of an environment variable alone (i.e.
@@ -1008,7 +1008,7 @@ custom:
   # the filter matches. Entries under `config` use the same schema as the
   # top-level entries (without `custom`).
   #
-  
+
   # Increase metric verbosity for processes owned by the "eg" user and running
   # on the "eg1" host.
   #
@@ -1026,7 +1026,7 @@ custom:
   # Enable the Cribl Stream destination for Nginx
   # processes. Both this entry and the `example` entry above would
   # apply if both filters match – so the service tag here would
-  # override the one above. In this example, we use a Cribl.Cloud-managed 
+  # override the one above. In this example, we use a Cribl.Cloud-managed
   # Cribl Stream instance.
   #
   #nginx:

--- a/website/src/pages/docs/config-file.md
+++ b/website/src/pages/docs/config-file.md
@@ -25,7 +25,7 @@ Below are the default contents of `scope.yml`:
 # After loading defaults, the library looks for a config in the following
 # places in the order shown. The first readable file found is used and the rest
 # are ignored. Entries in the config file override the defaults.
-# 
+#
 #   1. $SCOPE_CONF_PATH
 #   2. $SCOPE_HOME/conf/scope.yml
 #   3. $SCOPE_HOME/scope.yml
@@ -56,7 +56,7 @@ Below are the default contents of `scope.yml`:
 # Use the command below to get a stripped-down version of this config.
 #
 #   egrep -v '^ *#.*$' scope.yml | sed '/^$/d' >scope-minimal.yml
-# 
+#
 
 # Settings for metrics
 #
@@ -114,7 +114,7 @@ metric:
     # can be added to provide additional detail on the measurement. The library
     # adds expanded Statsd tags depending on the value of this setting as
     # described below. These affect the cardinality of the metrics data.
-    #   
+    #
     #   0  none
     #   1  adds data and unit
     #   2  adds class and proto
@@ -182,7 +182,7 @@ metric:
     #   Override: $SCOPE_METRIC_HTTP
     #
     - type: http
-  
+
     # Metric dns
     #   Type:     string
     #   Values:   dns
@@ -190,7 +190,7 @@ metric:
     #   Override: $SCOPE_METRIC_DNS
     #
     - type: dns
-  
+
     # Metric process
     #   Type:     string
     #   Values:   process
@@ -305,7 +305,7 @@ metric:
       #
       # Leave this blank when validateserver is set to true and the local
       # OS-provided trusted CA certificates are used to validate the server's
-      # certificate. To use a PEM certificate file instead, specify its 
+      # certificate. To use a PEM certificate file instead, specify its
       # full path; useful with self-signed certificates.
       #
       # Only applies if the connection type is tcp and TLS is enabled.
@@ -588,7 +588,7 @@ event:
       #
       # Leave this blank when validateserver is set to true and the local
       # OS-provided trusted CA certificates are used to validate the server's
-      # certificate. To use a PEM certificate file instead, specify its 
+      # certificate. To use a PEM certificate file instead, specify its
       # full path; useful with self-signed certificates.
       #
       # Only applies if the connection type is tcp and TLS is enabled.
@@ -649,7 +649,7 @@ libscope:
   #
   summaryperiod : 10
 
-  # Command directory 
+  # Command directory
   #   Type:     string
   #   Values:   (directory path)
   #   Default:  /tmp
@@ -699,7 +699,7 @@ libscope:
       #
       # Note: tls:// is not an option here. For TLS/SSL, use tcp://host:port and
       # set the $SCOPE_LOG_TLS_* variables.
-  
+
       # Connection type
       #   Type:     string
       #   Values:   udp, tcp, unix, file, and edge
@@ -714,7 +714,7 @@ libscope:
       #   Default:  (none)
       #   Override: the host token in the $SCOPE_LOG_DEST URL
       #
-      #host: 
+      #host:
 
       # Connection port
       #   Type:     integer or string
@@ -722,7 +722,7 @@ libscope:
       #   Default:  (none)
       #   Override: the port token in the $SCOPE_LOG_DEST URL
       #
-      #port: 
+      #port:
 
       # File path / unix domain socket path
       #   Type:     string
@@ -817,8 +817,8 @@ cribl:
     #   Override: the port token in the $SCOPE_CRIBL or $SCOPE_CRIBL_CLOUD URL
     #
     # Defaults to 10090, which is the TCP port on the AppScope Source
-    # in Cribl Stream or Cribl Edge. If you are using the cloud version, 
-    # 10090 is the TLS port on the client-facing load balancer which is 
+    # in Cribl Stream or Cribl Edge. If you are using the cloud version,
+    # 10090 is the TLS port on the client-facing load balancer which is
     # proxied to the cloud instance's TCP:10090 port, without TLS.
     #
     # Use 10091 here if you need to connect to Cribl.Cloud without TLS and
@@ -872,7 +872,7 @@ cribl:
       #
       # Leave this blank when validateserver is set to true and the local
       # OS-provided trusted CA certificates are used to validate the server's
-      # certificate. To use a PEM certificate file instead, specify its 
+      # certificate. To use a PEM certificate file instead, specify its
       # full path; useful with self-signed certificates.
       #
       # Only applies if the connection type is tcp and TLS is enabled.
@@ -897,7 +897,7 @@ tags:
   #
   #user: $USER
   #service: eg
-  
+
 # Protocol detection and handling
 #
 protocol:
@@ -925,9 +925,9 @@ protocol:
   # options here are ignored.
   #
   # Warning: The `name` value is currently inserted into the JSON header for
-  # payloads sent to Cribl Stream or Cribl Edge, so it cannot contain double 
-  # quotes or backslashes without breaking the JSON. It needs to be kept fairly 
-  # short, too, so the header doesn't exceed the 1k limit. If this becomes a 
+  # payloads sent to Cribl Stream or Cribl Edge, so it cannot contain double
+  # quotes or backslashes without breaking the JSON. It needs to be kept fairly
+  # short, too, so the header doesn't exceed the 1k limit. If this becomes a
   # problem, we'll consider adding logging and validation.
   #
 
@@ -1004,12 +1004,12 @@ custom:
   #
   #     Matches if the given string value matches the hostname of the machine
   #     where the scoped process is running.
-  #     
+  #
   #   username: string
   #
   #     Matches if the given string value matches the username for the scoped
   #     process's UID.
-  #     
+  #
   #   env: string
   #
   #     The string value is the name of an environment variable alone (i.e.
@@ -1025,7 +1025,7 @@ custom:
   # the filter matches. Entries under `config` use the same schema as the
   # top-level entries (without `custom`).
   #
-  
+
   # Increase metric verbosity for processes owned by the "eg" user and running
   # on the "eg1" host.
   #
@@ -1043,7 +1043,7 @@ custom:
   # Enable the Cribl Stream destination for Nginx
   # processes. Both this entry and the `example` entry above would
   # apply if both filters match – so the service tag here would
-  # override the one above. In this example, we use a Cribl.Cloud-managed 
+  # override the one above. In this example, we use a Cribl.Cloud-managed
   # Cribl Stream instance.
   #
   #nginx:

--- a/website/src/pages/docs/filter-file.md
+++ b/website/src/pages/docs/filter-file.md
@@ -28,7 +28,7 @@ Here are the contents of `example_filter.yml`:
 ```
 allow:
 - procname: nginx
-  arg: 
+  arg:
   config:
     metric:
       enable: true
@@ -114,7 +114,7 @@ allow:
           cacertpath: ''
           enable: false
           validateserver: true
-- procname: 
+- procname:
   arg: redis-server
   config:
     metric:


### PR DESCRIPTION
The intention is to fix the formatting `scope_minimal.yml` file.
We use the following snippet to generate a stripped-down version of the `scope.yml` config.
```
egrep -v '^ *#.*$' scope.yml | sed '/^$/d' >scope-minimal.yml
```
With the presence of trailing whitespaces, we generate a file as follows (see e.g. `watch` section in):
```
metric:
  enable: true
  format:
    type: statsd
    statsdprefix:
    statsdmaxlen: 512
    verbosity : 4
  watch:
    - type: statsd
    - type: fs
    - type: net
    - type: http
  
    - type: dns
  
    - type: process
  transport:
    type: udp
    host: 127.0.0.1
    port: 8125
    tls:
      enable: false
      validateserver: true
      cacertpath: ''
event:
  enable: true
  format:
    type: ndjson
    maxeventpersec: 10000
    enhancefs: true
  watch:
    - type: file
      name: (\/logs?\/)|(\.log$)|(\.log[.\d]) # matches the filename
      value: .*                               # matches data read or written
    - type: console
      name: (stdout)|(stderr) # matches the output stream
      value: .*               # matches data written
      allowbinary: true
    - type: net
      name: .*
      field: .*
      value: .*
    - type: fs
      name: .*
      field: .*
      value: .*
    - type: dns
      name: .*
      field: .*
      value: .*
    - type: http
      name: .*         # event name; http.req or http.resp
      field: .*        # matches field names; duration, http_status, etc
      value: .*        # matches field values
      headers:         # list of filters matched against header names
  transport:
    type: tcp
    host: 127.0.0.1
    port: 9109
    tls:
      enable: false
      validateserver: true
      cacertpath: ''
payload:
  enable: false
  dir: '/tmp'
libscope:
  configevent: true
  summaryperiod : 10
  commanddir : '/tmp'
  log:
    level: warning
    transport:
  
      type: file
      path: '/tmp/scope.log'
      buffer: line
cribl:
  enable: true
  transport:
    type: edge
    host: 127.0.0.1
    port: 10090
    tls:
      enable: false
      validateserver: true
      cacertpath: ''
tags:
  
protocol:
custom:
  

```
With this Pull Request the `scope_minimal.yml` looks like this:
```
metric:
  enable: true
  format:
    type: statsd
    statsdprefix:
    statsdmaxlen: 512
    verbosity : 4
  watch:
    - type: statsd
    - type: fs
    - type: net
    - type: http
    - type: dns
    - type: process
  transport:
    type: udp
    host: 127.0.0.1
    port: 8125
    tls:
      enable: false
      validateserver: true
      cacertpath: ''
event:
  enable: true
  format:
    type: ndjson
    maxeventpersec: 10000
    enhancefs: true
  watch:
    - type: file
      name: (\/logs?\/)|(\.log$)|(\.log[.\d]) # matches the filename
      value: .*                               # matches data read or written
    - type: console
      name: (stdout)|(stderr) # matches the output stream
      value: .*               # matches data written
      allowbinary: true
    - type: net
      name: .*
      field: .*
      value: .*
    - type: fs
      name: .*
      field: .*
      value: .*
    - type: dns
      name: .*
      field: .*
      value: .*
    - type: http
      name: .*         # event name; http.req or http.resp
      field: .*        # matches field names; duration, http_status, etc
      value: .*        # matches field values
      headers:         # list of filters matched against header names
  transport:
    type: tcp
    host: 127.0.0.1
    port: 9109
    tls:
      enable: false
      validateserver: true
      cacertpath: ''
payload:
  enable: false
  dir: '/tmp'
libscope:
  configevent: true
  summaryperiod : 10
  commanddir : '/tmp'
  log:
    level: warning
    transport:
      type: file
      path: '/tmp/scope.log'
      buffer: line
cribl:
  enable: true
  transport:
    type: edge
    host: 127.0.0.1
    port: 10090
    tls:
      enable: false
      validateserver: true
      cacertpath: ''
tags:
protocol:
custom:

```