### PR TITLE
(#1186) Modify `io_getevents` to use `syscall`

### DIFF
--- a/src/fn.c
+++ b/src/fn.c
@@ -334,7 +334,6 @@ initFn(void)
     GETADDR(g_fn.semtimedop, "semtimedop");
     GETADDR(g_fn.clock_nanosleep, "clock_nanosleep");
     GETADDR(g_fn.usleep, "usleep");
-    GETADDR(g_fn.io_getevents, "io_getevents");
     GETADDR(g_fn.setenv, "setenv");
     g_fn.app_setenv = dlsym(RTLD_DEFAULT, "setenv");
     GETADDR(g_fn.uv__read, "uv__read");

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -2073,8 +2073,8 @@ io_getevents(io_context_t ctx_id, long min_nr, long nr,
              struct io_event *events, struct timespec *timeout)
 {
     stopTimer();
-    WRAP_CHECK(io_getevents, -1);
-    return g_fn.io_getevents(ctx_id, min_nr, nr, events, timeout);
+    WRAP_CHECK(syscall, -1);
+    return g_fn.syscall(__NR_io_getevents, ctx_id, min_nr, nr, events, timeout);
 }
 
 EXPORTOFF int
@@ -5466,7 +5466,6 @@ static got_list_t inject_hook_list[] = {
     {"semtimedop",  semtimedop, &g_fn.semtimedop},
     {"clock_nanosleep", clock_nanosleep, &g_fn.clock_nanosleep},
     {"usleep", usleep, &g_fn.usleep},
-    {"io_getevents", io_getevents, &g_fn.io_getevents},
     {"open64", open64, &g_fn.open64},
     {"openat64", openat64, &g_fn.openat64},
     {"__open_2", __open_2, &g_fn.__open_2},


### PR DESCRIPTION
"glibc provides no wrapper for io_getevents(), necessitating
 the use of syscall(2)."

Ref: https://man7.org/linux/man-pages/man2/io_getevents.2.html

Closes #1186

TODO:
- [ ] Fix works with TCP but not with UNIX path 
- [ ] Figure out dev and official version during attach