### PR TITLE
(#1190) Add executable permissions to `scope`

### DIFF
--- a/cli/start/start.go
+++ b/cli/start/start.go
@@ -318,7 +318,7 @@ func extract(scopeDirVersion string) error {
 	}
 
 	// Copy scope
-	if _, err := util.CopyFile(os.Args[0], filepath.Join(scopeDirVersion, "scope")); err != nil {
+	if _, err := util.CopyFile(os.Args[0], filepath.Join(scopeDirVersion, "scope"), perms); err != nil {
 		if err != os.ErrExist {
 			log.Error().
 				Err(err).

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"math/rand"
 	"os"
@@ -350,8 +351,8 @@ func Confirm(s string) bool {
 	return false
 }
 
-// CopyFile copies a file from a source to a destination
-func CopyFile(src, dst string) (int64, error) {
+// CopyFile copies a file from a source to a destination with specific permissions
+func CopyFile(src, dst string, mode fs.FileMode) (int64, error) {
 	source, err := os.Open(src)
 	if err != nil {
 		return 0, err
@@ -363,6 +364,10 @@ func CopyFile(src, dst string) (int64, error) {
 		return 0, err
 	}
 	defer destination.Close()
+
+	if err := os.Chmod(dst, mode); err != nil {
+		return 0, err
+	}
 
 	nBytes, err := io.Copy(destination, source)
 	return nBytes, err


### PR DESCRIPTION
- change file permissions after copying a `scope` from `0644` to `0755`

Closes: #1190