### PR TITLE
(#1209) Optimize make to use `nproc` value

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -77,7 +77,7 @@ build/openssl/libssl.a build/openssl/libcrypto.a:
 	@echo "$${CI:+::group::}Building openssl"
 	@$(RM) -r build/openssl
 	@mkdir build/openssl
-	cd build/openssl && ../../openssl/Configure no-engine no-async no-tests no-unit-test no-threads && make -j8
+	cd build/openssl && ../../openssl/Configure no-engine no-async no-tests no-unit-test no-threads && make -j$(nproc)
 	# Yuck.  Avoids naming conflict between our wrap.c and libssl.a
 	objcopy --redefine-sym SSL_read=SCOPE_SSL_read build/openssl/libssl.a
 	objcopy --redefine-sym SSL_write=SCOPE_SSL_write build/openssl/libssl.a

--- a/test/integration/syscalls/Dockerfile
+++ b/test/integration/syscalls/Dockerfile
@@ -20,7 +20,7 @@ RUN cd /opt/test && \
       patch -p1 < /opt/test/ltp_p1.patch && \
       make autotools && \
       ./configure && \
-      make -j
+      make -j"$(nproc)"
 
 RUN source scl_source enable rh-python38 && \
     virtualenv -p $(which python) /opt/test-runner/
@@ -35,7 +35,7 @@ ENV SCOPE_EVENT_METRIC=true
 ENV SCOPE_EVENT_HTTP=true
 
 COPY ./syscalls/altp /opt/test/altp
-RUN cd /opt/test/altp && make -j
+RUN cd /opt/test/altp && make -j"$(nproc)"
 
 COPY ./test_runner/requirements.txt /opt/test-runner/requirements.txt
 RUN /opt/test-runner/bin/pip install -r /opt/test-runner/requirements.txt

--- a/test/integration/syscalls/Dockerfile.alpine
+++ b/test/integration/syscalls/Dockerfile.alpine
@@ -17,7 +17,7 @@ RUN cd /opt/test && \
       patch -p1 < /opt/test/ltp_p1.patch && \
       make autotools && \
       ./configure && \
-      make -j
+      make -j"$(nproc)"
 
 RUN virtualenv -p python3 /opt/test-runner/
 
@@ -31,7 +31,7 @@ ENV SCOPE_EVENT_METRIC=true
 ENV SCOPE_EVENT_HTTP=true
 
 COPY ./syscalls/altp /opt/test/altp
-RUN cd /opt/test/altp && make -j
+RUN cd /opt/test/altp && make -j"$(nproc)"
 
 COPY ./test_runner/requirements.txt /opt/test-runner/requirements.txt
 RUN /opt/test-runner/bin/pip install -r /opt/test-runner/requirements.txt


### PR DESCRIPTION
- limit the parallel execution of make to available physical cores

Closes: #1209