### PR TITLE
Add Podman container support - issue 1216

### DIFF
--- a/cli/start/start.go
+++ b/cli/start/start.go
@@ -55,6 +55,16 @@ func getContainersPids() []int {
 		cPids = append(cPids, ctrDPids...)
 	}
 
+	podmanPids, err := util.GetPodmanPids()
+	if err != nil {
+		log.Error().
+			Err(err).
+			Msg("Discover Podman containers failed.")
+	}
+	if podmanPids != nil {
+		cPids = append(cPids, podmanPids...)
+	}
+
 	lxcPids, err := util.GetLXCPids()
 	if err != nil {
 		switch {

--- a/cli/util/namespace.go
+++ b/cli/util/namespace.go
@@ -51,15 +51,24 @@ func GetLXCPids() ([]int, error) {
 
 // Get the List of PID(s) related to containerd container
 func GetContainerDPids() ([]int, error) {
+	return getContainerRuntimePids("containerd-shim")
+}
 
-	shimPids, err := PidScopeMapByProcessName("containerd-shim")
+// Get the List of PID(s) related to Podman container
+func GetPodmanPids() ([]int, error) {
+	return getContainerRuntimePids("conmon")
+}
+
+// Get the List of PID(s) related to specific container runtime
+func getContainerRuntimePids(runtimeProc string) ([]int, error) {
+	runtimeContPids, err := PidScopeMapByProcessName(runtimeProc)
 	if err != nil {
 		return nil, err
 	}
-	pids := make([]int, 0, len(shimPids))
+	pids := make([]int, 0, len(runtimeContPids))
 
-	for shimPid := range shimPids {
-		childrenPids, err := PidChildren(shimPid)
+	for runtimeContPid := range runtimeContPids {
+		childrenPids, err := PidChildren(runtimeContPid)
 		if err != nil {
 			return nil, err
 		}

--- a/src/loaderop.c
+++ b/src/loaderop.c
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include "libdir.h"
 #include "loaderop.h"
+#include "nsfile.h"
 
 #include "scopestdlib.h"
 
@@ -385,8 +386,9 @@ set_loader(char *exe)
 }
 
 static void
-do_musl(char *exld, char *ldscope)
+do_musl(char *exld, char *ldscope, uid_t nsUid, gid_t nsGid)
 {
+    int symlinkErr = 0;
     char *lpath = NULL;
     char *ldso = NULL;
     char *path;
@@ -411,8 +413,8 @@ do_musl(char *exld, char *ldscope)
     }
 
     // dir is expected to exist here, not creating one
-    if ((symlink((const char *)exld, lpath) == -1) &&
-        (errno != EEXIST)) {
+    if ((nsFileSymlink((const char *)exld, lpath, nsUid, nsGid, scope_geteuid(), scope_getegid(), &symlinkErr) == -1) &&
+        (symlinkErr != EEXIST)) {
         scope_perror("do_musl:symlink");
         if (ldso) scope_free(ldso);
         if (lpath) scope_free(lpath);
@@ -433,7 +435,7 @@ do_musl(char *exld, char *ldscope)
  * Returns 0 if musl was not detected and 1 if it was.
  */
 int
-loaderOpSetupLoader(char *ldscope)
+loaderOpSetupLoader(char *ldscope, uid_t nsUid, gid_t nsGid)
 {
     int ret = 0; // not musl
 
@@ -442,7 +444,7 @@ loaderOpSetupLoader(char *ldscope)
     if (((ldso = loaderOpGetLoader(EXE_TEST_FILE)) != NULL) &&
         (scope_strstr(ldso, LIBMUSL) != NULL)) {
             // we are using the musl ld.so
-            do_musl(ldso, ldscope);
+            do_musl(ldso, ldscope, nsUid, nsGid);
             ret = 1; // detected musl
     }
 

--- a/src/loaderop.h
+++ b/src/loaderop.h
@@ -10,6 +10,6 @@ typedef enum {
 } patch_status_t;
 
 patch_status_t loaderOpPatchLibrary(const char*);
-int loaderOpSetupLoader(char *);
+int loaderOpSetupLoader(char *, uid_t, gid_t);
 
 #endif // __LOADEROP_H__

--- a/src/nsfile.c
+++ b/src/nsfile.c
@@ -88,3 +88,18 @@ nsFileFopen(const char *restrict pathname, const char *restrict mode, uid_t nsUi
     scope_setegid(restoreGid);
     return fp;
 }
+
+int
+nsFileSymlink(const char *target, const char *linkpath, uid_t nsUid, gid_t nsGid, uid_t restoreUid, gid_t restoreGid, int *errnoVal) {
+    scope_setegid(nsGid);
+    scope_seteuid(nsUid);
+
+    int res = scope_symlink(target, linkpath);
+    if (res == -1) {
+        *errnoVal = scope_errno;
+    }
+
+    scope_seteuid(restoreUid);
+    scope_setegid(restoreGid);
+    return res;
+}

--- a/src/nsfile.c
+++ b/src/nsfile.c
@@ -41,7 +41,8 @@ nsFileOpenWithMode(const char *pathname, int flags, mode_t mode, uid_t nsUid, gi
     return fd;
 }
 
-int nsFileMkdir(const char *pathname, mode_t mode, uid_t nsUid, gid_t nsGid, uid_t restoreUid, gid_t restoreGid) {
+int
+nsFileMkdir(const char *pathname, mode_t mode, uid_t nsUid, gid_t nsGid, uid_t restoreUid, gid_t restoreGid) {
     scope_setegid(nsGid);
     scope_seteuid(nsUid);
 
@@ -52,7 +53,8 @@ int nsFileMkdir(const char *pathname, mode_t mode, uid_t nsUid, gid_t nsGid, uid
     return res;
 }
 
-int nsFileMksTemp(char *template, uid_t nsUid, gid_t nsGid, uid_t restoreUid, gid_t restoreGid) {
+int
+nsFileMksTemp(char *template, uid_t nsUid, gid_t nsGid, uid_t restoreUid, gid_t restoreGid) {
     scope_setegid(nsGid);
     scope_seteuid(nsUid);
 
@@ -63,7 +65,8 @@ int nsFileMksTemp(char *template, uid_t nsUid, gid_t nsGid, uid_t restoreUid, gi
     return res;
 }
 
-int nsFileRename(const char *oldpath, const char *newpath, uid_t nsUid, gid_t nsGid, uid_t restoreUid, gid_t restoreGid) {
+int
+nsFileRename(const char *oldpath, const char *newpath, uid_t nsUid, gid_t nsGid, uid_t restoreUid, gid_t restoreGid) {
     scope_setegid(nsGid);
     scope_seteuid(nsUid);
 
@@ -74,7 +77,8 @@ int nsFileRename(const char *oldpath, const char *newpath, uid_t nsUid, gid_t ns
     return res;
 }
 
-FILE *nsFileFopen(const char *restrict pathname, const char *restrict mode, uid_t nsUid, gid_t nsGid, uid_t restoreUid, gid_t restoreGid) {
+FILE *
+nsFileFopen(const char *restrict pathname, const char *restrict mode, uid_t nsUid, gid_t nsGid, uid_t restoreUid, gid_t restoreGid) {
     scope_setegid(nsGid);
     scope_seteuid(nsUid);
 

--- a/src/nsfile.h
+++ b/src/nsfile.h
@@ -31,5 +31,6 @@ int nsFileMkdir(const char *, mode_t, uid_t, gid_t, uid_t, gid_t);
 int nsFileMksTemp(char *, uid_t, gid_t, uid_t, gid_t);
 int nsFileRename(const char *, const char *, uid_t, gid_t, uid_t, gid_t);
 FILE *nsFileFopen(const char *, const char *, uid_t, gid_t, uid_t, gid_t);
+int nsFileSymlink(const char *, const char *, uid_t, gid_t, uid_t, gid_t, int *);
 
 #endif // __NSFILE_H__

--- a/src/scope_static.c
+++ b/src/scope_static.c
@@ -845,7 +845,7 @@ main(int argc, char **argv, char **env)
         return EXIT_FAILURE;
     }
 
-    loaderOpSetupLoader(loader);
+    loaderOpSetupLoader(loader, nsUid, nsGid);
 
     // set SCOPE_EXEC_PATH to path to `ldscope` if not set already
     if (getenv("SCOPE_EXEC_PATH") == 0) {

--- a/src/scopestdlib.c
+++ b/src/scopestdlib.c
@@ -209,6 +209,7 @@ extern int           scopelibc_ftruncate(int, off_t);
 extern int           scopelibc_setns(int, int);
 extern int           scopelibc_chown(const char *, uid_t, gid_t);
 extern int           scopelibc_fchown(int, uid_t, gid_t);
+extern int           scopelibc_symlink(const char *, const char *);
 
 static int g_go_static;
 
@@ -1238,3 +1239,7 @@ scope_fchown(int fd, uid_t owner, gid_t group) {
     return scopelibc_fchown(fd, owner, group);
 }
 
+int
+scope_symlink(const char *target, const char *linkpath) {
+    return scopelibc_symlink(target, linkpath);
+}

--- a/src/scopestdlib.h
+++ b/src/scopestdlib.h
@@ -284,6 +284,7 @@ void          scope_srand(unsigned int);
 int           scope_setns(int, int);
 int           scope_chown(const char *, uid_t, gid_t);
 int           scope_fchown(int, uid_t, gid_t);
+int           scope_symlink(const char *, const char *);
 
 
 #endif // __SCOPE_STDLIB_H__


### PR DESCRIPTION

- `conmon` is used as a parent process
  to find all child processses for root and
  rootless containers

E.g.

```
systemd(1)───systemd(4964)───conmon(2382451)───redis-server(2382454)
```

Closes: https://github.com/criblio/appscope/issues/1216