### PR TITLE
(#1251) Fix double free of `found` structure `destroyEntry`

### DIFF
--- a/src/cfgutils.c
+++ b/src/cfgutils.c
@@ -1762,7 +1762,6 @@ processProtocolEntry(config_t* config, yaml_document_t* doc, yaml_node_t* node)
                 DBG(NULL);
             }
             protocol_context = NULL;
-            destroyProtEntry(found);
             break;
         }
     }


### PR DESCRIPTION
- remove `destroyEntry` to avoid memory corruption
- the protocol entry `found` which was in `g_protlist` was already freed by calling `lstDelete(g_protlist, key)` by `list->delete_fn`

Fixes: #1251