### PR TITLE
Go MQ panic fix

### DIFF
--- a/cli/ipc/mq_test.go
+++ b/cli/ipc/mq_test.go
@@ -161,3 +161,19 @@ func TestCommunicationMqWriter(t *testing.T) {
 	err = msgQWriter.destroy()
 	assert.NoError(t, err)
 }
+
+func TestSimpleMqReader(t *testing.T) {
+	const mqName string = "goTestMqSimple"
+	msgQUnlink(mqName)
+	mqfd, err := msgQOpen(mqName, unix.O_CREAT|unix.O_RDONLY|unix.O_NONBLOCK|unix.O_EXCL)
+	assert.NoError(t, err)
+	for i := 0; i < 200000; i++ {
+		size, err := msgQCurrentMessages(mqfd)
+		assert.Zero(t, size)
+		assert.NoError(t, err)
+	}
+
+	unix.Close(mqfd)
+	// Always unlink even when closing fails
+	msgQUnlink(mqName)
+}

--- a/cli/util/util.S
+++ b/cli/util/util.S
@@ -1,0 +1,4 @@
+#include "textflag.h"
+
+TEXT ·KeepAlive(SB),NOSPLIT,$0
+	RET

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/fatih/structs"
 )
@@ -372,3 +373,6 @@ func CopyFile(src, dst string, mode fs.FileMode) (int64, error) {
 	nBytes, err := io.Copy(destination, source)
 	return nBytes, err
 }
+
+// See util.S for implementation
+func KeepAlive(unsafe.Pointer)


### PR DESCRIPTION
The garbage collector can usually understand not to free Unsafe.Pointer's pointing to Go objects.
But in the case of C malloc'ed objects, the garbage collector is unaware of their use.
So you should pretend to use the objects after calling C code (such as Syscall package code) to ensure they aren't GC'ed
while the C code is executing.
If you don't do this hack, you are vulnerable to a panic/segfault caused by nil-pointer dereference.
Note: the runtime package has a hack for this also "runtime.KeepAlive" [see here](https://cs.opensource.google/go/go/+/master:src/runtime/mfinal.go;drc=b2faff18ce28edad98303d2c3134dec1331fd7b5;l=483)
