### PR TITLE
Docs/update footer

### DIFF
--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -16,7 +16,7 @@ export default function Footer() {
             </a>
           </Col>
           <Col xs={12} md={6} className="text-right footer-right">
-            <p>Cribl, &copy; 2021</p>
+            <p>&copy;2017 – 2023 Cribl, Inc. | <a href="https://cribl.io/legal" target="_blank" rel="noopener">Legal</a></p>
             <a href="https://www.facebook.com/Cribl-258234158133458/">
               <FontAwesomeIcon icon={["fab", "facebook"]} />
             </a>

--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -16,7 +16,7 @@ export default function Footer() {
             </a>
           </Col>
           <Col xs={12} md={6} className="text-right footer-right">
-            <p>&copy;2017 – 2023 Cribl, Inc. | <a href="https://cribl.io/legal" target="_blank" rel="noopener">Legal</a></p>
+            <p>&copy;2017 – 2023 Cribl, Inc. | <a href="https://cribl.io/legal" target="_blank" rel="noopener"><strong>Legal</strong></a></p>
             <a href="https://www.facebook.com/Cribl-258234158133458/">
               <FontAwesomeIcon icon={["fab", "facebook"]} />
             </a>


### PR DESCRIPTION
As of 2/14 I have checked with Legal — this is good to merge now, thanks!

Our footer had an old copyright date, and lacked a link to Legal.

This PR makes the footer the same as the Cribl.io footer, fixing both issues.

I checked with @ricksalsa on this.

