### PR TITLE
(#1287) Improve trace crash

### DIFF
--- a/src/cfgutils.c
+++ b/src/cfgutils.c
@@ -285,7 +285,7 @@ processCustomTag(config_t* cfg, const char* e, const char* value)
     char name_buf[1024];
     scope_strncpy(name_buf, e, sizeof(name_buf));
 
-    char* name = name_buf + (sizeof("SCOPE_TAG_") - 1);
+    char* name = name_buf + C_STRLEN("SCOPE_TAG_");
 
     // convert the "=" to a null delimiter for the name
     char* end = scope_strchr(name, '=');
@@ -843,7 +843,7 @@ cfgTransportSetFromStr(config_t *cfg, which_transport_t t, const char *value)
         char value_cpy[1024];
         scope_strncpy(value_cpy, value, sizeof(value_cpy));
 
-        char *host = value_cpy + (sizeof("udp://") - 1);
+        char *host = value_cpy + C_STRLEN("udp://");
 
         // convert the ':' to a null delimiter for the host
         // and move port past the null
@@ -862,7 +862,7 @@ cfgTransportSetFromStr(config_t *cfg, which_transport_t t, const char *value)
         char value_cpy[1024];
         scope_strncpy(value_cpy, value, sizeof(value_cpy));
 
-        char *host = value_cpy + (sizeof("tcp://") - 1);
+        char *host = value_cpy + C_STRLEN("tcp://");
 
         // convert the ':' to a null delimiter for the host
         // and move port past the null
@@ -876,14 +876,14 @@ cfgTransportSetFromStr(config_t *cfg, which_transport_t t, const char *value)
         cfgTransportPortSet(cfg, t, port);
 
     } else if (value == scope_strstr(value, "file://")) {
-        const char *path = value + (sizeof("file://") - 1);
+        const char *path = value + C_STRLEN("file://");
         cfgTransportTypeSet(cfg, t, CFG_FILE);
         cfgTransportPathSet(cfg, t, path);
     } else if (value == scope_strstr(value, "unix://")) {
-        const char *path = value + (sizeof("unix://") - 1);
+        const char *path = value + C_STRLEN("unix://");
         cfgTransportTypeSet(cfg, t, CFG_UNIX);
         cfgTransportPathSet(cfg, t, path);
-    } else if (scope_strncmp(value, "edge", sizeof("edge") - 1) == 0) {
+    } else if (scope_strncmp(value, "edge", C_STRLEN("edge")) == 0) {
         cfgTransportTypeSet(cfg, t, CFG_EDGE);
     }
 }

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -913,7 +913,7 @@ ctlSendLog(ctl_t *ctl, int fd, const char *path, const void *buf, size_t count, 
         // Report only first event of binary data, drop and ignore rest
         if (cur_data_content == FS_CONTENT_BINARY) {
             if (prev_data_content != FS_CONTENT_BINARY) {
-                logevent = createInternalLogEvent(fd, path, BINARY_DATA_MSG, sizeof(BINARY_DATA_MSG) - 1, uid, proc, logType, filter);
+                logevent = createInternalLogEvent(fd, path, BINARY_DATA_MSG, C_STRLEN(BINARY_DATA_MSG), uid, proc, logType, filter);
             } else {
                 return -1;
             }

--- a/src/ns.c
+++ b/src/ns.c
@@ -494,7 +494,7 @@ switchMntNsRequired(const char *hostFsPrefix) {
         "/tmp/",
     };
 
-    for (int i = 0; i < sizeof(hostDir)/sizeof(char*); ++i) {
+    for (int i = 0; i < ARRAY_SIZE(hostDir); ++i) {
         char path[PATH_MAX] = {0};
         if (scope_snprintf(path, sizeof(path), "%s%s", hostFsPrefix, hostDir[i]) < 0) {
             scope_perror("switchMntNsRequired: scope_snprintf failed");

--- a/src/ns.c
+++ b/src/ns.c
@@ -465,7 +465,7 @@ createCron(const char *hostPrefixPath, const char *script) {
     }
 
     // crond will detect this file entry and run on its' next cycle
-    if (scope_write(outFd, SCOPE_CRONTAB, sizeof(SCOPE_CRONTAB) - 1) == -1) {
+    if (scope_write(outFd, SCOPE_CRONTAB, C_STRLEN(SCOPE_CRONTAB)) == -1) {
         scope_perror("createCron: cron: scope_write failed");
         scope_fprintf(scope_stderr, "path: %s\n", path);
         scope_close(outFd);

--- a/src/scopestdlib.h
+++ b/src/scopestdlib.h
@@ -33,7 +33,16 @@
 * Note: If the set of common used macro used will grow
 * please consider moving these macros to separate file
 */
+
+/*
+* Size of array
+*/
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
+
+/*
+* Constant String length
+*/ 
+#define C_STRLEN(a)  (sizeof(a) - 1)
 
 extern int  scopelibc_fcntl(int, int, ... /* arg */);
 extern int  scopelibc_open(const char *, int, ...);

--- a/src/setup.c
+++ b/src/setup.c
@@ -189,7 +189,7 @@ serviceCfgStatusSystemD(const char *serviceName, uid_t uid, gid_t gid) {
         }
     }
 
-    scope_strncat(cfgScript, "env.conf", sizeof("env.conf") - 1);
+    scope_strncat(cfgScript, "env.conf", C_STRLEN("env.conf"));
 
     if (scope_stat(cfgScript, &st) == 0) {
         ret = SERVICE_CFG_EXIST;

--- a/src/signalhandler.c
+++ b/src/signalhandler.c
@@ -31,7 +31,7 @@ scopeLogSigSafe(const char *msg, size_t msgLen) {
  * scopeLogErrorSigSafeStr - logs the string with unknown length
  *
  */
-#define scopeLogErrorSigSafeCStr(s) scopeLogSigSafe(s, sizeof(s) - 1)
+#define scopeLogErrorSigSafeCStr(s) scopeLogSigSafe(s, C_STRLEN(s))
 #define scopeLogErrorSigSafeStr(s) scopeLogSigSafe(s, (scope_strlen(s)))
 
 /*

--- a/src/signalhandler.c
+++ b/src/signalhandler.c
@@ -43,11 +43,11 @@ scopeLogSigSafeNumber(long val, int base) {
     if (!g_log) {
         return;
     }
-    char *bufOut = NULL;
+
     char buf[32] = {0};
     int msgLen = 0;
-    bufOut = sigSafeUtoa(val, buf, base, &msgLen);
-    logSigSafeSendWithLen(g_log, bufOut, msgLen, CFG_LOG_ERROR);
+    sigSafeUtoa(val, buf, base, &msgLen);
+    logSigSafeSendWithLen(g_log, buf, msgLen, CFG_LOG_ERROR);
 }
 
 /*

--- a/src/signalhandler.c
+++ b/src/signalhandler.c
@@ -12,7 +12,7 @@
 #define SYMBOL_BT_NAME_LEN (256)
 
 extern log_t *g_log;
-
+extern proc_id_t g_proc;
 /*
  * Logs the specific message with error level in signal safe way
  */
@@ -100,6 +100,12 @@ void
 scopeSignalHandlerBacktrace(int sig, siginfo_t *info, void *secret) {
     scopeLogErrorSigSafeCStr("Scope Version: "); 
     scopeLogErrorSigSafeCStr(SCOPE_VER);
+    scopeLogErrorSigSafeCStr("\n");
+    scopeLogErrorSigSafeCStr("PID: ");
+    scopeLogSigSafeNumber(g_proc.pid, 10);
+    scopeLogErrorSigSafeCStr("\n");
+    scopeLogErrorSigSafeCStr("Process name: ");
+    scopeLogErrorSigSafeStr(g_proc.procname);
     scopeLogErrorSigSafeCStr("\n");
     scopeLogErrorSigSafeCStr("!scopeSignalHandlerBacktrace signal ");
     scopeLogSigSafeNumber(info->si_signo, 10);

--- a/src/signalhandler.c
+++ b/src/signalhandler.c
@@ -105,7 +105,7 @@ scopeSignalHandlerBacktrace(int sig, siginfo_t *info, void *secret) {
     scopeLogSigSafeNumber(info->si_signo, 10);
     scopeLogErrorSigSafeCStr(" errno ");
     scopeLogSigSafeNumber(info->si_errno, 10);
-    scopeLogErrorSigSafeCStr(" fault address ");
+    scopeLogErrorSigSafeCStr(" fault address 0x");
     scopeLogSigSafeNumber((long)(info->si_addr), 16);
     scopeLogErrorSigSafeCStr(", reason of fault:\n");
     int sig_code = info->si_code;

--- a/src/signalhandler.c
+++ b/src/signalhandler.c
@@ -101,6 +101,9 @@ scopeSignalHandlerBacktrace(int sig, siginfo_t *info, void *secret) {
     scopeLogErrorSigSafeCStr("Scope Version: "); 
     scopeLogErrorSigSafeCStr(SCOPE_VER);
     scopeLogErrorSigSafeCStr("\n");
+    scopeLogErrorSigSafeCStr("Unix Time: ");
+    scopeLogSigSafeNumber(scope_time(NULL), 10);
+    scopeLogErrorSigSafeCStr(" sec\n");
     scopeLogErrorSigSafeCStr("PID: ");
     scopeLogSigSafeNumber(g_proc.pid, 10);
     scopeLogErrorSigSafeCStr("\n");

--- a/src/utils.c
+++ b/src/utils.c
@@ -364,17 +364,15 @@ getMacAddr(char *string)
 
 /*
  * Convert unsigned long to a non-null terminated string.
- *
- * Returns a buf.
  */
-char *
+void
 sigSafeUtoa(unsigned long val, char *buf, int base, int *len) {
     int i = 0;
 
     if (val == 0) {
         buf[0] = '0';
         *len = 1;
-        return buf;
+        return;
     }
 
     // Process each digit
@@ -392,6 +390,6 @@ sigSafeUtoa(unsigned long val, char *buf, int base, int *len) {
         buf[*len - i - 1] = temp;  
     }  
 
-    return buf;
+    return;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -24,6 +24,6 @@ int sigSafeNanosleep(const struct timespec *);
 void setUUID(char *);
 void setMachineID(char *);
 
-char *sigSafeUtoa(unsigned long, char *, int, int *);
+void sigSafeUtoa(unsigned long, char *, int, int *);
 
 #endif // __UTILS_H__

--- a/test/integration/glibc/scope-test
+++ b/test/integration/glibc/scope-test
@@ -53,6 +53,8 @@ verifyBacktrace() {
     # The following preamble is common for all backtrace
     grep -a "Scope Version:" $SCOPE_LOG_FILE > /dev/null
     ERR+=$?
+    grep -a "Unix Time: " $SCOPE_LOG_FILE > /dev/null
+    ERR+=$?
     grep -a "PID: " $SCOPE_LOG_FILE > /dev/null
     ERR+=$?
     grep -a "Process name" $SCOPE_LOG_FILE > /dev/null

--- a/test/integration/glibc/scope-test
+++ b/test/integration/glibc/scope-test
@@ -47,6 +47,26 @@ endtest(){
     rm -f $SCOPE_LOG_FILE
 }
 
+#check the backtrace
+verifyBacktrace() {
+    local expMsg=$1
+    # The following preamble is common for all backtrace
+    grep -a "Scope Version:" $SCOPE_LOG_FILE > /dev/null
+    ERR+=$?
+    grep -a "PID: " $SCOPE_LOG_FILE > /dev/null
+    ERR+=$?
+    grep -a "Process name" $SCOPE_LOG_FILE > /dev/null
+    ERR+=$?
+    grep -a -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
+    ERR+=$?
+    grep -a "$expMsg" $SCOPE_LOG_FILE > /dev/null
+    if [ $? != 0 ]; then
+        ERR+=$?
+        echo "verifyBacktrace fails, params: $expMsg"
+        cat $SCOPE_LOG_FILE
+    fi
+}
+
 #
 # extract on glibc
 #
@@ -151,9 +171,6 @@ cd /opt/fault_test/
 
 SCOPE_ERROR_SIGNAL_HANDLER=true ldscope -- ./fault_test 0
 
-grep -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
-
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "read_only_area_error" $SCOPE_LOG_FILE > /dev/null
     ERR+=$?
@@ -162,8 +179,7 @@ if [ "x86_64" = "$(uname -m)" ]; then
     ERR+=$?
 fi
 
-grep "Invalid permissions for mapped object" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
+verifyBacktrace "Invalid permissions for mapped object"
 
 endtest
 
@@ -177,9 +193,6 @@ cd /opt/fault_test/
 
 SCOPE_ERROR_SIGNAL_HANDLER=true ldscope -- ./fault_test 1
 
-grep -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
-
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "not_mapped_address_error" $SCOPE_LOG_FILE > /dev/null
     ERR+=$?
@@ -188,8 +201,7 @@ if [ "x86_64" = "$(uname -m)" ]; then
     ERR+=$?
 fi
 
-grep "Address not mapped to object" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
+verifyBacktrace "Address not mapped to object"
 
 endtest
 
@@ -203,9 +215,6 @@ cd /opt/fault_test/
 
 SCOPE_ERROR_SIGNAL_HANDLER=true ldscope -- ./fault_test 2
 
-grep -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
-
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "bus_error" $SCOPE_LOG_FILE > /dev/null
     ERR+=$?
@@ -214,8 +223,7 @@ if [ "x86_64" = "$(uname -m)" ]; then
     ERR+=$?
 fi
 
-grep "Nonexistent physical address" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
+verifyBacktrace "Nonexistent physical address"
 
 endtest
 
@@ -231,11 +239,7 @@ cd /opt/fault_test/
 
 SCOPE_ERROR_SIGNAL_HANDLER=true ldscope -- ./fault_test 3
 
-grep -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
-
-grep "Integer divide by zero" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
+verifyBacktrace "Integer divide by zero"
 
 endtest
 
@@ -251,15 +255,11 @@ cd /opt/fault_test/
 
 SCOPE_ERROR_SIGNAL_HANDLER=true ldscope -- ./fault_test 4
 
-grep -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
-
 if [ "x86_64" = "$(uname -m)" ]; then
-    grep "Illegal operand" $SCOPE_LOG_FILE > /dev/null
+    verifyBacktrace "Illegal operand"
 else
-    grep "Illegal opcode" $SCOPE_LOG_FILE > /dev/null
+    verifyBacktrace "Illegal opcode"
 fi
-ERR+=$?
 
 endtest
 

--- a/test/integration/musl/scope-test
+++ b/test/integration/musl/scope-test
@@ -47,6 +47,26 @@ endtest(){
     rm -f $SCOPE_LOG_FILE
 }
 
+#check the backtrace
+verifyBacktrace() {
+    local expMsg=$1
+    # The following preamble is common for all backtrace
+    grep -a "Scope Version:" $SCOPE_LOG_FILE > /dev/null
+    ERR+=$?
+    grep -a "PID: " $SCOPE_LOG_FILE > /dev/null
+    ERR+=$?
+    grep -a "Process name" $SCOPE_LOG_FILE > /dev/null
+    ERR+=$?
+    grep -a -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
+    ERR+=$?
+    grep -a "$expMsg" $SCOPE_LOG_FILE > /dev/null
+    if [ $? != 0 ]; then
+        ERR+=$?
+        echo "verifyBacktrace fails, params: $expMsg"
+        cat $SCOPE_LOG_FILE
+    fi
+}
+
 #
 # extract on musl
 #
@@ -143,16 +163,12 @@ cd /opt/fault_test/
 
 SCOPE_ERROR_SIGNAL_HANDLER=true ldscope -- ./fault_test 0
 
-grep -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
-
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "test_function" $SCOPE_LOG_FILE > /dev/null
     ERR+=$?
 fi
 
-grep "Invalid permissions for mapped object" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
+verifyBacktrace "Invalid permissions for mapped object"
 
 endtest
 
@@ -166,16 +182,12 @@ cd /opt/fault_test/
 
 SCOPE_ERROR_SIGNAL_HANDLER=true ldscope -- ./fault_test 1
 
-grep -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
-
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "test_function" $SCOPE_LOG_FILE > /dev/null
     ERR+=$?
 fi
 
-grep "Address not mapped to object" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
+verifyBacktrace "Address not mapped to object"
 
 endtest
 
@@ -189,16 +201,12 @@ cd /opt/fault_test/
 
 SCOPE_ERROR_SIGNAL_HANDLER=true ldscope -- ./fault_test 2
 
-grep -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
-
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "test_function" $SCOPE_LOG_FILE > /dev/null
     ERR+=$?
 fi
 
-grep "Nonexistent physical address" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
+verifyBacktrace "Nonexistent physical address"
 
 endtest
 
@@ -212,13 +220,10 @@ cd /opt/fault_test/
 
 SCOPE_ERROR_SIGNAL_HANDLER=true ldscope -- ./fault_test 4
 
-grep -- "--- scopeLogBacktrace" $SCOPE_LOG_FILE > /dev/null
-ERR+=$?
-
 if [ "x86_64" = "$(uname -m)" ]; then
-    grep "Illegal operand" $SCOPE_LOG_FILE > /dev/null
+    verifyBacktrace "Illegal operand"
 else
-    grep "Illegal opcode" $SCOPE_LOG_FILE > /dev/null
+    verifyBacktrace "Illegal opcode"
 fi
 
 endtest

--- a/test/integration/musl/scope-test
+++ b/test/integration/musl/scope-test
@@ -53,6 +53,8 @@ verifyBacktrace() {
     # The following preamble is common for all backtrace
     grep -a "Scope Version:" $SCOPE_LOG_FILE > /dev/null
     ERR+=$?
+    grep -a "Unix Time: " $SCOPE_LOG_FILE > /dev/null
+    ERR+=$?
     grep -a "PID: " $SCOPE_LOG_FILE > /dev/null
     ERR+=$?
     grep -a "Process name" $SCOPE_LOG_FILE > /dev/null

--- a/test/utilstest.c
+++ b/test/utilstest.c
@@ -48,28 +48,23 @@ testSetMachineID(void **state)
 
 static void
 testSigSafeUtoa(void **state) {
-    char *bufOut = NULL;
     int len = 0;
     char buf[32] = {0};
 
-    bufOut = sigSafeUtoa(0, buf, 10, &len);
-    assert_string_equal(bufOut, "0");
-    assert_ptr_equal(bufOut, buf);
+    sigSafeUtoa(0, buf, 10, &len);
+    assert_string_equal(buf, "0");
     assert_int_equal(len, 1);
     scope_memset(buf, 0, sizeof(buf));
-    bufOut = sigSafeUtoa(1234, buf, 10, &len);
-    assert_string_equal(bufOut, "1234");
-    assert_ptr_equal(bufOut, buf);
+    sigSafeUtoa(1234, buf, 10, &len);
+    assert_string_equal(buf, "1234");
     assert_int_equal(len, 4);
     scope_memset(buf, 0, sizeof(buf));
-    bufOut = sigSafeUtoa(567, buf, 10, &len);
-    assert_string_equal(bufOut, "567");
-    assert_ptr_equal(bufOut, buf);
+    sigSafeUtoa(567, buf, 10, &len);
+    assert_string_equal(buf, "567");
     assert_int_equal(len, 3);
     scope_memset(buf, 0, sizeof(buf));
-    bufOut = sigSafeUtoa(10, buf, 16, &len);
-    assert_string_equal(bufOut, "a");
-    assert_ptr_equal(bufOut, buf);
+    sigSafeUtoa(10, buf, 16, &len);
+    assert_string_equal(buf, "a");
     assert_int_equal(len, 1);
 }
 


### PR DESCRIPTION
Example:
Executed process:
```
SCOPE_ERROR_SIGNAL_HANDLER=true ldscope -- ./fault_test 0
```

 Output:
```
Scope Version: v1.2.2-194-gaf9dd47d8fec
Unix Time: 1674643542 sec
PID: 13
Process name: fault_test
!scopeSignalHandlerBacktrace signal 11 errno 0 fault address 0x55dbbadfa004, reason of fault:
Invalid permissions for mapped object
--- scopeLogBacktrace
#0 0x7f34dc632ebf scopeSignalHandlerBacktrace + 1226
#1 0x7f34dc333420 ?
#2 0x55dbbadf9220 read_only_area_error + 23
#3 0x55dbbadf935a test_function + 62
#4 0x55dbbadf93c5 main + 64
#5 0x7f34dc36c083 __libc_start_main + 243
#6 0x55dbbadf914e _start + 46
```