### PR TITLE
[#1279 4/4] Generate core dump in libscope.so

### DIFF
--- a/src/scopetypes.h
+++ b/src/scopetypes.h
@@ -208,6 +208,9 @@ typedef struct
 //    SCOPE_PAYLOAD_TO_DISK          if payloads are enabled, "true" forces writes to payload->dir
 //    SCOPE_ALLOW_CONSTRUCT_DBG      allows debug inside the constructor
 //    SCOPE_ERROR_SIGNAL_HANDLER     allows to register signal error handler for following signals: SIGSEGV, SIGBUS, SIGILL and SIGFPE
+//                                   "log" - log the backtrace
+//                                   "coredump" - generate coredump file as "/tmp/scope_core.<pid>"
+//                                   "full" - includes "log" and "coredump" functionality
 //    SCOPE_QUEUE_LENGTH             override default circular buffer sizes
 //    SCOPE_START_NOPROFILE          cause the start command to ignore updates to /etc/profile.d
 //    SCOPE_START_FORCE_PROFILE      force the start command to update profile.d with a dev version

--- a/src/signalhandler.h
+++ b/src/signalhandler.h
@@ -4,12 +4,17 @@
 #include <signal.h>
 
 /*
- *  Manage signal handler for backtrace
+ *  Manage signal handler for backtrace/coredump
  *  IMPORTANT NOTE:
  *  The API used in this module must be the signal safety
  *  https://man7.org/linux/man-pages/man7/signal-safety.7.html
  */
 
-void scopeSignalHandlerBacktrace(int , siginfo_t *, void *);
+/*
+ * Signal handlers for SIGSEGV, SIGBUS, SIGILL and SIGFPE
+ */
+void scopeSignalHandlerBacktrace(int, siginfo_t *, void *);
+void scopeSignalHandlerCoreDump(int, siginfo_t *, void *);
+void scopeSignalHandlerFull(int, siginfo_t *, void *);
 
 #endif // __SIGNALHANDLER_H__

--- a/test/integration/glibc/scope-test
+++ b/test/integration/glibc/scope-test
@@ -170,7 +170,7 @@ starttest fault_test_read_only_mem
 
 cd /opt/fault_test/
 
-SCOPE_ERROR_SIGNAL_HANDLER=true scope -z -- ./fault_test 0
+SCOPE_ERROR_SIGNAL_HANDLER=log scope -z -- ./fault_test 0
 
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "read_only_area_error" $SCOPE_LOG_FILE > /dev/null
@@ -192,7 +192,7 @@ starttest fault_test_not_mapped_mem
 
 cd /opt/fault_test/
 
-SCOPE_ERROR_SIGNAL_HANDLER=true scope -z -- ./fault_test 1
+SCOPE_ERROR_SIGNAL_HANDLER=log scope -z -- ./fault_test 1
 
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "not_mapped_address_error" $SCOPE_LOG_FILE > /dev/null
@@ -214,7 +214,7 @@ starttest fault_test_bus_error
 
 cd /opt/fault_test/
 
-SCOPE_ERROR_SIGNAL_HANDLER=true scope -z -- ./fault_test 2
+SCOPE_ERROR_SIGNAL_HANDLER=log scope -z -- ./fault_test 2
 
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "bus_error" $SCOPE_LOG_FILE > /dev/null
@@ -238,7 +238,7 @@ starttest div_by_zero_error
 
 cd /opt/fault_test/
 
-SCOPE_ERROR_SIGNAL_HANDLER=true scope -z ./fault_test 3
+SCOPE_ERROR_SIGNAL_HANDLER=log scope -z ./fault_test 3
 
 verifyBacktrace "Integer divide by zero"
 
@@ -254,7 +254,7 @@ starttest illegal_op_error
 
 cd /opt/fault_test/
 
-SCOPE_ERROR_SIGNAL_HANDLER=true scope -z ./fault_test 4
+SCOPE_ERROR_SIGNAL_HANDLER=log scope -z ./fault_test 4
 
 if [ "x86_64" = "$(uname -m)" ]; then
     verifyBacktrace "Illegal operand"

--- a/test/integration/musl/scope-test
+++ b/test/integration/musl/scope-test
@@ -161,7 +161,7 @@ starttest fault_test_read_only_mem
 
 cd /opt/fault_test/
 
-SCOPE_ERROR_SIGNAL_HANDLER=true scope -z -- ./fault_test 0
+SCOPE_ERROR_SIGNAL_HANDLER=log scope -z -- ./fault_test 0
 
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "test_function" $SCOPE_LOG_FILE > /dev/null
@@ -180,7 +180,7 @@ starttest fault_test_not_mapped_mem
 
 cd /opt/fault_test/
 
-SCOPE_ERROR_SIGNAL_HANDLER=true scope -z -- ./fault_test 1
+SCOPE_ERROR_SIGNAL_HANDLER=log scope -z -- ./fault_test 1
 
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "test_function" $SCOPE_LOG_FILE > /dev/null
@@ -199,7 +199,7 @@ starttest fault_test_bus_error
 
 cd /opt/fault_test/
 
-SCOPE_ERROR_SIGNAL_HANDLER=true scope -z -- ./fault_test 2
+SCOPE_ERROR_SIGNAL_HANDLER=log scope -z -- ./fault_test 2
 
 if [ "x86_64" = "$(uname -m)" ]; then
     grep "test_function" $SCOPE_LOG_FILE > /dev/null
@@ -218,7 +218,7 @@ starttest illegal_op_error
 
 cd /opt/fault_test/
 
-SCOPE_ERROR_SIGNAL_HANDLER=true scope -z ./fault_test 4
+SCOPE_ERROR_SIGNAL_HANDLER=log scope -z ./fault_test 4
 
 if [ "x86_64" = "$(uname -m)" ]; then
     verifyBacktrace "Illegal operand"


### PR DESCRIPTION
This Pull request required merging the following Pull Requests:
- [x] #1294 
- [x] #1295
- [x] #1296

In this Pull Request following changes are introduced:
- extending the possible values of `SCOPE_ERROR_SIGNAL_HANDLER`
- generates the coredump in signal handler based on `coredump` or `full` value
- core dump will be generated in `/tmp/scope_core.<PID>` path