### PR TITLE
(#1302) Fix compilation coredumper on Ubuntu 22.04

### DIFF
--- a/contrib/coredumper/configure.ac
+++ b/contrib/coredumper/configure.ac
@@ -26,7 +26,7 @@ AC_SUBST(LIBTOOL_DEPS)
 
 AC_CHECK_HEADERS([elf.h errno.h fcntl.h linux/unistd.h pthread.h signal.h     \
                   stdlib.h string.h sys/prctl.h sys/ptrace.h sys/resource.h   \
-                  sys/socket.h sys/stat.h sys/sysctl.h sys/time.h sys/types.h \
+                  sys/socket.h sys/stat.h sys/time.h sys/types.h \
                   sys/uio.h sys/wait.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics

--- a/contrib/coredumper/src/elfcore.c
+++ b/contrib/coredumper/src/elfcore.c
@@ -50,7 +50,6 @@ extern "C" {
 #include <sys/prctl.h>
 #include <sys/procfs.h>
 #include <sys/socket.h>
-#include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/uio.h>
 #include <sys/wait.h>

--- a/install_build_tools.sh
+++ b/install_build_tools.sh
@@ -247,6 +247,26 @@ yum_sudo_install() {
     fi
 }
 
+yum_curl_exists() {
+    if curl --version &>/dev/null; then
+        echo "curl is already installed; doing nothing for curl."
+    else
+        echo "curl is not already installed."
+        return 1
+    fi
+}
+
+yum_curl_install() {
+    echo "Installing curl."
+    yum install curl
+    if [ $? = 0 ]; then
+        echo "Installation of curl successful."
+    else
+        echo "Installation of curl failed."
+        FAILED=1
+    fi
+}
+
 yum_autoconf_exists() {
     if autoconf --version &>/dev/null; then
         echo "autoconf is already installed; doing nothing for autoconf."
@@ -429,6 +449,7 @@ yum_dump_versions() {
     fi
     yum --version | head -n1 | sed 's/^/      yum /'
     sudo --version | head -n1 | sed 's/^/      /'
+    curl --version | head -n1 | sed 's/^/      /'
     autoconf --version | head -n1 | sed 's/^/      /'
     make --version | head -n1 | sed 's/^/      /'
     automake --version | head -n1 | sed 's/^/      /'
@@ -444,6 +465,9 @@ yum_install() {
 
     if ! yum_sudo_exists; then
         yum_sudo_install
+    fi
+    if ! yum_curl_exists; then
+        yum_curl_install
     fi
     if ! yum_autoconf_exists; then
         yum_autoconf_install
@@ -511,6 +535,26 @@ apt_sudo_install() {
         echo "Installation of sudo successful."
     else
         echo "Installation of sudo failed."
+        FAILED=1
+    fi
+}
+
+apt_curl_exists() {
+    if curl --version &>/dev/null; then
+        echo "curl is already installed; doing nothing for curl."
+    else
+        echo "curl is not already installed."
+        return 1
+    fi
+}
+
+apt_curl_install() {
+    echo "Installing curl."
+    apt-get update && apt-get install curl
+    if [ $? = 0 ]; then
+        echo "Installation of curl successful."
+    else
+        echo "Installation of curl failed."
         FAILED=1
     fi
 }
@@ -649,6 +693,7 @@ apt_dump_versions() {
     fi
     apt-get --version | head -n1 | sed 's/^/      /'
     sudo --version | head -n1 | sed 's/^/      /'
+    curl --version | head -n1 | sed 's/^/      /'
     make --version | head -n1 | sed 's/^/      /'
     autoconf --version | head -n1 | sed 's/^/      /'
     libtool --version | head -n1 | sed 's/^/      /'
@@ -663,6 +708,9 @@ apt_install() {
 
     if ! apt_sudo_exists; then
         apt_sudo_install
+    fi
+    if ! apt_curl_exists; then
+        apt_curl_install
     fi
     if ! apt_make_exists; then
         apt_make_install

--- a/os/linux/Makefile
+++ b/os/linux/Makefile
@@ -96,7 +96,7 @@ $(LIBLOADER): src/loader/loader.c src/loader/nsinfo.c src/loader/nsfile.c src/lo
 
 $(SCOPEDYN): src/loader/scopedyn.c src/loader/loaderutils.c src/loader/libdir.c src/loader/libver.c src/loader/ns.c src/loader/nsinfo.c src/loader/setup.c src/loader/patch.c src/loader/nsfile.c
 	@echo "$${CI:+::group::}Building $@"
-	gcc -Wall -g $(LOADER_CFLAGS) \
+	$(CC) -Wall -g $(LOADER_CFLAGS) \
 	src/loader/scopedyn.c src/loader/loaderutils.c src/loader/libdir.c src/loader/libver.c src/loader/ns.c src/loader/nsinfo.c src/loader/setup.c src/loader/patch.c src/loader/nsfile.c \
 	-ldl -lrt -o $@ -I./os/$(OS) $(INCLUDES)
 	@[ -z "$(CI)" ] || echo "::endgroup::"


### PR DESCRIPTION
Coredumper code does not used anything from `sys/sysctl.h` support
so it should be removed. The inclusion of a `sys/sysctl.h` generates
following warning on Ubuntu 20.04
```
 "The <sys/sysctl.h> header is deprecated and will be removed.
```
On more modern OSes like Ubuntu 22.04 the warning mentioned above is
actually an error, since starting from glibc 2.32 the `sys/sysctl.h`
the header was removed.

Ref: https://abi-laboratory.pro/index.php?view=changelog&l=glibc&v=2.32

Other changes are not related to this PR but I found them during working on this issue