### PR TITLE
Add ability to extract file from namespace 1312

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -29,19 +29,19 @@ package main
 // scope [OPTIONS] --patch SO_FILE
 //
 // Options:
-// -l, --libbasedir DIR         specify parent for the library directory (default: /tmp)
-// -f DIR                       alias for \"-l DIR\" for backward compatibility
-// -a, --ldattach PID           attach to the specified process ID
-// -d, --lddetach PID           detach from the specified process ID
-// -c, --configure FILTER_PATH  configure scope environment with FILTER_PATH
-// -w, --unconfigure            unconfigure scope environment
-// -g, --getfile                get a file from a specified container PID
-// -s, --service SERVICE        setup specified service NAME
-// -v, --unservice              remove scope from all service configurations
-// -n  --namespace PID          perform service/configure operation on specified container PID
-// -p, --patch SO_FILE          patch specified libscope.so
-// -r, --starthost              execute the scope start command in a host context (must be run in the container)
-// -x, --stophost               execute the scope stop command in a host context (must be run in the container)
+// -l, --libbasedir DIR              specify parent for the library directory (default: /tmp)
+// -f DIR                            alias for \"-l DIR\" for backward compatibility
+// -a, --ldattach PID                attach to the specified process ID
+// -d, --lddetach PID                detach from the specified process ID
+// -c, --configure FILTER_PATH       configure scope environment with FILTER_PATH
+// -w, --unconfigure                 unconfigure scope environment
+// -g, --getfile SRC_FILE,DEST_FILE  get a file from SRC_FILE and put it in DEST_FILE
+// -s, --service SERVICE             setup specified service NAME
+// -v, --unservice                   remove scope from all service configurations
+// -n  --namespace PID               perform operation on specified container PID
+// -p, --patch SO_FILE               patch specified libscope.so
+// -r, --starthost                   execute the scope start command in a host context (must be run in the container)
+// -x, --stophost                    execute the scope stop command in a host context (must be run in the container)
 
 // Long aliases for short options
 // NOTE: Be sure to align these with the options listed in the call to getopt_long

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -389,10 +389,22 @@ cmdUnconfigure(pid_t nspid)
     return status;
 }
 
+// Handle getfile command
 int
-cmdGetFile(char *path, pid_t nspid)
+cmdGetFile(char *paths, pid_t nspid)
 {
+    char *src_path;
+    char *dest_path;
     pid_t nsContainerPid = 0;
+
+    if ((src_path = strtok(paths, ",")) == NULL) {
+        fprintf(stderr, "error: no source file path\n");
+        return EXIT_FAILURE;
+    }
+    if ((dest_path = strtok(NULL, ",")) == NULL) {
+        fprintf(stderr, "error: no destination file path\n");
+        return EXIT_FAILURE;
+    }
 
     if (nspid == -1) {
         fprintf(stderr, "error: getfile requires a namespace pid\n");
@@ -405,7 +417,7 @@ cmdGetFile(char *path, pid_t nspid)
         return EXIT_FAILURE;
     }
 
-    return nsGetFile(path, nspid);
+    return nsGetFile(src_path, dest_path, nspid);
 }
 
 // Handle attach and detach commands

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -389,6 +389,25 @@ cmdUnconfigure(pid_t nspid)
     return status;
 }
 
+int
+cmdGetFile(char *path, pid_t nspid)
+{
+    pid_t nsContainerPid = 0;
+
+    if (nspid == -1) {
+        fprintf(stderr, "error: getfile requires a namespace pid\n");
+        return EXIT_FAILURE;
+    }
+
+    if ((nsInfoGetPidNs(nspid, &nsContainerPid) == FALSE) ||
+        (nsInfoIsPidInSameMntNs(nspid) == TRUE)) {
+        fprintf(stderr, "error: invalid namespace\n");
+        return EXIT_FAILURE;
+    }
+
+    return nsGetFile(path, nspid);
+}
+
 // Handle attach and detach commands
 int
 cmdAttach(bool ldattach, bool lddetach, pid_t pid, pid_t nspid)

--- a/src/loader/loader.h
+++ b/src/loader/loader.h
@@ -9,6 +9,7 @@ int cmdService(char *, pid_t);
 int cmdUnservice(pid_t);
 int cmdConfigure(char *, pid_t);
 int cmdUnconfigure(pid_t);
+int cmdGetFile(char *, pid_t);
 int cmdAttach(bool, bool, pid_t, pid_t);
 int cmdRun(bool, bool, pid_t, pid_t, int, char **);
 

--- a/src/loader/ns.h
+++ b/src/loader/ns.h
@@ -10,7 +10,7 @@
 int nsForkAndExec(pid_t, pid_t, bool);
 int nsConfigure(pid_t, void *, size_t);
 int nsUnconfigure(pid_t);
-int nsGetFile(char *, pid_t);
+int nsGetFile(char *, char *, pid_t);
 service_status_t nsService(pid_t, const char *);
 service_status_t nsUnservice(pid_t);
 

--- a/src/loader/ns.h
+++ b/src/loader/ns.h
@@ -10,6 +10,7 @@
 int nsForkAndExec(pid_t, pid_t, bool);
 int nsConfigure(pid_t, void *, size_t);
 int nsUnconfigure(pid_t);
+int nsGetFile(char *, pid_t);
 service_status_t nsService(pid_t, const char *);
 service_status_t nsUnservice(pid_t);
 

--- a/src/loader/ns.h
+++ b/src/loader/ns.h
@@ -10,7 +10,7 @@
 int nsForkAndExec(pid_t, pid_t, bool);
 int nsConfigure(pid_t, void *, size_t);
 int nsUnconfigure(pid_t);
-int nsGetFile(char *, char *, pid_t);
+int nsGetFile(const char *, const char *, pid_t);
 service_status_t nsService(pid_t, const char *);
 service_status_t nsUnservice(pid_t);
 

--- a/test/integration/cli/test_options.sh
+++ b/test/integration/cli/test_options.sh
@@ -146,7 +146,7 @@ outputs "error: --passthrough cannot be used with --ldattach/--lddetach or --nam
 returns 1
 
 run ./bin/linux/${ARCH}/scope -n 1 ls
-outputs "error: --namespace option requires --configure/--unconfigure or --service/--unservice option"
+outputs "error: --namespace option requires --configure/--unconfigure or --service/--unservice or --getfile option"
 returns 1
 
 run ./bin/linux/${ARCH}/scope -s dummy_service_value -c dummy_filter_value

--- a/test/integration/cli/test_options.sh
+++ b/test/integration/cli/test_options.sh
@@ -73,6 +73,14 @@ run ./bin/linux/${ARCH}/scope --configure
 outputs "error: missing required value for -c option"
 returns 1
 
+run ./bin/linux/${ARCH}/scope -g
+outputs "error: missing required value for -g option"
+returns 1
+
+run ./bin/linux/${ARCH}/scope --getfile
+outputs "error: missing required value for -g option"
+returns 1
+
 run ./bin/linux/${ARCH}/scope -s
 outputs "error: missing required value for -s option"
 returns 1
@@ -188,6 +196,18 @@ returns 1
 
 run ./bin/linux/${ARCH}/scope -a 999999999
 outputs "error: --ldattach, --lddetach PID not a current process"
+returns 1
+
+run ./bin/linux/${ARCH}/scope -g ,
+outputs "error: no source file path"
+returns 1
+
+run ./bin/linux/${ARCH}/scope -g somefile
+outputs "error: no destination file path"
+returns 1
+
+run ./bin/linux/${ARCH}/scope -g somefile,
+outputs "error: no destination file path"
 returns 1
 
 export SCOPE_LIB_PATH=./lib/linux/${ARCH}/libscope.so


### PR DESCRIPTION
This PR adds the capability for scope (in constructor mode) to act as a utility get a file from a namespace, and save it to a destination on the host's disk.

**Testing**
Integration tests were added to test the argument handling when file paths are passed as arguments to the new command `--getfile`.

Closes: #1312