### PR TITLE
Add coredump and backtrace flags 1319

### DIFF
--- a/cli/cmd/attach.go
+++ b/cli/cmd/attach.go
@@ -6,7 +6,7 @@ import (
 )
 
 /* Args Matrix (X disallows)
- *                 cribldest metricformat metricdest eventdest nobreaker authtoken verbosity payloads loglevel librarypath userconfig
+ *                 cribldest metricformat metricdest eventdest nobreaker authtoken verbosity payloads loglevel librarypath userconfig coredump backtrace
  * cribldest       -                      X          X                                                                     X
  * metricformat              -                                                                                             X
  * metricdest      X                      -                                                                                X
@@ -17,7 +17,9 @@ import (
  * payloads                                                                                  -                             X
  * loglevel                                                                                           -                    X
  * librarypath                                                                                                 -
- * userconfig      X         X            X          X         X         X         X         X        X                    -
+ * userconfig      X         X            X          X         X         X         X         X        X                    -          X         X
+ * coredump     																										   X		  -
+ * backtrace  																											   X				    -
  */
 
 // attachCmd represents the attach command
@@ -56,6 +58,10 @@ scope attach --payloads 2000`,
 			helpErrAndExit(cmd, "Cannot specify --payloads and --userconfig")
 		} else if rc.Loglevel != "" && rc.UserConfig != "" {
 			helpErrAndExit(cmd, "Cannot specify --loglevel and --userconfig")
+		} else if rc.Backtrace && rc.UserConfig != "" {
+			helpErrAndExit(cmd, "Cannot specify --backtrace and --userconfig")
+		} else if rc.Coredump && rc.UserConfig != "" {
+			helpErrAndExit(cmd, "Cannot specify --coredump and --userconfig")
 		}
 
 		return rc.Attach(args)

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -9,7 +9,7 @@ import (
 )
 
 /* Args Matrix (X disallows)
- *                 cribldest metricformat metricdest eventdest nobreaker authtoken verbosity payloads loglevel librarypath userconfig
+ *                 cribldest metricformat metricdest eventdest nobreaker authtoken verbosity payloads loglevel librarypath userconfig coredump backtrace
  * cribldest       -                      X          X                                                                     X
  * metricformat              -                                                                                             X
  * metricdest      X                      -                                                                                X
@@ -20,7 +20,9 @@ import (
  * payloads                                                                                  -                             X
  * loglevel                                                                                           -                    X
  * librarypath                                                                                                 -
- * userconfig      X         X            X          X         X         X         X         X        X                    -
+ * userconfig      X         X            X          X         X         X         X         X        X                    -          X         X
+ * coredump     																										   X		  -
+ * backtrace  																											   X				    -
  */
 
 var rc *run.Config = &run.Config{}
@@ -63,6 +65,10 @@ scope run -c edge -- top`,
 			helpErrAndExit(cmd, "Cannot specify --payloads and --userconfig")
 		} else if rc.Loglevel != "" && rc.UserConfig != "" {
 			helpErrAndExit(cmd, "Cannot specify --loglevel and --userconfig")
+		} else if rc.Backtrace && rc.UserConfig != "" {
+			helpErrAndExit(cmd, "Cannot specify --backtrace and --userconfig")
+		} else if rc.Coredump && rc.UserConfig != "" {
+			helpErrAndExit(cmd, "Cannot specify --coredump and --userconfig")
 		}
 
 		rc.Run(args)

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -62,6 +62,8 @@ func runCmdFlags(cmd *cobra.Command, rc *run.Config) {
 	cmd.Flags().StringVar(&rc.Loglevel, "loglevel", "", "Set scope library log level (debug, warning, info, error, none)")
 	cmd.Flags().StringVarP(&rc.LibraryPath, "librarypath", "l", "", "Set path for dynamic libraries")
 	cmd.Flags().StringVarP(&rc.UserConfig, "userconfig", "u", "", "Scope an application with a user specified config file; overrides all other settings.")
+	cmd.Flags().BoolVarP(&rc.Coredump, "coredump", "d", false, "Enable core dump file generation when an application crashes.")
+	cmd.Flags().BoolVarP(&rc.Backtrace, "backtrace", "b", false, "Enable backtrace file generation when an application crashes.")
 	metricAndEventDestFlags(cmd, rc)
 }
 

--- a/cli/run/run.go
+++ b/cli/run/run.go
@@ -27,6 +27,8 @@ type Config struct {
 	AuthToken     string
 	UserConfig    string
 	CommandDir    string
+	Coredump      bool
+	Backtrace     bool
 
 	now func() time.Time
 	sc  *libscope.ScopeConfig

--- a/cli/run/scopeconfig.go
+++ b/cli/run/scopeconfig.go
@@ -274,6 +274,13 @@ func (c *Config) configFromRunOpts() error {
 	// To support mixing of config and environment variables
 	c.sc.Cribl.AuthToken = c.AuthToken
 
+	if c.Backtrace {
+		c.sc.Libscope.Snapshot.Backtrace = "true"
+	}
+	if c.Coredump {
+		c.sc.Libscope.Snapshot.Coredump = "true"
+	}
+
 	if c.CriblDest != "" {
 		err := parseDest(&c.sc.Cribl.Transport, c.CriblDest)
 		if err != nil {


### PR DESCRIPTION
This PR adds the `--backtrace` and `--coredump` flags to `scope run` and `scope attach` that will update the cli-generated configuration for libscope.

#### QA Instructions
```
scope run --help
# observe new flags
scope run -d -b top
# observe scope.yml sets both backtrace and snapshot to `true` in the session directory
```

Closes #1319 