### PR TITLE
Fix `scope events -f` regression

### DIFF
--- a/cli/cmd/events.go
+++ b/cli/cmd/events.go
@@ -36,7 +36,7 @@ import (
 var eventsCmd = &cobra.Command{
 	Use:   "events [flags] ([eventId])",
 	Short: "Outputs events for a session",
-	Long: `Outputs events for a session. You can obtain detailed information about each event by inputting the Event ID as a positional parameter. (By default, the Event ID appears in blue in []'s at the left.) You can provide filters to narrow down by name (e.g., http, net, fs, console), or by field (e.g., fs.open, stdout, or net.open). You can use JavaScript expressions to further refine the query, and to express logic.`,
+	Long:  `Outputs events for a session. You can obtain detailed information about each event by inputting the Event ID as a positional parameter. (By default, the Event ID appears in blue in []'s at the left.) You can provide filters to narrow down by name (e.g., http, net, fs, console), or by field (e.g., fs.open, stdout, or net.open). You can use JavaScript expressions to further refine the query, and to express logic.`,
 	Example: `scope events
 scope events m61
 scope events --sourcetype http
@@ -152,7 +152,7 @@ scope events -n 1000 -e 'sourcetype!="console" && source.indexOf("cribl.log") ==
 		if len(args) > 0 {
 			events.PrintEvent(out, jsonOut)
 		} else {
-			events.PrintEvents(out, fields, sortField, eval, jsonOut, sortReverse, allFields, forceColor, termWidth)
+			events.PrintEvents(out, fields, sortField, eval, jsonOut, sortReverse, allFields, forceColor, termWidth, follow)
 		}
 	},
 }

--- a/cli/events/events.go
+++ b/cli/events/events.go
@@ -228,7 +228,7 @@ func PrintEvent(in chan libscope.EventBody, jsonOut bool) {
 // PrintEvents prints multiple events
 // handles --eval
 // handles --json
-func PrintEvents(in chan libscope.EventBody, fields []string, sortField, eval string, jsonOut, sortReverse, allFields, forceColor bool, width int) {
+func PrintEvents(in chan libscope.EventBody, fields []string, sortField, eval string, jsonOut, sortReverse, allFields, forceColor bool, width int, follow bool) {
 	enc := json.NewEncoder(os.Stdout)
 	var vm *goja.Runtime
 	var prog *goja.Program
@@ -277,6 +277,12 @@ func PrintEvents(in chan libscope.EventBody, fields []string, sortField, eval st
 		}
 
 		events = append(events, e)
+
+		// No sorting needed for follow mode
+		if follow {
+			out := GetEventText(e, forceColor, allFields, fields, width)
+			util.Printf("%s\n", out)
+		}
 	}
 
 	// Sort events


### PR DESCRIPTION
A regression in recent versions has broken the `scope events -f` mode.

This PR fixes that by moving the event print statement into the reader loop that is being written to by the tail reader. 
It's safe to do here when not in `follow` mode because no event sorting is required (or possible) in follow mode.

**Testing**
This has been tested to work on a process in the same environment; and a processes running in a container with the events command running on the host.