### PR TITLE
Minor issues with IPC 1250 & typos

### DIFF
--- a/cli/cmd/daemon.go
+++ b/cli/cmd/daemon.go
@@ -20,11 +20,12 @@ import (
 
 // daemonCmd represents the daemon command
 var daemonCmd = &cobra.Command{
-	Use:     "daemon [flags]",
-	Short:   "Run the scope daemon",
-	Long:    `Listen and respond to system events.`,
-	Example: `scope daemon`,
-	Args:    cobra.NoArgs,
+	Use:   "daemon [flags]",
+	Short: "Run the scope daemon",
+	Long:  `Listen and respond to system events.`,
+	Example: `scope daemon
+	scope daemon --filedest localhost:10089`,
+	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		filedest, _ := cmd.Flags().GetString("filedest")
 		sendcore, _ := cmd.Flags().GetBool("sendcore")

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -17,8 +17,8 @@ var pidCtx *ipc.IpcPidCtx = &ipc.IpcPidCtx{}
 // inspectCmd represents the inspect command
 var inspectCmd = &cobra.Command{
 	Use:     "inspect",
-	Short:   "Returns information of scoped process",
-	Long:    `Returns information of scoped process identified by PID.`,
+	Short:   "Returns information about scoped process",
+	Long:    `Returns information about scoped process identified by PID.`,
 	Example: `scope inspect 1000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -39,7 +39,7 @@ var inspectCmd = &cobra.Command{
 
 		status, _ := util.PidScopeLibInMaps(pid)
 		if !status {
-			util.ErrAndExit("Unable to communicate with %v - process doesn't contains libscope.so library", pid)
+			util.ErrAndExit("Unable to communicate with %v - process is not scoped", pid)
 		}
 
 		pidCtx.Pid = pid

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -34,7 +34,7 @@ var inspectCmd = &cobra.Command{
 
 		pid, err := strconv.Atoi(args[0])
 		if err != nil {
-			util.ErrAndExit("Convert PID fails: %v", err)
+			util.ErrAndExit("error parsing PID argument")
 		}
 		pidCtx.Pid = pid
 		cfg, err := inspect.InspectProcess(*pidCtx)

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -17,8 +17,8 @@ var pidCtx *ipc.IpcPidCtx = &ipc.IpcPidCtx{}
 // inspectCmd represents the inspect command
 var inspectCmd = &cobra.Command{
 	Use:     "inspect",
-	Short:   "Return information on scoped process",
-	Long:    `Return information on scoped process identified by PID.`,
+	Short:   "Returns information of scoped process",
+	Long:    `Returns information of scoped process identified by PID.`,
 	Example: `scope inspect 1000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -36,6 +36,12 @@ var inspectCmd = &cobra.Command{
 		if err != nil {
 			util.ErrAndExit("error parsing PID argument")
 		}
+
+		status, _ := util.PidScopeLibInMaps(pid)
+		if !status {
+			util.ErrAndExit("Unable to communicate with %v - process doesn't contains libscope.so library", pid)
+		}
+
 		pidCtx.Pid = pid
 		cfg, err := inspect.InspectProcess(*pidCtx)
 		if err != nil {

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -16,11 +16,11 @@ import (
  */
 
 func getStopUsage() string {
-	return fmt.Sprintf(`The following actions will be performed on the host and in all relevant containers:
+	return `The following actions will be performed on the host and in all relevant containers:
 	- Removal of filter files /usr/lib/appscope/scope_filter and /tmp/appscope/scope_filter
 	- Detach from all existing scoped processes
 	- Removal of etc/profile.d/scope.sh script 
-	- Update the relevant service configurations to not LD_PRELOAD libscope if already doing so`)
+	- Update the relevant service configurations to not LD_PRELOAD libscope if already doing so`
 }
 
 // stopCmd represents the stop command

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -16,8 +16,8 @@ var cfgPath string
 // updateCmd represents the info command
 var updateCmd = &cobra.Command{
 	Use:     "update",
-	Short:   "Updates configuration of scoped process",
-	Long:    `Updates configuration of scoped process identified by PID.`,
+	Short:   "Updates the configuration of a scoped process",
+	Long:    `Updates the configuration of a scoped process identified by PID.`,
 	Example: `scope update 1000 --config test_cfg.yml`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -41,7 +41,7 @@ var updateCmd = &cobra.Command{
 
 		status, _ := util.PidScopeLibInMaps(pid)
 		if !status {
-			util.ErrAndExit("Unable to communicate with %v - process doesn't contains libscope.so library", pid)
+			util.ErrAndExit("Unable to communicate with %v - process is not scoped", pid)
 		}
 
 		pidCtx.Pid = pid

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -39,6 +39,11 @@ var updateCmd = &cobra.Command{
 			util.ErrAndExit("error parsing PID argument")
 		}
 
+		status, _ := util.PidScopeLibInMaps(pid)
+		if !status {
+			util.ErrAndExit("Unable to communicate with %v - process doesn't contains libscope.so library", pid)
+		}
+
 		pidCtx.Pid = pid
 
 		err = update.UpdateScopeCfg(*pidCtx, cfgPath)

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -36,7 +36,7 @@ var updateCmd = &cobra.Command{
 
 		pid, err := strconv.Atoi(args[0])
 		if err != nil {
-			util.ErrAndExit("Convert PID fails: %v", err)
+			util.ErrAndExit("error parsing PID argument")
 		}
 
 		pidCtx.Pid = pid

--- a/cli/update/update.go
+++ b/cli/update/update.go
@@ -9,7 +9,7 @@ import (
 
 var errSettingCfg = errors.New("error setting cfg")
 
-// UpdateScopeCfg updates the configuration of scoped process
+// UpdateScopeCfg updates the configuration of a scoped process
 func UpdateScopeCfg(pidCtx ipc.IpcPidCtx, confFile string) error {
 	content, err := os.ReadFile(confFile)
 	if err != nil {

--- a/cli/util/proc.go
+++ b/cli/util/proc.go
@@ -313,7 +313,19 @@ func PidUser(pid int) (string, error) {
 	return user.Username, nil
 }
 
-// // PidScopeStatus checks a Scope Status if a process specified by PID.
+// PidScopeLibInMaps checks if a process specified by PID contains libscope in memory mappings.
+func PidScopeLibInMaps(pid int) (bool, error) {
+	pidMapFile, err := os.ReadFile(fmt.Sprintf("/proc/%v/maps", pid))
+	if err != nil {
+		// Process or do not exist or we do not have permissions to read a map file
+		return false, err
+	}
+
+	pidMap := string(pidMapFile)
+	return strings.Contains(pidMap, "libscope"), nil
+}
+
+// PidScopeStatus checks a Scope Status if a process specified by PID.
 func PidScopeStatus(pid int) (ScopeStatus, error) {
 	pidMapFile, err := os.ReadFile(fmt.Sprintf("/proc/%v/maps", pid))
 	if err != nil {

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -187,7 +187,6 @@ snapInfo(const char *dirPath, const char *epochStr, siginfo_t *unused) {
     snapshotWriteNumberDec(fd, g_proc.pid);
     snapshotWriteConstStr(fd ,"\nProcess name: ");
     snapshotWriteStr(fd, g_proc.procname);
-    snapshotWriteConstStr(fd, "\n");
 
     scope_close(fd);
     return (scope_chmod(filePath, 0755) == 0) ? TRUE : FALSE;

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -1893,7 +1893,7 @@ sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
      */
     if (snapshotIsEnabled() == TRUE) {
 
-        // When act is NULL, return the saved applisction handler
+        // When act is NULL, return the saved application handler
         // but *do not* run snapshotBackupAppSignalHandler().
         // i.e., don't save the NULL as the latest application handler
         if (act == NULL) {


### PR DESCRIPTION
Following Pull Request addresss:
- https://github.com/criblio/appscope/issues/1250#issuecomment-1431440170
- fix typos discovered in code
- provide `scope daemon --filedest` example 
- remove unnecessary newline in `snapInfo` function
- remove unnecessary `fmt.Sprintf` in `getStopUsage` function