### PR TITLE
Fix overwrite value on stack `g_cfg.funcs_attached` - 1354

### DIFF
--- a/src/wrap_go.c
+++ b/src/wrap_go.c
@@ -81,7 +81,7 @@ int g_go_minor_ver = UNKNOWN_GO_VER;
 int g_go_maint_ver = UNKNOWN_GO_VER;
 int g_arch = ARCH;
 static char g_go_build_ver[7];
-static char g_ReadFrame_addr[sizeof(void *)];
+static char g_ReadFrame_addr[20];
 go_schema_t *g_go_schema = &go_9_schema; // overridden if later version
 uint64_t g_glibc_guard = 0LL;
 uint64_t go_systemstack_switch;
@@ -1025,7 +1025,7 @@ initGoHook(elf_buf_t *ebuf)
     }
 
     ReadFrame_addr = (uint64_t *)((uint64_t)ReadFrame_addr + base);
-    scope_sprintf(g_ReadFrame_addr, "%p\n", ReadFrame_addr);
+    scope_snprintf(g_ReadFrame_addr, sizeof(g_ReadFrame_addr), "%p\n", ReadFrame_addr);
 
     char gosave[30] = "gosave";
     if (g_go_minor_ver >= 17) scope_strcpy(gosave, "gosave_systemstack_switch");


### PR DESCRIPTION
```
scope_sprintf(g_ReadFrame_addr, "%p\n", ReadFrame_addr);
```

`scope_sprintf` will return 16 characters printed, while the size of `g_ReadFrame_addr` is 8 bytes `(sizeof(void*))`.

Side effect of the above is that without checking the return value and size limiation we will overwrite the value stored in `g_cfg.funcs_attached`.

Closes: #1354