### PR TITLE
Change `webhook-cert-manager` reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ docs-generate: require-docker-buildx-builder
 	@echo Running the AppScope docs generator
 	@docker run \
 		-v $(shell pwd):/home/node/appscope \
-		--rm cribl/scope:docs-$(ARCH) 
+		--rm $(TAG)
 	@echo AppScope docs generator finished: website/src/pages/docs/schema-reference.md is updated
 
 k8s-test: require-kind require-kubectl image

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ builder: require-docker-buildx-builder
 		--file docker/builder/Dockerfile.$(DIST) \
 		.
 
-image: TAG := cribl/scope:dev-$(ARCH)
+image: TAG := cribl/scope:dev
 image: require-qemu-binfmt
 	@docker buildx build \
 		--tag $(TAG) \
@@ -196,7 +196,7 @@ docs-generate: require-docker-buildx-builder
 	@echo AppScope docs generator finished: website/src/pages/docs/schema-reference.md is updated
 
 k8s-test: require-kind require-kubectl image
-	docker tag cribl/scope:dev-$(ARCH) cribl/scope:$(VERSION)
+	docker tag cribl/scope:dev cribl/scope:$(VERSION)
 	kind delete cluster
 	kind create cluster
 	kind load docker-image cribl/scope:$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ docs-generate: require-docker-buildx-builder
 	@echo AppScope docs generator finished: website/src/pages/docs/schema-reference.md is updated
 
 k8s-test: require-kind require-kubectl image
-	docker tag cribl/scope:dev-x86_64 cribl/scope:$(VERSION)
+	docker tag cribl/scope:dev-$(ARCH) cribl/scope:$(VERSION)
 	kind delete cluster
 	kind create cluster
 	kind load docker-image cribl/scope:$(VERSION)

--- a/cli/cmd/k8s.go
+++ b/cli/cmd/k8s.go
@@ -29,7 +29,7 @@ kubectl label namespace default scope=enabled`,
 			util.ErrAndExit("MetricDest set but EventDest is not")
 		}
 		if opt.Version == "" {
-			opt.Version = internal.GetVersion()
+			opt.Version = internal.GetNormalizedVersion()
 		}
 		opt.MetricDest = rc.MetricsDest
 		opt.MetricFormat = rc.MetricsFormat

--- a/cli/internal/version.go
+++ b/cli/internal/version.go
@@ -41,5 +41,8 @@ func GetNormalizedVersion() string {
 
 // IsVersionDev returns TRUE if used version is a developer version
 func IsVersionDev() bool {
-	return GitSummary[1:] != Version
+	if len(GitSummary) > 1 {
+		return GitSummary[1:] != Version
+	}
+	return false
 }

--- a/cli/k8s/configs.go
+++ b/cli/k8s/configs.go
@@ -172,7 +172,7 @@ spec:
       volumes:
         - name: certs
           secret:
-            secretName: {{ .App }}-secret 
+            secretName: {{ .App }}-secret
 ---
 apiVersion: v1
 kind: Service
@@ -187,7 +187,7 @@ spec:
       port: 443
       targetPort: {{ .Port }}
   selector:
-    app: {{ .App }} 
+    app: {{ .App }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/cli/k8s/configs.go
+++ b/cli/k8s/configs.go
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: webhook-cert-setup
         # This is a minimal kubectl image based on Alpine Linux that signs certificates using the k8s extension api server
-        image: newrelic/k8s-webhook-cert-manager:latest
+        image: cribl/k8s-webhook-cert-manager:latest
         command: ["./generate_certificate.sh"]
         args:
           - "--service"

--- a/cli/k8s/configs.go
+++ b/cli/k8s/configs.go
@@ -78,7 +78,7 @@ rules:
     verbs: ["get"]
   - apiGroups: ["certificates.k8s.io"]
     resources: ["signers"]
-    resourceNames: ["kubernetes.io/legacy-unknown"]
+    resourceNames: ["kubernetes.io/kubelet-serving"]
     verbs: ["approve"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/k8s/configs.go
+++ b/cli/k8s/configs.go
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: webhook-cert-setup
         # This is a minimal kubectl image based on Alpine Linux that signs certificates using the k8s extension api server
-        image: cribl/k8s-webhook-cert-manager:latest
+        image: cribl/k8s-webhook-cert-manager:1.0.0
         command: ["./generate_certificate.sh"]
         args:
           - "--service"

--- a/cli/k8s/webhook.go
+++ b/cli/k8s/webhook.go
@@ -47,7 +47,7 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 		shouldModify = false
 	}
 
-	ver := strings.Split(internal.GetVersion(), "-")
+	ver := internal.GetNormalizedVersion()
 
 	patch := []JSONPatchEntry{}
 	if shouldModify {
@@ -211,7 +211,7 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 			})
 			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, corev1.EnvVar{
 				Name:  "LD_LIBRARY_PATH",
-				Value: fmt.Sprintf("/tmp/appscope/%s/", ver[0]),
+				Value: fmt.Sprintf("/tmp/appscope/%s/", ver),
 			})
 			// Get some metadata pushed into scope from the K8S downward API
 			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, corev1.EnvVar{

--- a/cli/k8s/webhook.go
+++ b/cli/k8s/webhook.go
@@ -105,12 +105,12 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// InitContainer are splitted by 2 phases (scope-pod-init, scopeextract)
+		// InitContainer are splitted by 2 phases (scope-pod-init, scope-pod-extract)
 		// scope-pod-init: copy scope from cribl:/scope to shared volume /scope/scope
-		// scopeextract: create extraction directory (/scope/scope/<id>/) and perform
+		// scope-pod-extract: create extraction directory (/scope/scope/<id>/) and perform
 		// extract operation there
 		//
-		// Note: scopeextract is performed in context of application container
+		// Note: scope-pod-extract is performed in context of application container
 		// therefore we are able to detect proper loader used in application container
 
 		// scope-pod-init container will copy the scope binary
@@ -141,7 +141,7 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 
 		// add volume mount to all containers in the pod
 		for i := 0; i < len(pod.Spec.Containers); i++ {
-			// scopeextract container(s) will extract the scope files (library and config files)
+			// scope-pod-extract container(s) will extract the scope files (library and config files)
 			scopeDirPath := fmt.Sprintf("/scope/%d", i)
 			cmd := []string{
 				"/bin/sh",
@@ -173,7 +173,7 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 			cmdStr = append(cmdStr, scopeDirPath)
 			cmd = append(cmd, strings.Join(cmdStr, " "))
 			pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
-				Name:    fmt.Sprintf("scopeextract%d", i),
+				Name:    fmt.Sprintf("scope-pod-extract-%d", i),
 				Image:   pod.Spec.Containers[i].Image,
 				Command: cmd,
 				VolumeMounts: []corev1.VolumeMount{{

--- a/cli/k8s/webhook.go
+++ b/cli/k8s/webhook.go
@@ -116,7 +116,7 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 		// scope-pod-init container will copy the scope binary
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
 			Name:    "scope-pod-init",
-			Image:   fmt.Sprintf("cribl/scope:%s", internal.GetNormalizedVersion()),
+			Image:   fmt.Sprintf("cribl/scope:%s", ver),
 			Command: []string{"cp", "/usr/local/bin/scope", "/scope/scope"},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "scope",

--- a/cli/k8s/webhook.go
+++ b/cli/k8s/webhook.go
@@ -105,17 +105,17 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// InitContainer are splitted by 2 phases (scopeinit, scopeextract)
-		// scopeinit: copy scope from cribl:/scope to shared volume /scope/scope
+		// InitContainer are splitted by 2 phases (scope-pod-init, scopeextract)
+		// scope-pod-init: copy scope from cribl:/scope to shared volume /scope/scope
 		// scopeextract: create extraction directory (/scope/scope/<id>/) and perform
 		// extract operation there
 		//
 		// Note: scopeextract is performed in context of application container
 		// therefore we are able to detect proper loader used in application container
 
-		// scopeinit container will copy the scope binary
+		// scope-pod-init container will copy the scope binary
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
-			Name:    "scopeinit",
+			Name:    "scope-pod-init",
 			Image:   fmt.Sprintf("cribl/scope:%s", internal.GetNormalizedVersion()),
 			Command: []string{"cp", "/usr/local/bin/scope", "/scope/scope"},
 			VolumeMounts: []corev1.VolumeMount{{

--- a/cli/k8s/webhook.go
+++ b/cli/k8s/webhook.go
@@ -182,7 +182,7 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 			})
 			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, corev1.EnvVar{
 				Name:  "LD_LIBRARY_PATH",
-				Value: fmt.Sprintf("/tmp/libscope-%s", ver[0]),
+				Value: fmt.Sprintf("/tmp/appscope/%s/", ver[0]),
 			})
 			// Get some metadata pushed into scope from the K8S downward API
 			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, corev1.EnvVar{

--- a/cli/k8s/webhook.go
+++ b/cli/k8s/webhook.go
@@ -116,7 +116,7 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 		// scopeinit container will copy the scope binary
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
 			Name:    "scopeinit",
-			Image:   fmt.Sprintf("cribl/scope:%s", internal.GetVersion()),
+			Image:   fmt.Sprintf("cribl/scope:%s", internal.GetNormalizedVersion()),
 			Command: []string{"cp", "/usr/local/bin/scope", "/scope/scope"},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "scope",

--- a/cli/k8s/webhook.go
+++ b/cli/k8s/webhook.go
@@ -105,31 +105,19 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		cmd := []string{
-			"/usr/local/bin/scope",
-			"excrete",
-		}
-		if len(app.CriblDest) > 0 {
-			cmd = append(cmd,
-				"--cribldest",
-				app.CriblDest,
-			)
-		} else {
-			cmd = append(cmd,
-				"--metricdest",
-				app.MetricDest,
-				"--metricformat",
-				app.MetricFormat,
-				"--eventdest",
-				app.EventDest,
-			)
-		}
-		cmd = append(cmd, "/scope")
-		// Scope initcontainer will output the scope binary and scope library in the scope volume
+		// InitContainer are splitted by 2 phases (scopeinit, scopeextract)
+		// scopeinit: copy scope from cribl:/scope to shared volume /scope/scope
+		// scopeextract: create extraction directory (/scope/scope/<id>/) and perform
+		// extract operation there
+		//
+		// Note: scopeextract is performed in context of application container
+		// therefore we are able to detect proper loader used in application container
+
+		// scopeinit container will copy the scope binary
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
-			Name:    "scope",
+			Name:    "scopeinit",
 			Image:   fmt.Sprintf("cribl/scope:%s", internal.GetVersion()),
-			Command: cmd,
+			Command: []string{"cp", "/usr/local/bin/scope", "/scope/scope"},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "scope",
 				MountPath: "/scope",
@@ -153,6 +141,47 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 
 		// add volume mount to all containers in the pod
 		for i := 0; i < len(pod.Spec.Containers); i++ {
+			// scopeextract container(s) will extract the scope files (library and config files)
+			scopeDirPath := fmt.Sprintf("/scope/%d", i)
+			cmd := []string{
+				"/bin/sh",
+				"-c",
+			}
+			cmdStr := []string{
+				"mkdir",
+				scopeDirPath,
+				"&&",
+				"/scope/scope",
+				"excrete",
+			}
+			if len(app.CriblDest) > 0 {
+				cmdStr = append(cmdStr,
+					"--cribldest",
+					app.CriblDest,
+				)
+			} else {
+				cmdStr = append(cmdStr,
+					"--metricdest",
+					app.MetricDest,
+					"--metricformat",
+					app.MetricFormat,
+					"--eventdest",
+					app.EventDest,
+				)
+			}
+
+			cmdStr = append(cmdStr, scopeDirPath)
+			cmd = append(cmd, strings.Join(cmdStr, " "))
+			pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
+				Name:    fmt.Sprintf("scopeextract%d", i),
+				Image:   pod.Spec.Containers[i].Image,
+				Command: cmd,
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "scope",
+					MountPath: "/scope",
+				}},
+			})
+
 			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
 				Name:      "scope",
 				MountPath: "/scope",
@@ -170,11 +199,11 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 			// Add environment variables to configure scope
 			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, corev1.EnvVar{
 				Name:  "LD_PRELOAD",
-				Value: "/scope/libscope.so",
+				Value: fmt.Sprintf("%s/libscope.so", scopeDirPath),
 			})
 			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, corev1.EnvVar{
 				Name:  "SCOPE_CONF_PATH",
-				Value: "/scope/scope.yml",
+				Value: fmt.Sprintf("%s/scope.yml", scopeDirPath),
 			})
 			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, corev1.EnvVar{
 				Name:  "SCOPE_EXEC_PATH",


### PR DESCRIPTION
- `newrelic/k8s-webhook-cert-manager` is archived project since June 2, 2021
- update reference to https://github.com/criblio/k8s-webhook-cert-manager which handles deprecated API[1]:
```
The certificates.k8s.io/v1beta1 API version of CertificateSigningRequest is no longer served as of v1.22.

```
[1] https://kubernetes.io/docs/reference/using-api/deprecation-guide/

Required: 
- [x] k8s-webhook-cert-manager in [docker hub](https://hub.docker.com/r/cribl/k8s-webhook-cert-manager)
