### PR TITLE
Docs/fix noreferrers

### DIFF
--- a/test/integration/splunk/cribldemo/default/data/ui/views/encrypt.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/encrypt.xml
@@ -16,7 +16,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="masking" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Masking</a></span> 
+        background-color: #1890FF"><a href="" id="masking" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Masking</a></span> 
         </p>
       <p>Obfuscation (see <a href="pii">PII</a>) is a tried and true way of ensuring sensitive information isn't seen by someone downstream. But, what if some people need to see the data and other people do not? cribl provides the ability to encrypt and decrypt data based on role. Cribl allows for multiple levels and clearances, so that you can manage what level of sensitivity exists in your data. Lastly, this data can easily be at a <i>sub-field</i> level, meaning we can encrypt any part of a message including <code>_raw</code> and decrypt that on the fly.</p>
       <p>In the below example, we've taken a sensitive ID, the ESN, and now we've encrypted it, and on the right hand side we have decrypted it. Feel free to play with this yourself by drilling into the searches, or running these searches:</p>

--- a/test/integration/splunk/cribldemo/default/data/ui/views/filter.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/filter.xml
@@ -16,7 +16,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="sample_and_filter" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Sample and Filter</a></span> 
+        background-color: #1890FF"><a href="" id="sample_and_filter" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Sample and Filter</a></span> 
         </p>
       <p>As receivers of log data, we often have little control over what the developers of the originating system decided to log. In many instances, we are interested in one particular message or a subset of messages but we are deluged with superfluous data. Given the tooling available today, it is possible in Splunk to Null Queue certain messages and not others, but requires digging into props.conf and transforms.conf with some relatively esoteric syntax. Cribl makes it easy to filter and groom your data to just the messages you want to see through a rich interactive experience.</p>
       <p>In this example, we're using our web access log data source. In this data stream, we have a key value pair called action, and it contains all kinds of user related actions that occur on a fictional web shopping cart. In our case, we aren't interested in all user actions, but only in purchases. We use cribl to filter to only purchase messages, and you can see what a dramatic difference it makes in terms of data volume for this particular source.</p>

--- a/test/integration/splunk/cribldemo/default/data/ui/views/hash.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/hash.xml
@@ -16,7 +16,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="masking" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Masking</a></span> 
+        background-color: #1890FF"><a href="" id="masking" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Masking</a></span> 
         </p>
       <p>Hashing is often necessary when working with sensitive data and uniqueness guarantees are required. For example, if don't want to display certain sensitive fields, such as credit card numbers, API tokens, AWS/GCP/Azure keys, etc., but still want to preserve uniqueness because you care about statistics or associations with other fields then hashing is a perfect solution. <b>cribl provides the ability to hash data on the fly, using a variety of out-of-the-box algorithms; MD5, SHA* </b>. You can clone based on any index-time fields or event patterns.</p>
       <p>In the example below, we've taken data that contain a credit card number in <code>cardNumber</code> field, <b>MD5</b> hashed it and, just for the fun of it we substring-ed the hash to cardNumber's original length. Yes, we fully understand the impact of this - we're just showcasing cribl's capabilities!</p>

--- a/test/integration/splunk/cribldemo/default/data/ui/views/indextimefields.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/indextimefields.xml
@@ -16,7 +16,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="enrich" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Enrich</a></span> 
+        background-color: #1890FF"><a href="" id="enrich" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Enrich</a></span> 
         </p>
         <p>
           <b>Cribl allows for enriching events with index-time fields.</b> In this example, we're looking at web access logs and adding these index-time fields: <code>geo</code>, <code>dc</code>, and <code>rack</code>. Imagine these could come

--- a/test/integration/splunk/cribldemo/default/data/ui/views/lookup.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/lookup.xml
@@ -16,7 +16,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="enrich" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Enrich</a></span> 
+        background-color: #1890FF"><a href="" id="enrich" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Enrich</a></span> 
         </p>
         <p>
           One of the greatest features of Splunk is that it allows us lookup data in other, tabular sources, and enrich our log data. Some great examples include things like getting a location for an IP Address (GeoIP), looking up a user in a directory, or bringing more information about a host from an asset management system. One particular downside of lookups in Splunk, however, is that they can be very slow, especially if you're looking up data in an external system. They are also repeated every time a user runs a search. <b>Lastly, because they are at search time, the data is likely to have changed between when the event was emitted and when the lookup is done.</b>

--- a/test/integration/splunk/cribldemo/default/data/ui/views/metrics.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/metrics.xml
@@ -41,7 +41,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="logs_to_metrics" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Logs To Metrics</a></span> 
+        background-color: #1890FF"><a href="" id="logs_to_metrics" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Logs To Metrics</a></span> 
         </p>
         <p>
           <b>Cribl allows for taking any incoming log sources and converting them to precise metrics.</b>In this example, we're looking at plain old Apache access logs and converting a few of the fields into metrics. Specifically, we're making these two fields into metric values: <code>timeTaken</code>, <code>bytes</code>, and attaching the following as dimensions: 

--- a/test/integration/splunk/cribldemo/default/data/ui/views/pii.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/pii.xml
@@ -16,7 +16,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="masking" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Masking</a></span> 
+        background-color: #1890FF"><a href="" id="masking" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Masking</a></span> 
         </p>
         <p>
         Cribl can easily help us obfuscate sensitive information in our logs. First, lets look at an example where we have a social security number. Social Security numbers are hard because, intentionally, there is not an easy way to validate whether a given number is a social security number. It's just a string of 9 digits. For that reason, we need to configure cribl to look for something more than just a text string. In this case, we configured Cribl to look for a regex of <code>social=[0-9]{3}-?[0-9]{2}-?[0-9]{4}</code>. This is possible in Splunk today by modifying props and transforms, and is relatively simple and straightforward.

--- a/test/integration/splunk/cribldemo/default/data/ui/views/prettify.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/prettify.xml
@@ -16,7 +16,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="masking" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Prettify</a></span> 
+        background-color: #1890FF"><a href="" id="masking" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Prettify</a></span> 
         </p>
       <p>
         The data in this example comes from a middleware doing business event processing from a telco, and it's based on an actual log. It works well for Splunk, with Splunk's auto key/value extraction, but, <b>we'd like this data to be well formatted JSON</b> for sending to external systems. Lots of systems speak JSON natively, so we'd like to take this operational log and turn it into something more easily consumed. 

--- a/test/integration/splunk/cribldemo/default/data/ui/views/route.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/route.xml
@@ -7,7 +7,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="route" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Route</a></span> 
+        background-color: #1890FF"><a href="" id="route" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Route</a></span> 
         </p>
       <p>
         Splunk's forwarder is the best and most mature log data gathering technology, but until now it's only been able to deliver data to Splunk. For many of our customers and prospects, they've expressed a desire to be able to send some data they're gathering to Splunk and send some of their data to third party systems, like S3, NFS, Hadoop, or other file stores. Cribl makes this possible.

--- a/test/integration/splunk/cribldemo/default/data/ui/views/smart_sample.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/smart_sample.xml
@@ -16,7 +16,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="sample_and_filter" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Sample and Filter</a></span> 
+        background-color: #1890FF"><a href="" id="sample_and_filter" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Sample and Filter</a></span> 
         </p>
       <p>Many data sources are a mixed bag of value. In fact, many data sources simply never make it into Splunk because they present a dubious value proposition, like firewall logs, netflow logs, or web access logs. They may contain messages you absolutely have to have, and some which are significantly less valuable. <b>Cribl's smart sampling enables you to finally bring in high volume, low value data sources.</b>
         </p>     

--- a/test/integration/splunk/cribldemo/default/data/ui/views/start.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/start.xml
@@ -58,7 +58,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="cribluiaddress" target="_blank" style="color: #fff; text-decoration: none">Go To Cribl Management UI</a></span> 
+        background-color: #1890FF"><a href="" id="cribluiaddress" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Go To Cribl Management UI</a></span> 
         <p style="text-align: center">(same credentials as here)</p>
         </p>
         <hr/>

--- a/test/integration/splunk/cribldemo/default/data/ui/views/suppress.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/suppress.xml
@@ -16,7 +16,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="suppression" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Suppression</a></span> 
+        background-color: #1890FF"><a href="" id="suppression" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Suppression</a></span> 
         </p>
       <p>Logs come in a variety of forms and shapes. One of our favorites, for it's necessity but also complete oververbosity, is the status log. In this kind of log, some software outputs on an interval the status of a piece of running software. "Still running!" "Still running!". This is useful if you want to go back in time and find the particular time where the state changed, but it's also incredibly verbose and really would be better written to only output when the state changes.</p>
       <p>This is a great use case for suppression. With suppression, we can configure Cribl to only output N messages every X seconds that have the save signature, defined by a JavaScript expression. In this case, for every host and status, we configure out example log to only output one message every 60 seconds. This enables us to hugely reduce the amount of data being ingested while losing no functionality.</p>

--- a/test/integration/splunk/cribldemo/default/data/ui/views/trim.xml
+++ b/test/integration/splunk/cribldemo/default/data/ui/views/trim.xml
@@ -16,7 +16,7 @@
         <span style="margin-top:15px; 
         padding: 6px; 
         border-radius; 2px;
-        background-color: #1890FF"><a href="" id="trim_json" class="pipeline-name" target="_blank" style="color: #fff; text-decoration: none">Cribl Pipeline: Trim JSON</a></span> 
+        background-color: #1890FF"><a href="" id="trim_json" class="pipeline-name" target="_blank" rel="noreferrer noopener" style="color: #fff; text-decoration: none">Cribl Pipeline: Trim JSON</a></span> 
         </p>
       <p>One of the most frequent problems we've experienced with modern, structured, logging is over verbosity. From the producer's perspective, it's both easier and better to produce large structured events because they have no idea what may be needed in the future. From the consumer's perspective, this ends up in events which contain duplicative information or information which is simply not needed. Here's an example event taken from a real world log we have from a Lambda function we run along side a trimmed down log. You can see we remove a ton of duplicative information, such as the headers which are actually logged twice, along with field set to null and false because we can easily use something like <code>fillnull</code> to fill in default values. Using this mechanism, we easily trim 50% of data we don't care about.</p>
     </html>

--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -16,7 +16,7 @@ export default function Footer() {
             </a>
           </Col>
           <Col xs={12} md={6} className="text-right footer-right">
-            <p>&copy;2017 – 2023 Cribl, Inc. | <a href="https://cribl.io/legal" target="_blank" rel="noopener"><strong>Legal</strong></a></p>
+            <p>&copy;2017 – 2023 Cribl, Inc. | <a href="https://cribl.io/legal" target="_blank" rel="noreferrer noopener"><strong>Legal</strong></a></p>
             <a href="https://www.facebook.com/Cribl-258234158133458/">
               <FontAwesomeIcon icon={["fab", "facebook"]} />
             </a>

--- a/website/src/pages/docs/other-resources.md
+++ b/website/src/pages/docs/other-resources.md
@@ -29,5 +29,5 @@ See how AppScope addresses use cases that are relevant for you:
 - [How AppScope helped resolve a DNS problem](https://cribl.io/blog/how-appscope-helped-resolve-a-dns-problem/)
 - [AppScope: Postgres SQL Observability](https://cribl.io/blog/appscope-postgres-sql-observability/)
 
-You can find all of Cribl's blog posts about AppScope [here](https://cribl.io/blog/?s=appscope).
+Visit Cribl's [blog](https://cribl.io/blog/?s=appscope) and search on "AppScope" to discover more blog posts and podcasts.
 


### PR DESCRIPTION
@seanvaleo @jrcheli @iapaddler @michalbiesek @ricksalsa 

This PR does one small thing:

replaces a link in the Other Resources page that no longer works because the Cribl Blog's search function has evolved

It also does a slightly larger thing.

Whenever we built the docs (locally anyway) we got this ESLintError:

```
warning  Using target="_blank" without rel="noreferrer" is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener
```

So, this PR replaces all instances of `target="_blank"` with `target="_blank" rel="noreferrer noopener"` per recommendation of Liam and Randy.

I'd appreciate if the team could make sure I did this correctly and didn't set us up for unexpected consequences. What I am sure of is that now docs build without the ESLintError now.

This may be too late for 1.3.1 ... leaving that up to the team to decide. Thanks all!