### PR TITLE
Remove secure_getenv usage in openssl (1408)

### DIFF
--- a/contrib/redefine_syms.lst
+++ b/contrib/redefine_syms.lst
@@ -72,6 +72,7 @@ read scopelibc_read
 readdir scopelibc_readdir
 realloc scopelibc_realloc
 recvfrom scopelibc_recvfrom
+secure_getenv scope_secure_getenv
 select scopelibc_select
 sendto scopelibc_sendto
 setbuf scopelibc_setbuf

--- a/src/scopestdlib.c
+++ b/src/scopestdlib.c
@@ -1304,3 +1304,8 @@ int
 scope_mq_getattr(mqd_t mqd, struct mq_attr *attr) {
     return scopelibc_mq_getattr(mqd, attr);
 }
+
+char *
+scope_secure_getenv(const char *name) {
+    return getenv(name);
+}

--- a/test/unit/execute.sh
+++ b/test/unit/execute.sh
@@ -118,6 +118,9 @@ if [ "${OS}" = "linux" ]; then
 
     test/unit/undefined_sym.sh 2>&1
     ERR+=$?
+
+    test/unit/verboten_sym.sh 2>&1
+    ERR+=$?
 fi
 
 #                ^

--- a/test/unit/library/glibcvertest.c
+++ b/test/unit/library/glibcvertest.c
@@ -39,10 +39,6 @@ static const char* ok_private_funcs[] = {
     "__ctype_init"
 };
 
-static const char* funcs_to_avoid[] = {
-    "setenv",
-};
-
 static const char*
 getNextLine(FILE* input, char* line, int len)
 {
@@ -191,58 +187,6 @@ testEachLineInStreamWithActualLibraryData(void** state)
     //fclose(f_out);
 }
 
-// This test was created after we found that setenv was overridden in bash.
-// When our library called setenv within a bash process, it did not
-// work as expected, because the glibc version was not getting called.
-// (in this case not even indirectly through bash!)
-//
-// We can work around this by ensuring we call glibc functions directly.
-// See g_fn.setenv for an example of how to do this.
-//
-// Rather than let this kind of problem happen again silently, let's
-// detect at build-time if we're using any (glibc) functions we've had
-// troubles with.  Most of glibc's exported symbols are WEAK, and therefore
-// could theoretically be in this category, but it seems particularly
-// strange that bash didn't ever call glibc's setenv.  Until it becomes
-// necessary to stop using glibc funcs altogether, this can be the list
-// of those we want to avoid for now.
-static void
-testLibraryUsesFunctionsWeShouldNot(void **state)
-{
-#if defined(__x86_64__)
-    FILE* f_in = popen("nm ./lib/linux/x86_64/libscope.so", "r");
-#elif defined(__aarch64__)
-    FILE* f_in = popen("nm ./lib/linux/aarch64/libscope.so", "r");
-#else
-#error Unknown architecture!
-#endif
-    unsigned int lines_failed = 0;
-
-    char line[1024];
-    while (getNextLine(f_in, line, sizeof(line))) {
-        removeNewline(line);
-
-        int i, found = 0;
-        for (i=0; i<sizeof(funcs_to_avoid)/sizeof(funcs_to_avoid[0]); i++) {
-            char pattern[1024];
-            snprintf(pattern, sizeof(pattern), " U %s@", funcs_to_avoid[i]);
-            if (strstr(line, pattern)) {
-                found = 1;
-                break;
-            }
-        }
-        if (found) {
-            fprintf(stdout, "glibc symbol: '%s' is a function that we don't want to use\n", line);
-            lines_failed++;
-        }
-    }
-
-    if (lines_failed) {
-        fail_msg("test failed with %u glibc functions we don't want to use.\n", lines_failed);
-    }
-
-    pclose(f_in);
-}
 
 int
 main(int argc, char* argv[])
@@ -251,7 +195,6 @@ main(int argc, char* argv[])
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(testEachLineInStreamWorksWithCannedData),
         cmocka_unit_test(testEachLineInStreamWithActualLibraryData),
-        cmocka_unit_test(testLibraryUsesFunctionsWeShouldNot),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/unit/verboten_sym.sh
+++ b/test/unit/verboten_sym.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+SCOPE_LIB=./lib/linux/$(uname -m)/libscope.so
+
+# List of forbidden symbols
+declare -a verboten_syms=(
+"secure_getenv"
+)
+
+declare -i EXIT_STATUS=0
+echo "================================="
+echo "      Verboten  Symbol Test      "
+echo "================================="
+
+for sym in "${verboten_syms[@]}"
+do
+    if nm "$SCOPE_LIB" | grep -w "$sym";
+    then
+        EXIT_STATUS=1
+        echo "Test failed symbol $sym should not be present in $SCOPE_LIB"
+    fi
+done
+
+if (( "$EXIT_STATUS" == 0 )); then
+    echo "Success"
+fi
+
+exit ${EXIT_STATUS}

--- a/test/unit/verboten_sym.sh
+++ b/test/unit/verboten_sym.sh
@@ -5,6 +5,7 @@ SCOPE_LIB=./lib/linux/$(uname -m)/libscope.so
 # List of forbidden symbols
 declare -a verboten_syms=(
 "secure_getenv"
+"setenv"
 )
 
 declare -i EXIT_STATUS=0
@@ -23,6 +24,8 @@ done
 
 if (( "$EXIT_STATUS" == 0 )); then
     echo "Success"
+else
+    echo "Failed"
 fi
 
 exit ${EXIT_STATUS}


### PR DESCRIPTION
- `secure_get_env` is not supported by musl version prior 1.1.24

