### PR TITLE
Modify `scope-pod-extract` initContainer (1409)

### DIFF
--- a/cli/k8s/webhook.go
+++ b/cli/k8s/webhook.go
@@ -173,9 +173,10 @@ func (app *App) HandleMutate(w http.ResponseWriter, r *http.Request) {
 			cmdStr = append(cmdStr, scopeDirPath)
 			cmd = append(cmd, strings.Join(cmdStr, " "))
 			pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
-				Name:    fmt.Sprintf("scope-pod-extract-%d", i),
-				Image:   pod.Spec.Containers[i].Image,
-				Command: cmd,
+				Name:            fmt.Sprintf("scope-pod-extract-%d", i),
+				Image:           pod.Spec.Containers[i].Image,
+				ImagePullPolicy: pod.Spec.Containers[i].ImagePullPolicy,
+				Command:         cmd,
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "scope",
 					MountPath: "/scope",


### PR DESCRIPTION
- use the same "imagePullPolicy" for `scope-pod-extract` as
  for Application container
- this fix would allow to avoid `ImagePullBackOff` status for
  Application pod in following scenario:
  - step 1 we preload the application image into cluster
  - step 2 we deploy `scope k8s`
  - step 3 we deploy application container
- This commit will modify `scope-pod-extract` behavior
  to use the image which was preloaded in step 1 instead of
  pulling the image from non-existent location

Fixes: #1409