### PR TITLE
Capstone project rename build option: `CAPSTONE_BUILD_SHARED` -> `BUILD_SHARED_LIBS` (#1420)

### DIFF
--- a/contrib/funchook/CMakeLists.txt
+++ b/contrib/funchook/CMakeLists.txt
@@ -88,7 +88,7 @@ if (DISASM_CAPSTONE)
                       -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                       -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}
                       -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-                      -DCAPSTONE_BUILD_SHARED=OFF
+                      -DBUILD_SHARED_LIBS=OFF
                       -DCAPSTONE_BUILD_STATIC_RUNTIME=OFF
                       -DCAPSTONE_BUILD_TESTS=OFF
                       -DCAPSTONE_BUILD_CSTOOL=OFF


### PR DESCRIPTION
- this commit will fix following warning:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    CAPSTONE_BUILD_SHARED
```

See c8172e4 in capstone upstream repository for details

Fixes 1420