### PR TITLE
(#1133) Update GitHub action reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       # is one. We'll use the outputs in other places.
       - name: Get Version
         id: version
-        uses: battila7/get-version-action@v2
+        uses: Simply007/get-version-action@v2.3.0
 
       # This is our logic to decide how to tag the results and whether things
       # get published or not.

--- a/.github/workflows/update_latest.yml
+++ b/.github/workflows/update_latest.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Get Version
         id: version
-        uses: battila7/get-version-action@v2
+        uses: Simply007/get-version-action@v2.3.0
 
       - name: Get Tag
         id: tag

--- a/.github/workflows/update_latest_release.yml
+++ b/.github/workflows/update_latest_release.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Get Version
         id: version
-        uses: battila7/get-version-action@v2
+        uses: Simply007/get-version-action@v2.3.0
 
       - name: Get Tag
         id: tag


### PR DESCRIPTION
- fix the warning:
```
Get Build Info
The `set-output` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files.
For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Fixes 1133