### PR TITLE
Update the `inspect` cli command

### DIFF
--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 	"github.com/criblio/scope/inspect"
 	"github.com/criblio/scope/internal"
 	"github.com/criblio/scope/ipc"
+	"github.com/criblio/scope/run"
 	"github.com/criblio/scope/util"
 	"github.com/spf13/cobra"
 )
@@ -16,25 +18,68 @@ var pidCtx *ipc.IpcPidCtx = &ipc.IpcPidCtx{}
 
 // inspectCmd represents the inspect command
 var inspectCmd = &cobra.Command{
-	Use:     "inspect",
-	Short:   "Returns information about scoped process",
-	Long:    `Returns information about scoped process identified by PID.`,
-	Example: `scope inspect 1000`,
-	Args:    cobra.ExactArgs(1),
+	Use:   "inspect",
+	Short: "Returns information about scoped process",
+	Long:  `Returns information about scoped process identified by PID.`,
+	Example: `scope inspect
+scope inspect 1000
+scope inspect --all`,
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()
+		all, _ := cmd.Flags().GetBool("all")
+		// jsonOut, _ := cmd.Flags().GetBool("json")
+
 		// Nice message for non-adminstrators
 		err := util.UserVerifyRootPerm()
 		if errors.Is(err, util.ErrGetCurrentUser) {
 			util.ErrAndExit("Unable to get current user: %v", err)
 		}
 		if errors.Is(err, util.ErrMissingAdmPriv) {
-			fmt.Println("INFO: Run as root (or via sudo) to get info from all processes")
+			util.Warn("INFO: Run as root (or via sudo) to get info from all processes")
 		}
 
-		pid, err := strconv.Atoi(args[0])
-		if err != nil {
-			util.ErrAndExit("error parsing PID argument")
+		if all {
+			// Get all scoped processes
+			procs, err := util.ProcessesScoped()
+			if err != nil {
+				util.ErrAndExit("Unable to retrieve scoped processes: %v", err)
+			}
+
+			// Inspect each of them and store output in an array
+			iouts := make([]inspect.InspectOutput, 0)
+			for _, proc := range procs {
+				pidCtx.Pid = proc.Pid
+				iout, _, err := inspect.InspectProcess(*pidCtx)
+				if err != nil {
+					util.Warn("Inspect PID fails: %v", err)
+				}
+				iouts = append(iouts, iout)
+			}
+			cfgs, err := json.MarshalIndent(iouts, "", "   ")
+			if err != nil {
+				util.ErrAndExit("Error creating json array: %v", err)
+			}
+
+			fmt.Println(string(cfgs))
+			return
+		}
+
+		var pid int
+		if len(args) == 0 {
+			// If no pid argument was provided
+			// Helper menu to allow the user to select a pid to inspect
+
+			if pid, err = run.HandleInputArg("", false, true, false); err != nil {
+				util.ErrAndExit("No scoped processes to inspect")
+			}
+
+		} else {
+			// If a user specified a pid as an argument
+			pid, err = strconv.Atoi(args[0])
+			if err != nil {
+				util.ErrAndExit("error parsing PID argument")
+			}
 		}
 
 		status, _ := util.PidScopeLibInMaps(pid)
@@ -43,10 +88,11 @@ var inspectCmd = &cobra.Command{
 		}
 
 		pidCtx.Pid = pid
-		cfg, err := inspect.InspectProcess(*pidCtx)
+		_, cfg, err := inspect.InspectProcess(*pidCtx)
 		if err != nil {
 			util.ErrAndExit("Inspect PID fails: %v", err)
 		}
+
 		fmt.Println(cfg)
 	},
 }

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -69,4 +69,6 @@ func runCmdFlags(cmd *cobra.Command, rc *run.Config) {
 
 func ipcCmdFlags(cmd *cobra.Command, ipc *ipc.IpcPidCtx) {
 	cmd.Flags().StringVarP(&ipc.PrefixPath, "prefix", "p", "", "Prefix to proc filesystem")
+	cmd.Flags().BoolP("json", "j", false, "Output as newline delimited JSON")
+	cmd.Flags().BoolP("all", "a", false, "Inspect all processes")
 }

--- a/cli/inspect/inspect.go
+++ b/cli/inspect/inspect.go
@@ -9,52 +9,53 @@ import (
 
 var errInspectCfg = errors.New("error inspect cfg")
 
-type inspectOutput struct {
+type InspectOutput struct {
 	Cfg  ipc.ScopeGetCfgResponseCfg `mapstructure:"cfg" json:"cfg" yaml:"cfg"`
 	Desc ipc.ScopeInterfaceDesc     `mapstructure:"interfaces" json:"interfaces" yaml:"interfaces"`
 }
 
-// InspectProcess returns the configuration and status of scoped process
-func InspectProcess(pidCtx ipc.IpcPidCtx) (string, error) {
+// InspectProcess returns the configuratioutn and status of scoped process
+func InspectProcess(pidCtx ipc.IpcPidCtx) (InspectOutput, string, error) {
+	var iout InspectOutput
 
 	cmdGetCfg := ipc.CmdGetScopeCfg{}
 	resp, err := cmdGetCfg.Request(pidCtx)
 	if err != nil {
-		return "", err
+		return iout, "", err
 	}
 
 	err = cmdGetCfg.UnmarshalResp(resp.ResponseScopeMsgData)
 	if err != nil {
-		return "", err
+		return iout, "", err
 	}
 	if resp.MetaMsgStatus != ipc.ResponseOK || *cmdGetCfg.Response.Status != ipc.ResponseOK {
-		return "", errInspectCfg
+		return iout, "", errInspectCfg
 	}
 
 	cmdGetTransportStatus := ipc.CmdGetTransportStatus{}
 	respTr, err := cmdGetTransportStatus.Request(pidCtx)
 	if err != nil {
-		return "", err
+		return iout, "", err
 	}
 
 	err = cmdGetTransportStatus.UnmarshalResp(respTr.ResponseScopeMsgData)
 	if err != nil {
-		return "", err
+		return iout, "", err
 	}
 
 	if respTr.MetaMsgStatus != ipc.ResponseOK || *cmdGetTransportStatus.Response.Status != ipc.ResponseOK {
-		return "", errInspectCfg
+		return iout, "", errInspectCfg
 	}
 
-	summary := inspectOutput{
+	iout = InspectOutput{
 		Cfg:  cmdGetCfg.Response.Cfg,
 		Desc: cmdGetTransportStatus.Response.Interfaces,
 	}
 
-	sumPrint, err := json.MarshalIndent(summary, "", "   ")
+	sumPrint, err := json.MarshalIndent(iout, "", "   ")
 	if err != nil {
-		return "", err
+		return iout, "", err
 	}
 
-	return string(sumPrint), nil
+	return iout, string(sumPrint), nil
 }

--- a/cli/run/attach.go
+++ b/cli/run/attach.go
@@ -30,7 +30,7 @@ var (
 
 // Attach scopes an existing PID
 func (rc *Config) Attach(args []string) error {
-	pid, err := handleInputArg(args[0], true)
+	pid, err := HandleInputArg(args[0], true, false, true)
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func (rc *Config) DetachAll(args []string, prompt bool) error {
 
 // DetachSingle unscopes an existing PID
 func (rc *Config) DetachSingle(args []string) error {
-	pid, err := handleInputArg(args[0], false)
+	pid, err := HandleInputArg(args[0], false, false, true)
 	if err != nil {
 		return err
 	}
@@ -205,8 +205,8 @@ func (rc *Config) detach(args []string, pid int) error {
 	return err
 }
 
-// handleInputArg handles the input argument (process id/name)
-func handleInputArg(InputArg string, toAttach bool) (int, error) {
+// HandleInputArg handles the input argument (process id/name)
+func HandleInputArg(InputArg string, toAttach, singleProcMenu, warn bool) (int, error) {
 	// Get PID by name if non-numeric, otherwise validate/use InputArg
 	var pid int
 	var err error
@@ -235,15 +235,15 @@ func handleInputArg(InputArg string, toAttach bool) (int, error) {
 		if err != nil {
 			return -1, err
 		}
-		if len(procs) == 1 {
+		if len(procs) == 1 && !singleProcMenu {
 			pid = procs[0].Pid
-		} else if len(procs) > 1 {
-			if !adminStatus {
+		} else if len(procs) >= 1 {
+			if !adminStatus && warn {
 				fmt.Println("INFO: Run as root (or via sudo) to see all matching processes")
 			}
 
 			// user interface for selecting a PID
-			fmt.Println("Found multiple processes matching that name...")
+			fmt.Println("Select a process...")
 			util.PrintObj([]util.ObjField{
 				{Name: "ID", Field: "id"},
 				{Name: "Pid", Field: "pid"},
@@ -261,7 +261,7 @@ func handleInputArg(InputArg string, toAttach bool) (int, error) {
 			}
 			pid = procs[i].Pid
 		} else {
-			if !adminStatus {
+			if !adminStatus && warn {
 				fmt.Println("INFO: Run as root (or via sudo) to see all matching processes")
 			}
 			if toAttach {

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -83,6 +83,15 @@ func ErrAndExit(format string, a ...interface{}) {
 	os.Exit(1)
 }
 
+// Warn writes a format string to stderr
+func Warn(format string, a ...interface{}) {
+	out := fmt.Sprintf(format, a...)
+	if out[len(out)-1:] != "\n" {
+		out += "\n"
+	}
+	os.Stderr.WriteString(out)
+}
+
 // CheckFileExists checks if a file exists on the filesystem
 func CheckFileExists(filePath string) bool {
 	if _, err := os.Stat(os.ExpandEnv(filePath)); err == nil { // File exists, no errors

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -359,12 +359,18 @@ Returns information on scoped process identified by PID.
 
 #### Examples
 
-`scope inspect 1000`
+```
+scope inspect
+scope inspect 1000
+scope inspect --all
+```
 
 #### Flags
 
 ```
-  -h, --help            help for inspect
+  -a, --all             Inspect all processes
+  -h, --help            Help for inspect
+  -j, --json            Output as newline delimited JSON
   -p, --prefix string   When running AppScope in a container, and scoping an app that's running outside the container, 
 --prefix is the path to host filesystem of the scoped app
 ```


### PR DESCRIPTION
This PR:
- adds a `--all` argument to retrieve status of all scoped processes
  - in the case of multiple procs, the result will be a ndjson array of responses
- displays a helper menu when run without an argument
- ensures that successful output goes to stdout, all warnings and errors go to stderr

**Testing**
An integration test has been added to check that multiple scoped apps produce an array of results with the expected length.

**Documentation**
The cli-reference.md page has been updated accorgingly.

**QA**
Test the `scope inspect` command and its arguments ; when run as root/non-root ; on root/non-root procs.
Note: the `-j` flag currently has no implication, since output is already in json format. 

