### PR TITLE
Extend IPC with details about process (#1415) 

### DIFF
--- a/cli/inspect/inspect.go
+++ b/cli/inspect/inspect.go
@@ -9,14 +9,28 @@ import (
 
 var errInspectCfg = errors.New("error inspect cfg")
 
+// procDetails describes details of process
+type procDetails struct {
+	// Pid
+	Pid int `mapstructure:"pid" json:"pid" yaml:"pid"`
+	// UUID
+	Uuid string `mapstructure:"uuid" json:"uuid" yaml:"uuid"`
+	// Id
+	Id string `mapstructure:"id" json:"id" yaml:"id"`
+	// Machine id
+	MachineId string `mapstructure:"machine_id" json:"machine_id" yaml:"machine_id"`
+}
+
 type inspectOutput struct {
-	Cfg  ipc.ScopeGetCfgResponseCfg `mapstructure:"cfg" json:"cfg" yaml:"cfg"`
-	Desc ipc.ScopeInterfaceDesc     `mapstructure:"interfaces" json:"interfaces" yaml:"interfaces"`
+	Cfg     ipc.ScopeGetCfgResponseCfg `mapstructure:"cfg" json:"cfg" yaml:"cfg"`
+	Desc    ipc.ScopeInterfaceDesc     `mapstructure:"interfaces" json:"interfaces" yaml:"interfaces"`
+	Process procDetails                `mapstructure:"process" json:"process" yaml:"process"`
 }
 
 // InspectProcess returns the configuration and status of scoped process
 func InspectProcess(pidCtx ipc.IpcPidCtx) (string, error) {
 
+	// Get configuration
 	cmdGetCfg := ipc.CmdGetScopeCfg{}
 	resp, err := cmdGetCfg.Request(pidCtx)
 	if err != nil {
@@ -31,6 +45,7 @@ func InspectProcess(pidCtx ipc.IpcPidCtx) (string, error) {
 		return "", errInspectCfg
 	}
 
+	// Get transport status
 	cmdGetTransportStatus := ipc.CmdGetTransportStatus{}
 	respTr, err := cmdGetTransportStatus.Request(pidCtx)
 	if err != nil {
@@ -46,9 +61,31 @@ func InspectProcess(pidCtx ipc.IpcPidCtx) (string, error) {
 		return "", errInspectCfg
 	}
 
+	// Get process details
+	cmdGetProcDetails := ipc.CmdGetProcessDetails{}
+	respPd, err := cmdGetProcDetails.Request(pidCtx)
+	if err != nil {
+		return "", err
+	}
+
+	err = cmdGetProcDetails.UnmarshalResp(respPd.ResponseScopeMsgData)
+	if err != nil {
+		return "", err
+	}
+
+	if respPd.MetaMsgStatus != ipc.ResponseOK || *cmdGetProcDetails.Response.Status != ipc.ResponseOK {
+		return "", errInspectCfg
+	}
+
 	summary := inspectOutput{
 		Cfg:  cmdGetCfg.Response.Cfg,
 		Desc: cmdGetTransportStatus.Response.Interfaces,
+		Process: procDetails{
+			Pid:       cmdGetProcDetails.Response.Pid,
+			Uuid:      cmdGetProcDetails.Response.Uuid,
+			Id:        cmdGetProcDetails.Response.Id,
+			MachineId: cmdGetProcDetails.Response.MachineId,
+		},
 	}
 
 	sumPrint, err := json.MarshalIndent(summary, "", "   ")

--- a/cli/inspect/inspect.go
+++ b/cli/inspect/inspect.go
@@ -21,7 +21,7 @@ type procDetails struct {
 	MachineId string `mapstructure:"machine_id" json:"machine_id" yaml:"machine_id"`
 }
 
-type inspectOutput struct {
+type InspectOutput struct {
 	Cfg     ipc.ScopeGetCfgResponseCfg `mapstructure:"cfg" json:"cfg" yaml:"cfg"`
 	Desc    ipc.ScopeInterfaceDesc     `mapstructure:"interfaces" json:"interfaces" yaml:"interfaces"`
 	Process procDetails                `mapstructure:"process" json:"process" yaml:"process"`
@@ -66,19 +66,19 @@ func InspectProcess(pidCtx ipc.IpcPidCtx) (InspectOutput, string, error) {
 	cmdGetProcDetails := ipc.CmdGetProcessDetails{}
 	respPd, err := cmdGetProcDetails.Request(pidCtx)
 	if err != nil {
-		return "", err
+		return iout, "", err
 	}
 
 	err = cmdGetProcDetails.UnmarshalResp(respPd.ResponseScopeMsgData)
 	if err != nil {
-		return "", err
+		return iout, "", err
 	}
 
 	if respPd.MetaMsgStatus != ipc.ResponseOK || *cmdGetProcDetails.Response.Status != ipc.ResponseOK {
-		return "", errInspectCfg
+		return iout, "", errInspectCfg
 	}
 
-	summary := inspectOutput{
+	iout = InspectOutput{
 		Cfg:  cmdGetCfg.Response.Cfg,
 		Desc: cmdGetTransportStatus.Response.Interfaces,
 		Process: procDetails{

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -434,6 +434,7 @@ static responseProcessor supportedResp[] = {
     [IPC_CMD_GET_SCOPE_CFG]        = ipcRespGetScopeCfg, 
     [IPC_CMD_SET_SCOPE_CFG]        = ipcRespSetScopeCfg,
     [IPC_CMD_GET_TRANSPORT_STATUS] = ipcRespGetTransportStatus,
+    [IPC_CMD_GET_PROC_DETAILS]     = ipcRespGetProcessDetails,
     [IPC_CMD_UNKNOWN]              = ipcRespStatusNotImplemented
 };
 

--- a/src/ipc_resp.c
+++ b/src/ipc_resp.c
@@ -17,6 +17,7 @@ static const char* cmdScopeName[] = {
     [IPC_CMD_GET_SCOPE_CFG]        = "getScopeCfg",
     [IPC_CMD_SET_SCOPE_CFG]        = "setScopeCfg",
     [IPC_CMD_GET_TRANSPORT_STATUS] = "getTransportStatus",
+    [IPC_CMD_GET_PROC_DETAILS]     = "getProcessDetails",
 };
 
 #define CMD_SCOPE_SIZE  (ARRAY_SIZE(cmdScopeName))
@@ -475,6 +476,47 @@ allocFail:
     return NULL; 
 }
 
+/*
+ * Creates the wrapper for response to IPC_CMD_GET_PROC_DETAILS
+ * TODO: use unused attribute later
+ */
+scopeRespWrapper *
+ipcRespGetProcessDetails(const cJSON *unused) {
+    scopeRespWrapper *wrap = respWrapperCreate();
+    if (!wrap) {
+        return NULL;
+    }
+    cJSON *resp = cJSON_CreateObject();
+    if (!resp) {
+        goto allocFail;
+    }
+    wrap->resp = resp;
+    if (!cJSON_AddNumberToObjLN(resp, "status", IPC_RESP_OK)) {
+        goto allocFail;
+    }
+
+    if (!cJSON_AddNumberToObjLN(resp, "pid", g_proc.pid)) {
+        goto allocFail;
+    }
+
+    if (!cJSON_AddStringToObject(resp, "uuid", g_proc.uuid)) {
+        goto allocFail;
+    }
+
+    if (!cJSON_AddStringToObject(resp, "id", g_proc.id)) {
+        goto allocFail;
+    }
+
+    if (!cJSON_AddStringToObject(resp, "machine_id", g_proc.machine_id)) {
+        goto allocFail;
+    }
+
+    return wrap;
+
+allocFail:
+    ipcRespWrapperDestroy(wrap);
+    return NULL; 
+}
 /*
  * Creates the wrapper for failed case in processing scope msg
  */

--- a/src/ipc_resp.h
+++ b/src/ipc_resp.h
@@ -27,6 +27,7 @@ typedef enum {
     IPC_CMD_GET_SCOPE_CFG,        // Retrieves the current configuration, introduced in: 1.3.0
     IPC_CMD_SET_SCOPE_CFG,        // Update the current configuration, introduced in: 1.3.0
     IPC_CMD_GET_TRANSPORT_STATUS, // Retrieves the transport status, introduced in: 1.3.0
+    IPC_CMD_GET_PROC_DETAILS,     // Retrieves the process details, introduced in: 1.4.0
     // Place to add new message
     IPC_CMD_UNKNOWN,              // MUST BE LAST - points to unsupported message
 } ipc_scope_req_t;
@@ -74,6 +75,7 @@ scopeRespWrapper *ipcRespGetScopeStatus(const cJSON *);
 scopeRespWrapper *ipcRespGetScopeCfg(const cJSON *);
 scopeRespWrapper *ipcRespSetScopeCfg(const cJSON *);
 scopeRespWrapper *ipcRespGetTransportStatus(const cJSON *);
+scopeRespWrapper *ipcRespGetProcessDetails(const cJSON *);
 scopeRespWrapper *ipcRespStatusNotImplemented(const cJSON *);
 scopeRespWrapper *ipcRespStatusScopeError(ipc_resp_status_t);
 

--- a/test/manual/ipcclient.c
+++ b/test/manual/ipcclient.c
@@ -166,6 +166,7 @@ printMsgInfo(void) {
     printf("quit - stop sending\n");
     printf("cmds - get information about supported cmd\n");
     printf("status - get information about scope status\n");
+    printf("details - get information about process details\n");
 }
 
 static ipc_msg_t *
@@ -179,6 +180,9 @@ msgPrepareInfo(const char *inputBuf) {
     } else if(strcmp("status\n", inputBuf) == 0) {
         printf("status message\n");
         return createIpcMessage("{\"req\":0,\"uniq\":1234,\"remain\":128}", "{\"req\":1}");
+    } else if(strcmp("details\n", inputBuf) == 0) {
+        printf("details message\n");
+        return createIpcMessage("{\"req\":0,\"uniq\":1234,\"remain\":128}", "{\"req\":5}");
     }
 
     printf("Unknown message %s\n", inputBuf);


### PR DESCRIPTION
- provide information about pid, UUID, id and machine_id

Example  inspect output See process section:
```
{
   "cfg": {
      "current": {
         "cribl": {
            "enable": "false",
            "transport": {
               "type": "edge",
               "tls": {
                  "enable": "",
                  "validateserver": "",
                  "cacertpath": ""
               }
            },
            "authtoken": ""
         },
         "metric": {
            "enable": "true",
            "format": {
               "type": "ndjson",
               "statsdmaxlen": 512,
               "verbosity": 4
            },
            "transport": {
               "type": "file",
               "path": "/home/foouser/.scope/history/htop_41_388986_1681742511594174848/metrics.json",
               "buffering": "line",
               "tls": {
                  "enable": "",
                  "validateserver": "",
                  "cacertpath": ""
               }
            },
            "watch": [
               {
                  "type": "fs"
               },
               {
                  "type": "net"
               },
               {
                  "type": "http"
               },
               {
                  "type": "dns"
               },
               {
                  "type": "process"
               },
               {
                  "type": "statsd"
               }
            ]
         },
         "event": {
            "enable": "true",
            "format": {
               "type": "ndjson"
            },
            "transport": {
               "type": "file",
               "path": "/home/foouser/.scope/history/htop_41_388986_1681742511594174848/events.json",
               "buffering": "line",
               "tls": {
                  "enable": "",
                  "validateserver": "",
                  "cacertpath": ""
               }
            },
            "watch": [
               {
                  "type": "file",
                  "name": "(\\/logs?\\/)|(\\.log$)|(\\.log[.\\d])",
                  "field": ".*",
                  "value": ".*"
               },
               {
                  "type": "console",
                  "name": "(stdout|stderr)",
                  "field": ".*",
                  "value": ".*",
                  "allowbinary": "false"
               },
               {
                  "type": "http",
                  "name": ".*",
                  "field": ".*",
                  "value": ".*"
               },
               {
                  "type": "net",
                  "name": ".*",
                  "field": ".*",
                  "value": ".*"
               },
               {
                  "type": "fs",
                  "name": ".*",
                  "field": ".*",
                  "value": ".*"
               },
               {
                  "type": "dns",
                  "name": ".*",
                  "field": ".*",
                  "value": ".*"
               }
            ]
         },
         "payload": {
            "enable": "false",
            "dir": "/tmp"
         },
         "libscope": {
            "configevent": "false",
            "summaryperiod": 10,
            "commanddir": "/home/foouser/.scope/history/htop_41_388986_1681742511594174848/cmd",
            "log": {
               "level": "warning",
               "transport": {
                  "type": "file",
                  "path": "/home/foouser/.scope/history/htop_41_388986_1681742511594174848/libscope.log",
                  "buffering": "line",
                  "tls": {
                     "enable": "",
                     "validateserver": "",
                     "cacertpath": ""
                  }
               }
            },
            "snapshot": {
               "coredump": "false",
               "backtrace": "false"
            }
         }
      }
   },
   "interfaces": [
      {
         "name": "log",
         "connected": true,
         "config": "file:///home/foouser/.scope/history/htop_41_388986_1681742511594174848/libscope.log"
      },
      {
         "name": "events",
         "connected": true,
         "config": "file:///home/foouser/.scope/history/htop_41_388986_1681742511594174848/events.json"
      },
      {
         "name": "metrics",
         "connected": true,
         "config": "file:///home/foouser/.scope/history/htop_41_388986_1681742511594174848/metrics.json"
      }
   ],
   "process": {
      "pid": 407117,
      "uuid": "c0ca3b31-8f32-4487-b167-d4890aeca794",
      "id": "foouser-htop-htop",
      "machine_id": "ca99ededf5d44bd4a0a9ee8198957c78"
   }
}

```