### PR TITLE
Sync with webhook cert manager changes (#1434)

### DIFF
--- a/cli/cmd/k8s.go
+++ b/cli/cmd/k8s.go
@@ -57,7 +57,7 @@ func init() {
 	RootCmd.AddCommand(k8sCmd)
 	k8sCmd.Flags().StringVar(&opt.App, "app", "scope", "Name of the app in Kubernetes")
 	k8sCmd.Flags().StringVar(&opt.Namespace, "namespace", "default", "Name of the namespace in which to install")
-	k8sCmd.Flags().StringVar(&opt.SignerName, "signername", "kubernetes.io/kubelet-serving", "Name of the signer used for certificate request")
+	k8sCmd.Flags().StringVar(&opt.SignerName, "signername", "kubernetes.io/kubelet-serving", "Name of the signer used to sign the certificate request for the AppScope Admission Webhook")
 	k8sCmd.Flags().StringVar(&opt.Version, "version", "", "Version of scope to deploy")
 	k8sCmd.Flags().StringVar(&opt.CertFile, "certfile", "/etc/certs/tls.crt", "Certificate file for TLS in the container (mounted secret)")
 	k8sCmd.Flags().StringVar(&opt.KeyFile, "keyfile", "/etc/certs/tls.key", "Private key file for TLS in the container (mounted secret)")

--- a/cli/cmd/k8s.go
+++ b/cli/cmd/k8s.go
@@ -57,6 +57,7 @@ func init() {
 	RootCmd.AddCommand(k8sCmd)
 	k8sCmd.Flags().StringVar(&opt.App, "app", "scope", "Name of the app in Kubernetes")
 	k8sCmd.Flags().StringVar(&opt.Namespace, "namespace", "default", "Name of the namespace in which to install")
+	k8sCmd.Flags().StringVar(&opt.SignerName, "signername", "kubernetes.io/kubelet-serving", "Name of the signer used for certificate request")
 	k8sCmd.Flags().StringVar(&opt.Version, "version", "", "Version of scope to deploy")
 	k8sCmd.Flags().StringVar(&opt.CertFile, "certfile", "/etc/certs/tls.crt", "Certificate file for TLS in the container (mounted secret)")
 	k8sCmd.Flags().StringVar(&opt.KeyFile, "keyfile", "/etc/certs/tls.key", "Private key file for TLS in the container (mounted secret)")

--- a/cli/k8s/configs.go
+++ b/cli/k8s/configs.go
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: webhook-cert-setup
         # This is a minimal kubectl image based on Alpine Linux that signs certificates using the k8s extension api server
-        image: cribl/k8s-webhook-cert-manager:1.0.0
+        image: cribl/k8s-webhook-cert-manager:1.0.1
         command: ["./generate_certificate.sh"]
         args:
           - "--service"

--- a/cli/k8s/configs.go
+++ b/cli/k8s/configs.go
@@ -53,6 +53,8 @@ spec:
           - "{{ .App }}-secret"
           - "--namespace"
           - "{{ .Namespace }}"
+          - "--signer-name"
+          - "{{ .SignerName }}"
       restartPolicy: OnFailure
   backoffLimit: 3
 ---
@@ -78,7 +80,7 @@ rules:
     verbs: ["get"]
   - apiGroups: ["certificates.k8s.io"]
     resources: ["signers"]
-    resourceNames: ["kubernetes.io/kubelet-serving"]
+    resourceNames: ["{{ .SignerName }}"]
     verbs: ["approve"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/k8s/template.go
+++ b/cli/k8s/template.go
@@ -11,6 +11,7 @@ import (
 type Options struct {
 	App             string
 	Namespace       string
+	SignerName      string
 	Version         string
 	CriblDest       string
 	MetricDest      string

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -404,7 +404,7 @@ kubectl label namespace default scope=enabled
   -n, --nobreaker             Set Cribl Stream to not break streams into events
       --port int              Port to listen on (default 4443)
       --server                Run Webhook server
-      --signername string     Name of the signer used for certificate request (default "kubernetes.io/kubelet-serving")
+      --signername string     Name of the signer used to sign the certificate request for the AppScope Admission Webhook (default "kubernetes.io/kubelet-serving")
       --version string        Version of scope to deploy
 
 ```

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -404,6 +404,7 @@ kubectl label namespace default scope=enabled
   -n, --nobreaker             Set Cribl Stream to not break streams into events
       --port int              Port to listen on (default 4443)
       --server                Run Webhook server
+      --signername string     Name of the signer used for certificate request (default "kubernetes.io/kubelet-serving")
       --version string        Version of scope to deploy
 
 ```


### PR DESCRIPTION
- update used ` cribl/k8s-webhook-cert-manager`image 
- provide support for signername parameter in `scope k8s` command