### PR TITLE
Add k8s support for scope prometheus exporter (#1419)

### DIFF
--- a/cli/cmd/k8s.go
+++ b/cli/cmd/k8s.go
@@ -19,7 +19,10 @@ var k8sCmd = &cobra.Command{
 
 The --*dest flags accept file names like /tmp/scope.log; URLs like file:///tmp/scope.log; or sockets specified with the pattern unix:///var/run/mysock, tcp://hostname:port, udp://hostname:port, or tls://hostname:port.`,
 	Example: `scope k8s --metricdest tcp://some.host:8125 --eventdest tcp://other.host:10070 | kubectl apply -f -
-kubectl label namespace default scope=enabled`,
+kubectl label namespace default scope=enabled
+
+scope k8s --metricdest tcp://scope-prom-export:9109 --metricformat prometheus --eventdest tcp://other.host:10070 | kubectl apply -f -
+`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if rc.CriblDest == "" && rc.MetricsDest == "" {
@@ -40,6 +43,8 @@ kubectl label namespace default scope=enabled`,
 		opt.ScopeConfigYaml, err = rc.ScopeConfigYaml()
 		util.CheckErrSprintf(err, "%v", err)
 		server, _ := cmd.Flags().GetBool("server")
+		opt.PromDisable, _ = cmd.Flags().GetBool("noprom")
+
 		if !server {
 			opt.PrintConfig(os.Stdout)
 			os.Exit(0)
@@ -63,5 +68,9 @@ func init() {
 	k8sCmd.Flags().IntVar(&opt.Port, "port", 4443, "Port to listen on")
 	k8sCmd.Flags().Bool("server", false, "Run Webhook server")
 	k8sCmd.Flags().BoolVar(&opt.Debug, "debug", false, "Turn on debug logging in the scope webhook container")
+	k8sCmd.Flags().Bool("noprom", false, "Disable Prometheus Exporter deployment")
+	k8sCmd.Flags().IntVar(&opt.PromMPort, "prommport", 9109, "Specify Prometheus Exporter port for metrics from libscope")
+	k8sCmd.Flags().IntVar(&opt.PromSPort, "promsport", 9090, "Specify Prometheus Exporter port for HTTP metrics requests")
+
 	metricAndEventDestFlags(k8sCmd, rc)
 }

--- a/cli/k8s/configs.go
+++ b/cli/k8s/configs.go
@@ -169,10 +169,39 @@ spec:
           ports:
             - containerPort: {{ .Port }}
               protocol: TCP
+{{- if not .PromDisable }}
+        - name: {{ .App }}-prom-export
+          image: cribl/scope:{{ .Version }}
+          command: ["/bin/bash"]
+          args:
+          - "-c"
+          - "/usr/local/bin/scope prom --mport {{ .PromMPort }} --sport {{ .PromSPort }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .PromMPort }}
+              protocol: TCP
+{{- end }}
       volumes:
         - name: certs
           secret:
             secretName: {{ .App }}-secret
+{{- if not .PromDisable }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .App }}-prom-export
+  namespace: {{ .Namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: {{ .PromMPort }}-prom-export-tcp
+      protocol: TCP
+      port: {{ .PromMPort }}
+      targetPort: {{ .PromMPort }}
+  selector:
+    app: {{ .App }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/cli/k8s/template.go
+++ b/cli/k8s/template.go
@@ -20,6 +20,9 @@ type Options struct {
 	KeyFile         string
 	Port            int
 	Debug           bool
+	PromDisable     bool
+	PromMPort       int
+	PromSPort       int
 	ScopeConfigYaml []byte
 }
 

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -402,7 +402,10 @@ kubectl label namespace default scope=enabled
       --metricformat string   Set format of metrics output (statsd|ndjson); default is "ndjson"
       --namespace string      Name of the namespace in which to install; default is "default"
   -n, --nobreaker             Set Cribl Stream to not break streams into events
+      --noprom                Disable Prometheus Exporter deployment
       --port int              Port to listen on (default 4443)
+      --prommport int         Specify Prometheus Exporter port for metrics from libscope (default 9109)
+      --promsport int         Specify Prometheus Exporter port for HTTP metrics requests (default 9090)
       --server                Run Webhook server
       --version string        Version of scope to deploy
 


### PR DESCRIPTION
- enable by default
- add option to disable it (`noprom`)
- add option to specify Prometheus exporter listening on port (`promport`)

Fixes #1419