### PR TITLE
Extend the `scope update` command (#1414)

### DIFF
--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -14,8 +14,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var pidCtx *ipc.IpcPidCtx = &ipc.IpcPidCtx{}
-
 // inspectCmd represents the inspect command
 var inspectCmd = &cobra.Command{
 	Use:   "inspect",
@@ -28,6 +26,7 @@ scope inspect --all`,
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()
 		all, _ := cmd.Flags().GetBool("all")
+		prefix, _ := cmd.Flags().GetString("prefix")
 		// jsonOut, _ := cmd.Flags().GetBool("json")
 
 		// Nice message for non-adminstrators
@@ -37,6 +36,10 @@ scope inspect --all`,
 		}
 		if errors.Is(err, util.ErrMissingAdmPriv) {
 			util.Warn("INFO: Run as root (or via sudo) to get info from all processes")
+		}
+
+		pidCtx := &ipc.IpcPidCtx{
+			PrefixPath: prefix,
 		}
 
 		if all {
@@ -98,6 +101,8 @@ scope inspect --all`,
 }
 
 func init() {
-	ipcCmdFlags(inspectCmd, pidCtx)
+	inspectCmd.Flags().StringP("prefix", "p", "", "Prefix to proc filesystem")
+	inspectCmd.Flags().BoolP("json", "j", false, "Output as newline delimited JSON")
+	inspectCmd.Flags().BoolP("all", "a", false, "Inspect all processes")
 	RootCmd.AddCommand(inspectCmd)
 }

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -34,8 +34,9 @@ scope inspect --all`,
 		if errors.Is(err, util.ErrGetCurrentUser) {
 			util.ErrAndExit("Unable to get current user: %v", err)
 		}
+		admin := true
 		if errors.Is(err, util.ErrMissingAdmPriv) {
-			util.Warn("INFO: Run as root (or via sudo) to get info from all processes")
+			admin = false
 		}
 
 		pidCtx := &ipc.IpcPidCtx{
@@ -46,6 +47,9 @@ scope inspect --all`,
 			// Get all scoped processes
 			procs, err := util.ProcessesScoped()
 			if err != nil {
+				if !admin {
+					util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
+				}
 				util.ErrAndExit("Unable to retrieve scoped processes: %v", err)
 			}
 
@@ -55,6 +59,9 @@ scope inspect --all`,
 				pidCtx.Pid = proc.Pid
 				iout, _, err := inspect.InspectProcess(*pidCtx)
 				if err != nil {
+					if !admin {
+						util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
+					}
 					util.Warn("Inspect PID fails: %v", err)
 				}
 				iouts = append(iouts, iout)
@@ -74,6 +81,9 @@ scope inspect --all`,
 			// Helper menu to allow the user to select a pid to inspect
 
 			if pid, err = run.HandleInputArg("", false, true, false); err != nil {
+				if !admin {
+					util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
+				}
 				util.ErrAndExit("No scoped processes to inspect")
 			}
 
@@ -87,12 +97,18 @@ scope inspect --all`,
 
 		status, _ := util.PidScopeLibInMaps(pid)
 		if !status {
+			if !admin {
+				util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
+			}
 			util.ErrAndExit("Unable to communicate with %v - process is not scoped", pid)
 		}
 
 		pidCtx.Pid = pid
 		_, cfg, err := inspect.InspectProcess(*pidCtx)
 		if err != nil {
+			if !admin {
+				util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
+			}
 			util.ErrAndExit("Inspect PID fails: %v", err)
 		}
 

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -37,7 +37,7 @@ scope update 1000 < test_cfg.yml`,
 			util.ErrAndExit("Unable to get current user: %v", err)
 		}
 		if errors.Is(err, util.ErrMissingAdmPriv) {
-			fmt.Println("INFO: Run as root (or via sudo) to get info from all processes")
+			util.Warn("INFO: Run as root (or via sudo) to get info from all processes")
 		}
 
 		var cfgBytes []byte

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -36,8 +36,9 @@ scope update 1000 < test_cfg.yml`,
 		if errors.Is(err, util.ErrGetCurrentUser) {
 			util.ErrAndExit("Unable to get current user: %v", err)
 		}
+		admin := true
 		if errors.Is(err, util.ErrMissingAdmPriv) {
-			util.Warn("INFO: Run as root (or via sudo) to get info from all processes")
+			admin = false
 		}
 
 		var cfgBytes []byte
@@ -68,6 +69,9 @@ scope update 1000 < test_cfg.yml`,
 
 		status, _ := util.PidScopeLibInMaps(pid)
 		if !status {
+			if !admin {
+				util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
+			}
 			util.ErrAndExit("Unable to communicate with %v - process is not scoped", pid)
 		}
 
@@ -78,6 +82,9 @@ scope update 1000 < test_cfg.yml`,
 
 		err = update.UpdateScopeCfg(*pidCtx, cfgBytes)
 		if err != nil {
+			if !admin {
+				util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
+			}
 			util.ErrAndExit("Update Scope configuration fails: %v", err)
 		}
 		fmt.Println("Update Scope configuration success.")
@@ -86,6 +93,9 @@ scope update 1000 < test_cfg.yml`,
 			time.Sleep(2 * time.Second)
 			_, cfg, err := inspect.InspectProcess(*pidCtx)
 			if err != nil {
+				if !admin {
+					util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
+				}
 				util.ErrAndExit("Inspect PID fails: %v", err)
 			}
 

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -19,11 +19,12 @@ import (
 
 // updateCmd represents the info command
 var updateCmd = &cobra.Command{
-	Use:     "update",
-	Short:   "Updates the configuration of a scoped process",
-	Long:    `Updates the configuration of a scoped process identified by PID.`,
-	Example: `scope update 1000 --config test_cfg.yml`,
-	Args:    cobra.ExactArgs(1),
+	Use:   "update",
+	Short: "Updates the configuration of a scoped process",
+	Long:  `Updates the configuration of a scoped process identified by PID.`,
+	Example: `scope update 1000 --config test_cfg.yml
+scope update 1000 < test_cfg.yml`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()
 		prefix, _ := cmd.Flags().GetString("prefix")

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -51,7 +51,7 @@ scope update 1000 < test_cfg.yml`,
 				util.ErrAndExit("Unable to read bytes from config path: %v", err)
 			}
 		} else {
-			// User did not specigy a path to a config with --config. Try to read from StdIn
+			// User did not specify a path to a config with --config. Try to read from StdIn
 			var scopeCfg libscope.ScopeConfig
 			if scopeCfg, err = update.GetCfgStdIn(); err != nil {
 				util.ErrAndExit("Unable to parse config from stdin: %v", err)

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -3,15 +3,19 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
+	"time"
 
+	"github.com/criblio/scope/inspect"
 	"github.com/criblio/scope/internal"
+	"github.com/criblio/scope/ipc"
+	"github.com/criblio/scope/libscope"
 	"github.com/criblio/scope/update"
 	"github.com/criblio/scope/util"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
-
-var cfgPath string
 
 // updateCmd represents the info command
 var updateCmd = &cobra.Command{
@@ -21,10 +25,11 @@ var updateCmd = &cobra.Command{
 	Example: `scope update 1000 --config test_cfg.yml`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if !util.CheckFileExists(cfgPath) {
-			util.ErrAndExit("Configuration file: %s does not exist", cfgPath)
-		}
 		internal.InitConfig()
+		prefix, _ := cmd.Flags().GetString("prefix")
+		fetch, _ := cmd.Flags().GetBool("fetch")
+		cfgPath, _ := cmd.Flags().GetString("config")
+
 		// Nice message for non-adminstrators
 		err := util.UserVerifyRootPerm()
 		if errors.Is(err, util.ErrGetCurrentUser) {
@@ -32,6 +37,27 @@ var updateCmd = &cobra.Command{
 		}
 		if errors.Is(err, util.ErrMissingAdmPriv) {
 			fmt.Println("INFO: Run as root (or via sudo) to get info from all processes")
+		}
+
+		var cfgBytes []byte
+		if cfgPath != "" {
+			// User specified a path to a config with --config
+			if !util.CheckFileExists(cfgPath) {
+				util.ErrAndExit("Configuration file: %s does not exist", cfgPath)
+			}
+			cfgBytes, err = os.ReadFile(cfgPath)
+			if err != nil {
+				util.ErrAndExit("Unable to read bytes from config path", err)
+			}
+		} else {
+			// User did not specigy a path to a config with --config. Try to read from StdIn
+			var scopeCfg libscope.ScopeConfig
+			if scopeCfg, err = update.GetCfgStdIn(); err != nil {
+				util.ErrAndExit("Unable to parse config from stdin", err)
+			}
+			if cfgBytes, err = yaml.Marshal(scopeCfg); err != nil {
+				util.ErrAndExit("Unable to marshal scope config into byte array", err)
+			}
 		}
 
 		pid, err := strconv.Atoi(args[0])
@@ -44,19 +70,33 @@ var updateCmd = &cobra.Command{
 			util.ErrAndExit("Unable to communicate with %v - process is not scoped", pid)
 		}
 
-		pidCtx.Pid = pid
+		pidCtx := &ipc.IpcPidCtx{
+			PrefixPath: prefix,
+			Pid:        pid,
+		}
 
-		err = update.UpdateScopeCfg(*pidCtx, cfgPath)
+		err = update.UpdateScopeCfg(*pidCtx, cfgBytes)
 		if err != nil {
 			util.ErrAndExit("Update Scope configuration fails: %v", err)
 		}
 		fmt.Println("Update Scope configuration success.")
+
+		if fetch {
+			time.Sleep(2 * time.Second)
+			_, cfg, err := inspect.InspectProcess(*pidCtx)
+			if err != nil {
+				util.ErrAndExit("Inspect PID fails: %v", err)
+			}
+
+			fmt.Println(cfg)
+		}
 	},
 }
 
 func init() {
-	ipcCmdFlags(updateCmd, pidCtx)
-	updateCmd.Flags().StringVarP(&cfgPath, "config", "c", "", "Path to configuration file")
-	updateCmd.MarkFlagRequired("config")
+	updateCmd.Flags().BoolP("fetch", "f", false, "Inspect the process after the update is complete")
+	updateCmd.Flags().StringP("prefix", "p", "", "Prefix to proc filesystem")
+	updateCmd.Flags().BoolP("json", "j", false, "Output as newline delimited JSON")
+	updateCmd.Flags().StringP("config", "c", "", "Path to configuration file")
 	RootCmd.AddCommand(updateCmd)
 }

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -48,16 +48,16 @@ scope update 1000 < test_cfg.yml`,
 			}
 			cfgBytes, err = os.ReadFile(cfgPath)
 			if err != nil {
-				util.ErrAndExit("Unable to read bytes from config path", err)
+				util.ErrAndExit("Unable to read bytes from config path: %v", err)
 			}
 		} else {
 			// User did not specigy a path to a config with --config. Try to read from StdIn
 			var scopeCfg libscope.ScopeConfig
 			if scopeCfg, err = update.GetCfgStdIn(); err != nil {
-				util.ErrAndExit("Unable to parse config from stdin", err)
+				util.ErrAndExit("Unable to parse config from stdin: %v", err)
 			}
 			if cfgBytes, err = yaml.Marshal(scopeCfg); err != nil {
-				util.ErrAndExit("Unable to marshal scope config into byte array", err)
+				util.ErrAndExit("Unable to marshal scope config into byte array: %v", err)
 			}
 		}
 

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/criblio/scope/history"
-	"github.com/criblio/scope/ipc"
 	"github.com/criblio/scope/run"
 	"github.com/criblio/scope/util"
 	"github.com/spf13/cobra"
@@ -65,10 +64,4 @@ func runCmdFlags(cmd *cobra.Command, rc *run.Config) {
 	cmd.Flags().BoolVarP(&rc.Coredump, "coredump", "d", false, "Enable core dump file generation when an application crashes.")
 	cmd.Flags().BoolVarP(&rc.Backtrace, "backtrace", "b", false, "Enable backtrace file generation when an application crashes.")
 	metricAndEventDestFlags(cmd, rc)
-}
-
-func ipcCmdFlags(cmd *cobra.Command, ipc *ipc.IpcPidCtx) {
-	cmd.Flags().StringVarP(&ipc.PrefixPath, "prefix", "p", "", "Prefix to proc filesystem")
-	cmd.Flags().BoolP("json", "j", false, "Output as newline delimited JSON")
-	cmd.Flags().BoolP("all", "a", false, "Inspect all processes")
 }

--- a/cli/update/update.go
+++ b/cli/update/update.go
@@ -2,20 +2,50 @@ package update
 
 import (
 	"errors"
+	"io"
 	"os"
 
 	"github.com/criblio/scope/ipc"
+	"github.com/criblio/scope/libscope"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v2"
 )
 
 var errSettingCfg = errors.New("error setting cfg")
+var errWaitingInput = errors.New("error waiting for input")
+var errReadingStdIn = errors.New("error reading standard input")
+var errReadingData = errors.New("error reading data")
+
+// GetCfgStdIn reads a Scope Config file from StdIn
+func GetCfgStdIn() (libscope.ScopeConfig, error) {
+	var cfg libscope.ScopeConfig
+
+	stdinFs, err := os.Stdin.Stat()
+	if err != nil {
+		return cfg, errReadingStdIn
+	}
+
+	// Avoid waiting for input from terminal when no data was provided
+	if stdinFs.Mode()&os.ModeCharDevice != 0 && stdinFs.Size() == 0 {
+		return cfg, errWaitingInput
+	}
+
+	var cfgData []byte
+	if cfgData, err = io.ReadAll(os.Stdin); err != nil {
+		return cfg, errReadingData
+	}
+
+	if err := yaml.Unmarshal(cfgData, &cfg); err != nil {
+		log.Error().Err(err).Msg("Bad config file format.")
+		return cfg, err
+	}
+
+	return cfg, nil
+}
 
 // UpdateScopeCfg updates the configuration of a scoped process
-func UpdateScopeCfg(pidCtx ipc.IpcPidCtx, confFile string) error {
-	content, err := os.ReadFile(confFile)
-	if err != nil {
-		return err
-	}
-	cmd := ipc.CmdSetScopeCfg{CfgData: content}
+func UpdateScopeCfg(pidCtx ipc.IpcPidCtx, confFile []byte) error {
+	cmd := ipc.CmdSetScopeCfg{CfgData: confFile}
 	resp, err := cmd.Request(pidCtx)
 	if err != nil {
 		return err

--- a/test/integration/cli/Dockerfile
+++ b/test/integration/cli/Dockerfile
@@ -22,6 +22,7 @@ COPY ./cli/test_inspect.sh /opt/test/bin/test_inspect.sh
 COPY ./cli/expected.yml /
 RUN mkdir /opt/test/conf
 COPY ./cli/payload_conf.yml /opt/test/bin/payload_conf.yml
+COPY ./cli/update_log_dest.yml /opt/test/bin/update_log_dest.yml
 
 RUN mkdir /opt/test-runner && \
     mkdir -p /var/run/appscope/ && \

--- a/test/integration/cli/test_cli.sh
+++ b/test/integration/cli/test_cli.sh
@@ -409,6 +409,56 @@ endtest
 #endtest
 
 
+#
+# Scope Update from stdin (same namespace)
+#
+starttest "Scope update from stdin"
+
+top -b -d 1 > /dev/null &
+top_pid=$!
+sleep 2
+
+scope --ldattach $top_pid
+returns 0
+sleep 2
+
+scope update $top_pid < /opt/test/bin/update_log_dest.yml
+returns 0
+sleep 3
+
+kill $top_pid
+sleep 2
+
+is_file /tmp/top_events.log
+
+endtest
+
+
+#
+# Scope Update from file path (same namespace)
+#
+starttest "Scope update from file path"
+
+top -b -d 1 > /dev/null &
+top_pid=$!
+sleep 2
+
+scope --ldattach $top_pid
+returns 0
+sleep 2
+
+scope update $top_pid --config /opt/test/bin/update_log_dest.yml
+returns 0
+sleep 3
+
+kill $top_pid
+sleep 2
+
+is_file /tmp/top_events.log
+
+endtest
+
+
 ################# END TESTS ################# 
 
 #

--- a/test/integration/cli/update_log_dest.yml
+++ b/test/integration/cli/update_log_dest.yml
@@ -1,0 +1,45 @@
+cribl:
+  enable: false
+  transport:
+    type: ""
+    tls:
+      enable: false
+      validateserver: false
+      cacertpath: ""
+  authtoken: ""
+event:
+  enable: true
+  format:
+    type: ndjson
+  transport:
+    type: file
+    path: /tmp/top_events.log
+    buffering: line
+    tls:
+      enable: false
+      validateserver: false
+      cacertpath: ""
+  watch:
+  - type: file
+    name: (\/logs?\/)|(\.log$)|(\.log[.\d])
+    value: .*
+  - type: console
+    name: (stdout|stderr)
+    value: .*
+    allowbinary: false
+  - type: net
+    name: .*
+    field: .*
+    value: .*
+  - type: fs
+    name: .*
+    field: .*
+    value: .*
+  - type: dns
+    name: .*
+    field: .*
+    value: .*
+  - type: http
+    name: .*
+    field: .*
+    value: .*

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -666,11 +666,13 @@ Updates configuration of scoped process identified by PID.
 #### Examples
 
 `scope update 1000 --config test_cfg.yml`
+`scope update 1000 < test_cfg.yml`
 
 #### Flags
 
 ```
 Flags:
+  -f, --fetch           Inspect the process after the update is complete
   -c, --config string   Path to configuration file
   -h, --help            help for update
   -p, --prefix string   Prefix to /proc filesystem


### PR DESCRIPTION
This PR:
- Extends the `scope update` command to accept a config file from StdIn
- Adds a `--fetch` argument to the `scope update` command. When provided, the process will be inspected after the config change.
- Ensures that successful output goes to stdout, all warnings and errors go to stderr

**Testing**
- An integration test has been added that passes a valid/invalid config to StdIn ; and another that passes it to `--config`

**Documentation**
- The website's `cli-reference.md` page has been updated accordingly.
- The cli's help menu has been updated with examples where appropriate.

**QA Instructions**
- Review the code
- Test the `scope update` command and its arguments.
