### PR TITLE
Enable process start event by default in the cli (#1451)

### DIFF
--- a/cli/events/events.go
+++ b/cli/events/events.go
@@ -130,7 +130,7 @@ func ParseEvent(b []byte) (libscope.EventBody, error) {
 	if event.Type == "evt" {
 		return event.Body, nil
 	}
-	return event.Body, fmt.Errorf("could not find body in event")
+	return event.Body, fmt.Errorf("config event")
 }
 
 // EventMatch helps retrieve events from events.json

--- a/cli/run/scopeconfig.go
+++ b/cli/run/scopeconfig.go
@@ -107,7 +107,7 @@ func (c *Config) SetDefault() error {
 		Libscope: libscope.ScopeLibscopeConfig{
 			SummaryPeriod: 10,
 			CommandDir:    filepath.Join(c.WorkDir, "cmd"),
-			ConfigEvent:   "false",
+			ConfigEvent:   "true",
 			Log: libscope.ScopeLogConfig{
 				Level: "warning",
 				Transport: libscope.ScopeTransport{

--- a/cli/run/setup_test.go
+++ b/cli/run/setup_test.go
@@ -160,7 +160,7 @@ event:
     field: .*
     value: .*
 libscope:
-  configevent: false
+  configevent: true
   summaryperiod: 10
   commanddir: CMDDIR
   log:

--- a/test/integration/cli/expected.yml
+++ b/test/integration/cli/expected.yml
@@ -64,7 +64,7 @@ event:
     field: .*
     value: .*
 libscope:
-  configevent: false
+  configevent: true
   summaryperiod: 10
   commanddir: /tmp/SESSIONPATH/cmd
   log:

--- a/test/integration/cli/test_cli_dest.sh
+++ b/test/integration/cli/test_cli_dest.sh
@@ -81,7 +81,9 @@ ERR+=$?
 scope run --eventdest=unix://$FILE_SOCKET ls
 ERR+=$?
 
-count=$(grep '"type":"metric"' $DEST_FILE | wc -l)
+# "type":"metric" appears in the proc start event 
+# the ,"body" in the grep statement ensures we only pick up real metrics
+count=$(grep '"type":"metric","body"' $DEST_FILE | wc -l)
 if [ $count -ne 0 ] ; then
     ERR+=1
 fi


### PR DESCRIPTION
**This PR**
- Enables the process start event in the default scope cli config
- Ensures that process start events are redacted in the `scope events` output

**Testing**
- Unit and integration tests have been updated to ensure that expected configs match the new default output.

**Documentation**
n/a

**QA Instructions**
- Review the code
- Test the `scope events` command

Closes: #1451 