### PR TITLE
Replace the Dockerfile for `go1.9.0` and `go1.10.0`

### DIFF
--- a/test/integration/docker-compose.x86_64.yml
+++ b/test/integration/docker-compose.x86_64.yml
@@ -126,7 +126,7 @@ services:
       cache_from:
         - ghcr.io/criblio/appscope-test-go_9:${TAG:?Missing TAG environment variable}
       context: .
-      dockerfile: ./go/Dockerfile
+      dockerfile: ./go/Dockerfile.stretch
       args:
         GO_IMAGE_VER: golang:1.9
     <<: *scope-common
@@ -136,7 +136,7 @@ services:
       cache_from:
         - ghcr.io/criblio/appscope-test-go_10:${TAG:?Missing TAG environment variable}
       context: .
-      dockerfile: ./go/Dockerfile
+      dockerfile: ./go/Dockerfile.stretch
       args:
         GO_IMAGE_VER: golang:1.10
     <<: *scope-common

--- a/test/integration/go/Dockerfile.stretch
+++ b/test/integration/go/Dockerfile.stretch
@@ -1,0 +1,107 @@
+ARG GO_IMAGE_VER=golang:1.14
+FROM $GO_IMAGE_VER
+
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list \
+    && sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list \
+    && sed -i '/stretch-updates/d' /etc/apt/sources.list 
+
+RUN apt-get -o Acquire::Check-Valid-Until=false update && \
+    apt-get install -y vim curl file bsdmainutils gdb
+
+COPY ./go/test_go.sh /go
+COPY ./go/test_go_struct.sh /go
+
+RUN mkdir /go/thread
+COPY ./go/thread/fileThread.go /go/thread
+RUN cd /go/thread && CGO_ENABLED=0 go build fileThread.go
+
+RUN mkdir /go/syscalls
+COPY ./go/syscalls/unlinkat.go /go/syscalls
+RUN cd /go/syscalls && \
+    go build -o unlinkat unlinkat.go
+COPY ./go/syscalls/opfalse.go /go/syscalls
+RUN cd /go/syscalls && \
+    go build -o opfalse opfalse.go
+COPY ./go/syscalls/readdir.go /go/syscalls
+RUN cd /go/syscalls && \
+    go build -o readdir readdir.go
+
+RUN mkdir /go/net
+COPY ./go/net/plainServer.go /go/net
+RUN cd /go/net && \
+    go build -buildmode=pie -o plainServerDynamicPie plainServer.go
+RUN cd /go/net && \
+    go build -o plainServerDynamic plainServer.go
+RUN cd /go/net && \
+    CGO_ENABLED=0 go build -o plainServerStatic plainServer.go
+COPY ./go/net/tlsServer.go /go/net
+RUN cd /go/net && \
+    go build -o tlsServerDynamic tlsServer.go
+RUN cd /go/net && \
+    CGO_ENABLED=0 go build -o tlsServerStatic tlsServer.go
+RUN cd /go/net && \
+    openssl genrsa -out server.key 2048 && \
+    openssl ecparam -genkey -name secp384r1 -out server.key && \
+    openssl req -new -x509 -sha256 \
+      -key server.key \
+      -out server.crt \
+      -days 3650 \
+      -subj "/C=US/ST=California/L=San Francisco/O=Cribl/OU=Cribl/CN=localhost"
+COPY ./go/net/plainClient.go /go/net
+RUN cd /go/net &&\
+    go build -o plainClientDynamic plainClient.go
+RUN cd /go/net && \
+    CGO_ENABLED=0 go build -o plainClientStatic plainClient.go
+RUN cd /go/net && \
+    CGO_ENABLED=0 go build -ldflags='-s' -o plainClientStaticStripped plainClient.go
+COPY ./go/net/tlsClient.go /go/net
+RUN cd /go/net && \
+    go build -o tlsClientDynamic tlsClient.go
+RUN cd /go/net && \
+    CGO_ENABLED=0 go build -o tlsClientStatic tlsClient.go
+
+RUN mkdir /go/signals
+COPY ./go/signals/signalHandler.go /go/signals
+RUN cd /go/signals && \
+    go build -o signalHandlerDynamic signalHandler.go && \
+    CGO_ENABLED=0 go build -o signalHandlerStatic signalHandler.go && \
+    CGO_ENABLED=0 go build -ldflags="-s -w" -o signalHandlerStaticStripped signalHandler.go
+
+RUN mkdir /go/cgo
+COPY ./go/cgo/Makefile /go/cgo
+COPY ./go/cgo/myc.c /go/cgo
+COPY ./go/cgo/myc.h /go/cgo
+COPY ./go/cgo/mygo.go /go/cgo
+RUN cd /go/cgo && make all
+
+RUN mkdir -p /go/influx
+COPY ./go/influx/* /go/influx/
+COPY ./go/influx/influxdb-selfsigned.key /etc/ssl/.
+COPY ./go/influx/influxdb-selfsigned.crt /etc/ssl/.
+
+ENV SCOPE_CRIBL_ENABLE=false
+ENV SCOPE_LOG_LEVEL=warning
+ENV SCOPE_LOG_DEST=file:///tmp/scope.log
+ENV SCOPE_METRIC_VERBOSITY=4
+ENV SCOPE_EVENT_LOGFILE=true
+ENV SCOPE_EVENT_CONSOLE=true
+ENV SCOPE_EVENT_METRIC=true
+ENV SCOPE_EVENT_HTTP=true
+ENV SCOPE_EVENT_DEST=file:///go/events.log
+
+RUN echo "export PATH=/usr/local/scope:/usr/local/scope/bin:${PATH}" >/etc/profile.d/path.sh
+COPY scope-profile.sh /etc/profile.d/scope.sh
+COPY gdbinit /root/.gdbinit
+
+RUN  mkdir /usr/local/scope && \
+     mkdir /usr/local/scope/bin && \
+     mkdir /usr/local/scope/lib && \
+     ln -s /opt/appscope/bin/linux/$(uname -m)/scope /usr/local/scope/bin/scope && \
+     ln -s /opt/appscope/lib/linux/$(uname -m)/libscope.so /usr/local/scope/lib/libscope.so
+
+COPY go/scope-test /usr/local/scope/scope-test
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["test"]
+


### PR DESCRIPTION
- Go `1.9.0`[1] and `1.10.0`[2] versions are based on Debian stretch distro which recently archive the repository [3]
- this change will replace the `/etc/apt/sources.list` references to reflect the archive step

Ref: [1] https://hub.docker.com/layers/library/golang/1.9.0/images/sha256-63c6aa4e9641e4f5e9a95270585cf4e2d925206571b269be5e4bdf086eea54f0?context=explore
Ref: [2] https://hub.docker.com/layers/library/golang/1.10.0/images/sha256-0c4109858680d4cede075491298de88b5d3df24380c328f7be417d22282acb8b?context=explore
Ref: [3] https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html