### PR TITLE
Generate prometheus format from libscope.so, part two

### DIFF
--- a/test/integration/metriccapture/scope-test
+++ b/test/integration/metriccapture/scope-test
@@ -162,6 +162,65 @@ fi
 endtest
 
 
+###########################################################################
+# Repeating a few of the tests above, this time for the prometheus format
+###########################################################################
+export SCOPE_METRIC_FORMAT=prometheus
+export SCOPE_STATSD_PREFIX=AppScope
+
+# Desired "default" dimension priority.  This describes what we want
+# when a field name is common across multiple sources (which source
+# wins).
+#   (1) captured_dimension
+#   (2) custom_dimension
+#   (3) builtin_dimension
+
+# test (1) vs (2) with conflicting "source"
+starttest "captured_tag_priority"
+SCOPE_TAG_source=conflictvalue LD_PRELOAD=/usr/local/scope/lib/libscope.so SCOPE_METRIC_DEST=file://$OUTFILE node hotshot.ts
+evaltest
+# pick one metric to test
+METRIC=`grep "^AppScope_my_histogram" $OUTFILE`
+for DIM in "source=\"hot-shots\""; do
+   if echo $METRIC | grep $DIM; then
+       echo "as expected, found $DIM"
+   else
+       ERR+=1
+   fi
+done
+for DIM in "source=\"conflictvalue\""; do
+   if echo $METRIC | grep $DIM; then
+       ERR+=1
+       echo "did not expect $DIM to exist"
+   fi
+done
+endtest
+
+# test (2) vs (3) with conflicting "proc"
+starttest "custom_tag_priority"
+SCOPE_TAG_proc=myprocval LD_PRELOAD=/usr/local/scope/lib/libscope.so SCOPE_METRIC_DEST=file://$OUTFILE node hotshot.ts
+evaltest
+# pick one metric to test
+METRIC=`grep "^AppScope_my_histogram" $OUTFILE`
+for DIM in "proc=\"myprocval\""; do
+   if echo $METRIC | grep $DIM; then
+       echo "as expected, found $DIM"
+   else
+       ERR+=1
+   fi
+done
+for DIM in "proc=\"node\""; do
+   if echo $METRIC | grep $DIM; then
+       ERR+=1
+       echo "did not expect $DIM to exist"
+   fi
+done
+endtest
+
+unset SCOPE_METRIC_FORMAT
+unset SCOPE_STATSD_PREFIX
+
+###########################################################################
 
 if (( $FAILED_TEST_COUNT == 0 )); then
     echo ""

--- a/test/unit/library/mtcformattest.c
+++ b/test/unit/library/mtcformattest.c
@@ -200,48 +200,6 @@ mtcFormatEventForOutputHappyPathStatsd(void **state)
 }
 
 static void
-mtcFormatEventForOutputHappyPathPrometheus(void **state)
-{
-    char *g_hostname = "myhost";
-    char *g_procname = "testapp";
-    int g_openPorts = 2;
-    pid_t pid = 666;
-    int fd = 3;
-    char *proto = "TCP";
-    in_port_t localPort = 8125;
-
-    event_field_t fields[] = {
-        STRFIELD("proc",    g_procname,   2,  TRUE),
-        NUMFIELD("pid",     pid,          7,  TRUE),
-        NUMFIELD("fd",      fd,           7,  TRUE),
-        STRFIELD("host",    g_hostname,   2,  TRUE),
-        STRFIELD("proto",   proto,        1,  TRUE),
-        NUMFIELD("port",    localPort,    4,  TRUE),
-        FIELDEND
-    };
-    event_t e = INT_EVENT("net.port", g_openPorts, CURRENT, fields);
-
-    mtc_fmt_t *fmt = mtcFormatCreate(CFG_FMT_PROMETHEUS);
-    assert_non_null(fmt);
-    mtcFormatVerbositySet(fmt, CFG_MAX_VERBOSITY);
-
-    char *msg = mtcFormatEventForOutput(fmt, &e, NULL);
-    assert_non_null(msg);
-
-    char expected[1024];
-    int rv = snprintf(expected, sizeof(expected),
-        "# TYPE net_port gauge\n"
-        "net_port{proc=\"%s\",pid=\"%d\",fd=\"%d\",host=\"%s\",proto=\"%s\",port=\"%d\"} %d\n",
-         g_procname, pid, fd, g_hostname, proto, localPort, g_openPorts);
-    assert_true(rv > 0 && rv < 1024);
-    assert_string_equal(expected, msg);
-    scope_free(msg);
-
-    mtcFormatDestroy(&fmt);
-    assert_null(fmt);
-}
-
-static void
 mtcFormatEventForOutputHappyPathJson(void **state)
 {
     char *g_hostname = "myhost";
@@ -277,7 +235,7 @@ mtcFormatEventForOutputHappyPathJson(void **state)
     assert_non_null(json);
 
     assert_true(cJSON_HasObjectItem(json, "type"));
-    
+
     cJSON *body = cJSON_GetObjectItem(json, "body");
 
     // Fields expected for all json metrics
@@ -295,6 +253,48 @@ mtcFormatEventForOutputHappyPathJson(void **state)
     assert_true(cJSON_HasObjectItem(body, "_time"));
 
     cJSON_Delete(json);
+    scope_free(msg);
+
+    mtcFormatDestroy(&fmt);
+    assert_null(fmt);
+}
+
+static void
+mtcFormatEventForOutputHappyPathPrometheus(void **state)
+{
+    char *g_hostname = "myhost";
+    char *g_procname = "testapp";
+    int g_openPorts = 2;
+    pid_t pid = 666;
+    int fd = 3;
+    char *proto = "TCP";
+    in_port_t localPort = 8125;
+
+    event_field_t fields[] = {
+        STRFIELD("proc",    g_procname,   2,  TRUE),
+        NUMFIELD("pid",     pid,          7,  TRUE),
+        NUMFIELD("fd",      fd,           7,  TRUE),
+        STRFIELD("host",    g_hostname,   2,  TRUE),
+        STRFIELD("proto",   proto,        1,  TRUE),
+        NUMFIELD("port",    localPort,    4,  TRUE),
+        FIELDEND
+    };
+    event_t e = INT_EVENT("net.port", g_openPorts, CURRENT, fields);
+
+    mtc_fmt_t *fmt = mtcFormatCreate(CFG_FMT_PROMETHEUS);
+    assert_non_null(fmt);
+    mtcFormatVerbositySet(fmt, CFG_MAX_VERBOSITY);
+
+    char *msg = mtcFormatEventForOutput(fmt, &e, NULL);
+    assert_non_null(msg);
+
+    char expected[1024];
+    int rv = snprintf(expected, sizeof(expected),
+        "# TYPE net_port gauge\n"
+        "net_port{proc=\"%s\",pid=\"%d\",fd=\"%d\",host=\"%s\",proto=\"%s\",port=\"%d\"} %d\n",
+         g_procname, pid, fd, g_hostname, proto, localPort, g_openPorts);
+    assert_true(rv > 0 && rv < 1024);
+    assert_string_equal(expected, msg);
     scope_free(msg);
 
     mtcFormatDestroy(&fmt);
@@ -357,6 +357,43 @@ mtcFormatEventForOutputJsonWithCustomFields(void **state)
     cJSON_Delete(json);
     scope_free(msg);
 
+    mtcFormatDestroy(&fmt);
+    assert_null(fmt);
+}
+
+static void
+mtcFormatEventForOutputPrometheusWithCustomFields(void **state)
+{
+    char *g_procname = "testapp";
+    float g_chickenTeeth = 2.3 / 4.3;
+
+    event_field_t fields[] = {
+        STRFIELD("proc",    g_procname,   2,  TRUE),
+        FIELDEND
+    };
+    event_t e = FLT_EVENT("chicken.teeth", g_chickenTeeth, DELTA, fields);
+
+    mtc_fmt_t *fmt = mtcFormatCreate(CFG_FMT_PROMETHEUS);
+    assert_non_null(fmt);
+
+    custom_tag_t t1 = {"name1", "value1"};
+    custom_tag_t t2 = {"name2", "value2"};
+    custom_tag_t *tags[] = { &t1, &t2, NULL };
+    mtcFormatCustomTagsSet(fmt, tags);
+    mtcFormatVerbositySet(fmt, CFG_MAX_VERBOSITY);
+
+    char *msg = mtcFormatEventForOutput(fmt, &e, NULL);
+    assert_non_null(msg);
+
+    char expected[1024];
+    int rv = snprintf(expected, sizeof(expected),
+        "# TYPE chicken_teeth counter\n"
+        "chicken_teeth{name1=\"%s\",name2=\"%s\",proc=\"%s\"} %.2f\n",
+         "value1", "value2", g_procname, g_chickenTeeth);
+    assert_true(rv > 0 && rv < 1024);
+    assert_string_equal(expected, msg);
+
+    scope_free(msg);
     mtcFormatDestroy(&fmt);
     assert_null(fmt);
 }
@@ -735,9 +772,10 @@ main(int argc, char *argv[])
         cmocka_unit_test(mtcFormatEventForOutputNullEventFieldsDoesntCrash),
         cmocka_unit_test(mtcFormatEventForOutputNullFmtDoesntCrash),
         cmocka_unit_test(mtcFormatEventForOutputHappyPathStatsd),
-        cmocka_unit_test(mtcFormatEventForOutputHappyPathPrometheus),
         cmocka_unit_test(mtcFormatEventForOutputHappyPathJson),
+        cmocka_unit_test(mtcFormatEventForOutputHappyPathPrometheus),
         cmocka_unit_test(mtcFormatEventForOutputJsonWithCustomFields),
+        cmocka_unit_test(mtcFormatEventForOutputPrometheusWithCustomFields),
         cmocka_unit_test(mtcFormatEventForOutputHappyPathFilteredFields),
         cmocka_unit_test(mtcFormatEventForOutputWithCustomFields),
         cmocka_unit_test(mtcFormatEventForOutputWithCustomAndStatsdFields),


### PR DESCRIPTION
Resolves #1397.

This makes some additional changes to prometheus format work that was originally done on the [feature/1397-prometheus-fmt](https://github.com/criblio/appscope/tree/feature/1397-prometheus-fmt) branch and merged into the [feature/prom-server-1398](https://github.com/criblio/appscope/tree/feature/prom-server-1398) branch by PR #1427.