### PR TITLE
`scope update` json fixes

### DIFF
--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -66,18 +66,22 @@ scope inspect --all`,
 				}
 				iouts = append(iouts, iout)
 			}
-			cfgs, err := json.MarshalIndent(iouts, "", "   ")
-			if err != nil {
-				util.ErrAndExit("Error creating json array: %v", err)
-			}
 
 			if jsonOut {
 				// Print each json entry on a newline, without any pretty printing
-				for _, state := range iouts {
-					fmt.Println(state)
+				for _, iout := range iouts {
+					cfg, err := json.Marshal(iout)
+					if err != nil {
+						util.ErrAndExit("Error creating json object: %v", err)
+					}
+					fmt.Println(string(cfg))
 				}
 			} else {
 				// Print the array, in a pretty format
+				cfgs, err := json.MarshalIndent(iouts, "", "   ")
+				if err != nil {
+					util.ErrAndExit("Error creating json array: %v", err)
+				}
 				fmt.Println(string(cfgs))
 			}
 

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -117,7 +117,7 @@ scope inspect --all`,
 		}
 
 		pidCtx.Pid = pid
-		_, cfg, err := inspect.InspectProcess(*pidCtx)
+		iout, _, err := inspect.InspectProcess(*pidCtx)
 		if err != nil {
 			if !admin {
 				util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
@@ -125,7 +125,21 @@ scope inspect --all`,
 			util.ErrAndExit("Inspect PID fails: %v", err)
 		}
 
-		fmt.Println(cfg)
+		if jsonOut {
+			// Print the json object without any pretty printing
+			cfg, err := json.Marshal(iout)
+			if err != nil {
+				util.ErrAndExit("Error creating json object: %v", err)
+			}
+			fmt.Println(string(cfg))
+		} else {
+			// Print the json in a pretty format
+			cfg, err := json.MarshalIndent(iout, "", "   ")
+			if err != nil {
+				util.ErrAndExit("Error creating json array: %v", err)
+			}
+			fmt.Println(string(cfg))
+		}
 	},
 }
 

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -27,7 +27,7 @@ scope inspect --all`,
 		internal.InitConfig()
 		all, _ := cmd.Flags().GetBool("all")
 		prefix, _ := cmd.Flags().GetString("prefix")
-		// jsonOut, _ := cmd.Flags().GetBool("json")
+		jsonOut, _ := cmd.Flags().GetBool("json")
 
 		// Nice message for non-adminstrators
 		err := util.UserVerifyRootPerm()
@@ -71,7 +71,16 @@ scope inspect --all`,
 				util.ErrAndExit("Error creating json array: %v", err)
 			}
 
-			fmt.Println(string(cfgs))
+			if jsonOut {
+				// Print each json entry on a newline, without any pretty printing
+				for _, state := range iouts {
+					fmt.Println(state)
+				}
+			} else {
+				// Print the array, in a pretty format
+				fmt.Println(string(cfgs))
+			}
+
 			return
 		}
 

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -370,7 +370,7 @@ scope inspect --all
 ```
   -a, --all             Inspect all processes
   -h, --help            Help for inspect
-  -j, --json            Output as newline delimited JSON
+  -j, --json            Output as newline delimited JSON without pretty printing
   -p, --prefix string   When running AppScope in a container, and scoping an app that's running outside the container, 
 --prefix is the path to host filesystem of the scoped app
 ```
@@ -680,6 +680,7 @@ Flags:
   -c, --config string   Path to configuration file
   -h, --help            help for update
   -p, --prefix string   Prefix to /proc filesystem
+  -j, --json            Output as newline delimited JSON without pretty printing
 ```
 
 ### version


### PR DESCRIPTION
**This PR**
When the `--json` argument is provided to `scope inspect` or `scope inspect --all`:
1) Don't pretty the json output
2) In the case of `--all`, render ndjson output, instead of an array of json objects

The `scope update` command has also been updated in the case that the `--fetch` argument was supplied.

**Testing**
No additional tests were added. QA instructions should suffice for this change.

**Documentation**
The CLI reference page has been updated to reflect new behavior.

**QA**
Try:
```
scope inspect
scope inspect --json
scope inspect <pid> --json | jq
scope inspect --all
scope inspect --all --json
scope inspect --all --json | jq
scope update <pid> --config ./conf/scope.yml --fetch --json
scope update <pid> --config ./conf/scope.yml --fetch --json | jq
```