### PR TITLE
Handle `BufferAddr` in Java Agent

### DIFF
--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -330,6 +330,15 @@ services:
       context: .
       dockerfile: ./prometheus/Dockerfile
     <<: *scope-common
+  
+  jetty:
+    image: ghcr.io/criblio/appscope-test-jetty:${TAG:?Missing TAG environment variable}
+    build:
+      cache_from:
+        - ghcr.io/criblio/appscope-test-jetty:${TAG:?Missing TAG environment variable}
+      context: .
+      dockerfile: ./jetty/Dockerfile
+    <<: *scope-common
 
   go_19:
     image: ghcr.io/criblio/appscope-test-go_19:${TAG:?Missing TAG environment variable}

--- a/test/integration/jetty/Dockerfile
+++ b/test/integration/jetty/Dockerfile
@@ -1,0 +1,32 @@
+FROM jetty:jdk17
+
+USER root
+
+ENV SCOPE_CRIBL_ENABLE=false
+ENV SCOPE_LOG_LEVEL=debug
+ENV SCOPE_METRIC_VERBOSITY=4
+ENV SCOPE_EVENT_LOGFILE=true
+ENV SCOPE_EVENT_CONSOLE=true
+ENV SCOPE_EVENT_METRIC=true
+ENV SCOPE_EVENT_HTTP=true
+ENV SCOPE_EVENT_NET=true
+ENV SCOPE_EVENT_FS=true
+ENV SCOPE_LOG_DEST=file:///opt/test-runner/logs/scope.log
+ENV SCOPE_EVENT_DEST=file:///opt/test-runner/logs/events.log
+ENV SCOPE_METRIC_DEST=file:///opt/test-runner/logs/metrics.log
+ENV PATH="/usr/local/scope:/usr/local/scope/bin:${PATH}"
+COPY scope-profile.sh /etc/profile.d/scope.sh
+COPY gdbinit /root/.gdbinit
+RUN  mkdir /opt/test/
+RUN  mkdir /usr/local/scope && \
+     mkdir /usr/local/scope/bin && \
+     mkdir /usr/local/scope/lib && \
+     mkdir -p /opt/test-runner/logs/ && \
+     ln -s /opt/appscope/bin/linux/$(uname -m)/scope /usr/local/scope/bin/scope && \
+     ln -s /opt/appscope/lib/linux/$(uname -m)/libscope.so /usr/local/scope/lib/libscope.so
+
+COPY jetty/scope-test /usr/local/scope/scope-test
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["test"]

--- a/test/integration/jetty/scope-test
+++ b/test/integration/jetty/scope-test
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+DEBUG=0  # set this to 1 to capture the EVT_FILE for each test
+
+FAILED_TEST_LIST=""
+FAILED_TEST_COUNT=0
+EVT_FILE="/opt/test-runner/logs/events.log"
+METRIC_FILE="/opt/test-runner/logs/metrics.log"
+SCOPE_LOG_FILE="/opt/test-runner/logs/scope.log"
+
+starttest(){
+    CURRENT_TEST=$1
+    echo "==============================================="
+    echo "             Testing $CURRENT_TEST             "
+    echo "==============================================="
+    ERR=0
+}
+
+evaltest(){
+    echo "             Evaluating $CURRENT_TEST"
+}
+
+endtest(){
+    if [ $ERR -eq "0" ]; then
+        RESULT=PASSED
+    else
+        RESULT=FAILED
+        FAILED_TEST_LIST+=$CURRENT_TEST
+        FAILED_TEST_LIST+=" "
+        FAILED_TEST_COUNT=$(($FAILED_TEST_COUNT + 1))
+    fi
+
+    echo "*************** $CURRENT_TEST $RESULT ***************"
+    echo ""
+    echo ""
+
+    # copy the EVT_FILE/METRIC_FILE/SCOPE_LOG_FILE to help with debugging
+    if (( $DEBUG )) || [ $RESULT == "FAILED" ]; then
+        cp -f $EVT_FILE $EVT_FILE.$CURRENT_TEST
+        cp -f $METRIC_FILE $METRIC_FILE.$CURRENT_TEST
+        cp -f $SCOPE_LOG_FILE $SCOPE_LOG_FILE.$CURRENT_TEST
+    fi
+
+    rm -f $METRIC_FILE
+    rm -f $EVT_FILE
+    rm -f $SCOPE_LOG_FILE
+}
+
+#
+# test jetty
+#
+
+starttest jetty-ssl-java
+
+# Start the server
+cd /opt/test
+java -jar $JETTY_HOME/start.jar --add-modules=ssl,http2,https,test-keystore
+LD_PRELOAD=/usr/local/scope/lib/libscope.so java -jar $JETTY_HOME/start.jar &
+
+sleep 2
+JAVA_PID=`pidof java`
+
+# Use https request to listening server
+curl -k https://localhost:8443
+
+sleep 2
+
+# Observe that Java process is still alive there was no SIGSEGV
+if ! kill -0 $JAVA_PID &>/dev/null; then
+    echo "$JAVA_PID does not exists anymore"
+    ERR+=1
+fi
+
+endtest
+
+if (( $FAILED_TEST_COUNT == 0 )); then
+    echo ""
+    echo ""
+    echo "*************** ALL TESTS PASSED ***************"
+else
+    echo "*************** SOME TESTS FAILED ***************"
+    echo "Failed tests: $FAILED_TEST_LIST"
+    echo "Refer to these files for more info:"
+    for FAILED_TEST in $FAILED_TEST_LIST; do
+        echo "  $EVT_FILE.$FAILED_TEST"
+    done
+fi
+
+exit ${FAILED_TEST_COUNT}


### PR DESCRIPTION
- Do not call `GetPrimitiveArrayCritical` on buffer address
- Perform explicitly memory allocation & copy