### PR TITLE
Extend `scope prom` service with metrics port

### DIFF
--- a/cli/k8s/configs.go
+++ b/cli/k8s/configs.go
@@ -182,6 +182,8 @@ spec:
           ports:
             - containerPort: {{ .PromMPort }}
               protocol: TCP
+            - containerPort: {{ .PromSPort }}
+              protocol: TCP
 {{- end }}
       volumes:
         - name: certs
@@ -201,6 +203,10 @@ spec:
       protocol: TCP
       port: {{ .PromMPort }}
       targetPort: {{ .PromMPort }}
+    - name: {{ .PromSPort }}-prom-export-http
+      protocol: TCP
+      port: {{ .PromSPort }}
+      targetPort: {{ .PromSPort }}
   selector:
     app: {{ .App }}
 {{- end }}


### PR DESCRIPTION
- allows to access `/metrics` endpoint

QA instructions:
```
#checkout to this branch
make build CMD="make all"
make image
kind create cluster
kind load docker-image cribl/scope:dev
docker run -it cribl/scope:dev scope k8s --metricdest tcp://scope-prom-export:9109 --metricformat prometheus --eventdest tcp://other.host:10070 --debug | kubectl apply -f -
kubectl run mycurlpod --image=curlimages/curl -i --tty -- sh
# inside the new pod You should receive status 200 for following request
curl scope-prom-export:9090/metrics -v
```