### PR TITLE
Rootdir support in proc utils (#1414)

### DIFF
--- a/cli/cmd/attach.go
+++ b/cli/cmd/attach.go
@@ -36,6 +36,7 @@ scope attach --payloads 2000`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		internal.InitConfig()
+		rc.Rootdir, _ = cmd.Flags().GetString("rootdir")
 
 		// Disallow bad argument combinations (see Arg Matrix at top of file)
 		if rc.CriblDest != "" && rc.MetricsDest != "" {
@@ -70,5 +71,6 @@ scope attach --payloads 2000`,
 
 func init() {
 	runCmdFlags(attachCmd, rc)
+	attachCmd.Flags().StringP("rootdir", "R", "", "Path to root filesystem of target namespace")
 	RootCmd.AddCommand(attachCmd)
 }

--- a/cli/cmd/attach.go
+++ b/cli/cmd/attach.go
@@ -32,6 +32,8 @@ The --*dest flags accept file names like /tmp/scope.log or URLs like file:///tmp
 be set to sockets with unix:///var/run/mysock, tcp://hostname:port, udp://hostname:port, or tls://hostname:port.`,
 	Example: `scope attach 1000
 scope attach firefox 
+scope attach --rootdir /path/to/host firefox 
+scope attach --rootdir /path/to/host/mount/proc/<hostpid>/root 1000
 scope attach --payloads 2000`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/detach.go
+++ b/cli/cmd/detach.go
@@ -17,7 +17,10 @@ var detachCmd = &cobra.Command{
 	Long:  `Unscopes a currently-running process identified by PID or <process_name>.`,
 	Example: `scope detach 1000
 scope detach firefox
-scope detach --all`,
+scope detach --all
+scope detach 1000 --rootdir /path/to/host/mount
+scope detach --rootdir /path/to/host/mount
+scope detach --all --rootdir /path/to/host/mount/proc/<hostpid>/root`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		internal.InitConfig()

--- a/cli/cmd/detach.go
+++ b/cli/cmd/detach.go
@@ -22,24 +22,25 @@ scope detach --all`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		internal.InitConfig()
 		all, _ := cmd.Flags().GetBool("all")
-
-		// Disallow bad argument combinations (see Arg Matrix at top of file)
-		if !all && len(args) == 0 {
-			helpErrAndExit(cmd, "Must specify a pid, process name, or --all")
-		}
+		rc.Rootdir, _ = cmd.Flags().GetString("rootdir")
 
 		if all {
 			if len(args) != 0 {
 				helpErrAndExit(cmd, "--all flag is mutual exclusive with PID or <process_name>")
 			}
 			rc.Subprocess = true
-			return rc.DetachAll(args, true)
+			return rc.DetachAll(true)
 		}
-		return rc.DetachSingle(args)
+		if len(args) == 0 {
+			return rc.DetachSingle("")
+		}
+
+		return rc.DetachSingle(args[0])
 	},
 }
 
 func init() {
 	detachCmd.Flags().BoolP("all", "a", false, "Detach from all processes")
+	detachCmd.Flags().StringP("rootdir", "R", "", "Path to root filesystem of target namespace")
 	RootCmd.AddCommand(detachCmd)
 }

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -93,7 +93,7 @@ scope inspect --all`,
 			// If no pid argument was provided
 			// Helper menu to allow the user to select a pid to inspect
 
-			if pid, err = run.HandleInputArg("", false, true, false); err != nil {
+			if pid, err = run.HandleInputArg(rootdir, "", false, true, false); err != nil {
 				if !admin {
 					util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
 				}
@@ -144,7 +144,7 @@ scope inspect --all`,
 }
 
 func init() {
-	inspectCmd.Flags().StringP("rootdir", "p", "", "Path to root filesystem of target namespace")
+	inspectCmd.Flags().StringP("rootdir", "R", "", "Path to root filesystem of target namespace")
 	inspectCmd.Flags().BoolP("json", "j", false, "Output as newline delimited JSON")
 	inspectCmd.Flags().BoolP("all", "a", false, "Inspect all processes")
 	RootCmd.AddCommand(inspectCmd)

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -45,7 +45,7 @@ scope inspect --all`,
 
 		if all {
 			// Get all scoped processes
-			procs, err := util.ProcessesScoped()
+			procs, err := util.ProcessesScoped(rootdir)
 			if err != nil {
 				if !admin {
 					util.Warn("INFO: Run as root (or via sudo) to interact with all processes")
@@ -108,7 +108,7 @@ scope inspect --all`,
 			}
 		}
 
-		status, _ := util.PidScopeLibInMaps(pid)
+		status, _ := util.PidScopeLibInMaps(rootdir, pid)
 		if !status {
 			if !admin {
 				util.Warn("INFO: Run as root (or via sudo) to interact with all processes")

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -21,7 +21,10 @@ var inspectCmd = &cobra.Command{
 	Long:  `Returns information about scoped process identified by PID.`,
 	Example: `scope inspect
 scope inspect 1000
-scope inspect --all`,
+scope inspect --all --json
+scope inspect 1000 --rootdir /path/to/host/mount
+scope inspect --all --rootdir /path/to/host/mount
+scope inspect --all --rootdir /path/to/host/mount/proc/<hostpid>/root`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()

--- a/cli/cmd/ps.go
+++ b/cli/cmd/ps.go
@@ -20,6 +20,8 @@ var psCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()
+		rootdir, _ := cmd.Flags().GetString("rootdir")
+
 		// Nice message for non-adminstrators
 		err := util.UserVerifyRootPerm()
 		if errors.Is(err, util.ErrGetCurrentUser) {
@@ -29,7 +31,7 @@ var psCmd = &cobra.Command{
 			fmt.Println("INFO: Run as root (or via sudo) to see all scoped processes")
 		}
 
-		procs, err := util.ProcessesScoped("")
+		procs, err := util.ProcessesScoped(rootdir)
 		if err != nil {
 			util.ErrAndExit("Unable to retrieve scoped processes: %v", err)
 		}
@@ -43,5 +45,7 @@ var psCmd = &cobra.Command{
 }
 
 func init() {
+	psCmd.Flags().StringP("rootdir", "R", "", "Path to root filesystem of target namespace")
+	psCmd.Flags().BoolP("json", "j", false, "Output as newline delimited JSON")
 	RootCmd.AddCommand(psCmd)
 }

--- a/cli/cmd/ps.go
+++ b/cli/cmd/ps.go
@@ -16,8 +16,12 @@ import (
 var psCmd = &cobra.Command{
 	Use:   "ps",
 	Short: "List processes currently being scoped",
-	Long:  `Lists all processes where the libscope library is injected.`,
-	Args:  cobra.NoArgs,
+	Long:  `List processes currently being scoped.`,
+	Example: `scope ps
+scope ps --json
+scope ps --rootdir /path/to/host/mount
+scope ps --rootdir /path/to/host/mount/proc/<hostpid>/root`,
+	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()
 		rootdir, _ := cmd.Flags().GetString("rootdir")

--- a/cli/cmd/ps.go
+++ b/cli/cmd/ps.go
@@ -29,7 +29,7 @@ var psCmd = &cobra.Command{
 			fmt.Println("INFO: Run as root (or via sudo) to see all scoped processes")
 		}
 
-		procs, err := util.ProcessesScoped()
+		procs, err := util.ProcessesScoped("")
 		if err != nil {
 			util.ErrAndExit("Unable to retrieve scoped processes: %v", err)
 		}

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -37,6 +37,6 @@ scope start --rootdir /hostfs`,
 }
 
 func init() {
-	startCmd.Flags().StringP("rootdir", "p", "", "Path to root filesystem of target namespace")
+	startCmd.Flags().StringP("rootdir", "R", "", "Path to root filesystem of target namespace")
 	RootCmd.AddCommand(startCmd)
 }

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -69,7 +69,7 @@ scope update 1000 < test_cfg.yml`,
 			util.ErrAndExit("error parsing PID argument")
 		}
 
-		status, _ := util.PidScopeLibInMaps(pid)
+		status, _ := util.PidScopeLibInMaps(rootdir, pid)
 		if !status {
 			if !admin {
 				util.Warn("INFO: Run as root (or via sudo) to interact with all processes")

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -122,7 +122,7 @@ scope update 1000 < test_cfg.yml`,
 
 func init() {
 	updateCmd.Flags().BoolP("fetch", "f", false, "Inspect the process after the update is complete")
-	updateCmd.Flags().StringP("rootdir", "p", "", "Path to root filesystem of target namespace")
+	updateCmd.Flags().StringP("rootdir", "R", "", "Path to root filesystem of target namespace")
 	updateCmd.Flags().BoolP("json", "j", false, "Output as newline delimited JSON")
 	updateCmd.Flags().StringP("config", "c", "", "Path to configuration file")
 	RootCmd.AddCommand(updateCmd)

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -23,8 +23,11 @@ var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Updates the configuration of a scoped process",
 	Long:  `Updates the configuration of a scoped process identified by PID.`,
-	Example: `scope update 1000 --config test_cfg.yml
-scope update 1000 < test_cfg.yml`,
+	Example: `scope update 1000 --config scope_cfg.yml
+scope update 1000 < scope_cfg.yml
+scope update 1000 --json < scope_cfg.yml
+scope update 1000 --rootdir /path/to/host/mount --config scope_cfg.yml
+scope update 1000 --rootdir /path/to/host/mount/proc/<hostpid>/root < scope_cfg.yml`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()

--- a/cli/run/attach.go
+++ b/cli/run/attach.go
@@ -175,7 +175,7 @@ func (rc *Config) DetachAll(prompt bool) error {
 
 // DetachSingle unscopes an existing scoped process, identified by name or pid
 func (rc *Config) DetachSingle(id string) error {
-	pid, err := HandleInputArg(rc.Rootdir, id, false, false, true)
+	pid, err := HandleInputArg(rc.Rootdir, id, false, true, true)
 	if err != nil {
 		return err
 	}

--- a/cli/run/attach.go
+++ b/cli/run/attach.go
@@ -37,7 +37,7 @@ func (rc *Config) Attach(args []string) error {
 	args[0] = fmt.Sprint(pid)
 	var reattach bool
 	// Check PID is not already being scoped
-	status, err := util.PidScopeStatus(pid)
+	status, err := util.PidScopeStatus("", pid)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func (rc *Config) DetachSingle(args []string) error {
 	args[0] = fmt.Sprint(pid)
 
 	// Check PID is already being scoped
-	status, err := util.PidScopeStatus(pid)
+	status, err := util.PidScopeStatus("", pid)
 	if err != nil {
 		return err
 	} else if status != util.Active {

--- a/cli/run/run.go
+++ b/cli/run/run.go
@@ -29,6 +29,7 @@ type Config struct {
 	CommandDir    string
 	Coredump      bool
 	Backtrace     bool
+	Rootdir       string
 
 	now func() time.Time
 	sc  *libscope.ScopeConfig

--- a/cli/stop/stop.go
+++ b/cli/stop/stop.go
@@ -164,7 +164,7 @@ func Stop() error {
 		Subprocess: true,
 		Verbosity:  4, // Default
 	}
-	if err := rc.DetachAll([]string{}, false); err != nil {
+	if err := rc.DetachAll(false); err != nil {
 		log.Error().
 			Err(err).
 			Msg("Error detaching from all Scoped processes")

--- a/cli/util/namespace.go
+++ b/cli/util/namespace.go
@@ -61,21 +61,21 @@ func GetPodmanPids() ([]int, error) {
 
 // Get the List of PID(s) related to specific container runtime
 func getContainerRuntimePids(runtimeProc string) ([]int, error) {
-	runtimeContPids, err := PidScopeMapByProcessName(runtimeProc)
+	runtimeContPids, err := PidScopeMapByProcessName("", runtimeProc)
 	if err != nil {
 		return nil, err
 	}
 	pids := make([]int, 0, len(runtimeContPids))
 
 	for runtimeContPid := range runtimeContPids {
-		childrenPids, err := PidChildren(runtimeContPid)
+		childrenPids, err := PidChildren("", runtimeContPid)
 		if err != nil {
 			return nil, err
 		}
 
 		// Iterate over all the children to found container init process
 		for _, childPid := range childrenPids {
-			status, _ := PidInitContainer(childPid)
+			status, _ := PidInitContainer("", childPid)
 			if status {
 				pids = append(pids, childPid)
 			}

--- a/cli/util/proc.go
+++ b/cli/util/proc.go
@@ -40,7 +40,7 @@ var (
 // searchPidByProcName check if specified inputProcName fully match the pid's process name
 func searchPidByProcName(pid int, inputProcName string) bool {
 
-	procName, err := PidCommand(pid)
+	procName, err := PidCommand("", pid)
 	if err != nil {
 		return false
 	}
@@ -50,7 +50,7 @@ func searchPidByProcName(pid int, inputProcName string) bool {
 // searchPidByCmdLine check if specified inputArg submatch the pid's command line
 func searchPidByCmdLine(pid int, inputArg string) bool {
 
-	cmdLine, err := PidCmdline(pid)
+	cmdLine, err := PidCmdline("", pid)
 	if err != nil {
 		return false
 	}
@@ -63,7 +63,7 @@ type searchFunc func(int, string) bool
 func pidScopeMapSearch(inputArg string, sF searchFunc) (PidScopeMapState, error) {
 	pidMap := make(PidScopeMapState)
 
-	procs, err := pidProcDirsNames()
+	procs, err := pidProcDirsNames("")
 	if err != nil {
 		return pidMap, err
 	}
@@ -81,7 +81,7 @@ func pidScopeMapSearch(inputArg string, sF searchFunc) (PidScopeMapState, error)
 		}
 
 		if sF(pid, inputArg) {
-			status, err := PidScopeStatus(pid)
+			status, err := PidScopeStatus("", pid)
 			if err != nil {
 				continue
 			}
@@ -102,9 +102,10 @@ func PidScopeMapByCmdLine(cmdLine string) (PidScopeMapState, error) {
 	return pidScopeMapSearch(cmdLine, searchPidByCmdLine)
 }
 
-// pidProcDirsNames returns a list wiht process directory names
-func pidProcDirsNames() ([]string, error) {
-	procDir, err := os.Open("/proc")
+// pidProcDirsNames returns a list with process directory names
+func pidProcDirsNames(rootdir string) ([]string, error) {
+	procPath := fmt.Sprintf("%s/proc", rootdir)
+	procDir, err := os.Open(procPath)
 	if err != nil {
 		return nil, errOpenProc
 	}
@@ -127,7 +128,7 @@ func ProcessesByNameToAttach(name string) (Processes, error) {
 func processesByName(name string, activeOnly bool) (Processes, error) {
 	processes := make([]Process, 0)
 
-	procs, err := pidProcDirsNames()
+	procs, err := pidProcDirsNames("")
 	if err != nil {
 		return processes, err
 	}
@@ -152,23 +153,23 @@ func processesByName(name string, activeOnly bool) (Processes, error) {
 			continue
 		}
 
-		command, err := PidCommand(pid)
+		command, err := PidCommand("", pid)
 		if err != nil {
 			continue
 		}
 
-		cmdLine, err := PidCmdline(pid)
+		cmdLine, err := PidCmdline("", pid)
 		if err != nil {
 			continue
 		}
 
 		// TODO in container namespace we cannot depend on following info
-		userName, err := PidUser(pid)
+		userName, err := PidUser("", pid)
 		if err != nil && !errors.Is(err, errMissingUser) {
 			continue
 		}
 
-		status, err := PidScopeStatus(pid)
+		status, err := PidScopeStatus("", pid)
 		if err != nil {
 			continue
 		}
@@ -191,10 +192,10 @@ func processesByName(name string, activeOnly bool) (Processes, error) {
 }
 
 // ProcessesScoped returns an array of processes that are currently being scoped
-func ProcessesScoped() (Processes, error) {
+func ProcessesScoped(rootdir string) (Processes, error) {
 	processes := make([]Process, 0)
 
-	procs, err := pidProcDirsNames()
+	procs, err := pidProcDirsNames(rootdir)
 	if err != nil {
 		return processes, err
 	}
@@ -212,19 +213,18 @@ func ProcessesScoped() (Processes, error) {
 			continue
 		}
 
-		cmdLine, err := PidCmdline(pid)
+		cmdLine, err := PidCmdline(rootdir, pid)
 		if err != nil {
 			continue
 		}
 
-		// TODO in container namespace we cannot depend on following info
-		userName, err := PidUser(pid)
+		userName, err := PidUser(rootdir, pid)
 		if err != nil && !errors.Is(err, errMissingUser) {
 			continue
 		}
 
 		// Add process if is is scoped
-		status, err := PidScopeStatus(pid)
+		status, err := PidScopeStatus(rootdir, pid)
 		if err != nil {
 			continue
 		}
@@ -246,7 +246,7 @@ func ProcessesScoped() (Processes, error) {
 func ProcessesToDetach() (Processes, error) {
 	processes := make([]Process, 0)
 
-	procs, err := pidProcDirsNames()
+	procs, err := pidProcDirsNames("")
 	if err != nil {
 		return processes, err
 	}
@@ -264,19 +264,18 @@ func ProcessesToDetach() (Processes, error) {
 			continue
 		}
 
-		cmdLine, err := PidCmdline(pid)
+		cmdLine, err := PidCmdline("", pid)
 		if err != nil {
 			continue
 		}
 
-		// TODO in container namespace we cannot depend on following info
-		userName, err := PidUser(pid)
+		userName, err := PidUser("", pid)
 		if err != nil && !errors.Is(err, errMissingUser) {
 			continue
 		}
 
 		// Detach the process in case the situation we are not able to retrieve the info
-		status, err := PidScopeStatus(pid)
+		status, err := PidScopeStatus("", pid)
 		if err != nil && !errors.Is(err, ipc.ErrConsumerTimeout) {
 			continue
 		}
@@ -296,10 +295,10 @@ func ProcessesToDetach() (Processes, error) {
 }
 
 // PidUser returns the user owning the process specified by PID
-func PidUser(pid int) (string, error) {
+func PidUser(rootdir string, pid int) (string, error) {
 
 	// Get uid from status
-	pStat, err := linuxproc.ReadProcessStatus(fmt.Sprintf("/proc/%v/status", pid))
+	pStat, err := linuxproc.ReadProcessStatus(fmt.Sprintf("%s/proc/%v/status", rootdir, pid))
 	if err != nil {
 		return "", errGetProcStatus
 	}
@@ -314,8 +313,8 @@ func PidUser(pid int) (string, error) {
 }
 
 // PidScopeLibInMaps checks if a process specified by PID contains libscope in memory mappings.
-func PidScopeLibInMaps(pid int) (bool, error) {
-	pidMapFile, err := os.ReadFile(fmt.Sprintf("/proc/%v/maps", pid))
+func PidScopeLibInMaps(rootdir string, pid int) (bool, error) {
+	pidMapFile, err := os.ReadFile(fmt.Sprintf("%s/proc/%v/maps", rootdir, pid))
 	if err != nil {
 		// Process or do not exist or we do not have permissions to read a map file
 		return false, err
@@ -326,8 +325,8 @@ func PidScopeLibInMaps(pid int) (bool, error) {
 }
 
 // PidScopeStatus checks a Scope Status if a process specified by PID.
-func PidScopeStatus(pid int) (ScopeStatus, error) {
-	pidMapFile, err := os.ReadFile(fmt.Sprintf("/proc/%v/maps", pid))
+func PidScopeStatus(rootdir string, pid int) (ScopeStatus, error) {
+	pidMapFile, err := os.ReadFile(fmt.Sprintf("%s/proc/%v/maps", rootdir, pid))
 	if err != nil {
 		// Process or do not exist or we do not have permissions to read a map file
 		return Disable, err
@@ -339,8 +338,9 @@ func PidScopeStatus(pid int) (ScopeStatus, error) {
 		return Disable, nil
 	}
 
-	// Ignore scope process // TODO: Still Needed?
-	command, err := PidCommand(pid)
+	// Ignore scopedyn processes
+	// TODO: Still intended?
+	command, err := PidCommand(rootdir, pid)
 	if err != nil {
 		return Disable, nil
 	}
@@ -349,14 +349,14 @@ func PidScopeStatus(pid int) (ScopeStatus, error) {
 	}
 
 	// Check shmem does not exist (if scope_anon does not exist the proc is scoped)
-	files, err := os.ReadDir(fmt.Sprintf("/proc/%v/fd", pid))
+	files, err := os.ReadDir(fmt.Sprintf("%s/proc/%v/fd", rootdir, pid))
 	if err != nil {
 		// Process or do not exist or we do not have permissions to read a fd file
 		return Disable, err
 	}
 
 	for _, file := range files {
-		filePath := fmt.Sprintf("/proc/%v/fd/%s", pid, file.Name())
+		filePath := fmt.Sprintf("%s/proc/%v/fd/%s", rootdir, pid, file.Name())
 		resolvedFileName, err := os.Readlink(filePath)
 		if err != nil {
 			continue
@@ -365,15 +365,16 @@ func PidScopeStatus(pid int) (ScopeStatus, error) {
 			return Setup, nil
 		}
 	}
+	fmt.Println(pid)
 
 	// Retrieve information from IPC
-	return getScopeStatus(pid)
+	return getScopeStatus(rootdir, pid)
 }
 
 // PidCommand gets the command used to start the process specified by PID
-func PidCommand(pid int) (string, error) {
+func PidCommand(rootdir string, pid int) (string, error) {
 	// Get command from status
-	pStat, err := linuxproc.ReadProcessStatus(fmt.Sprintf("/proc/%v/status", pid))
+	pStat, err := linuxproc.ReadProcessStatus(fmt.Sprintf("%s/proc/%v/status", rootdir, pid))
 	if err != nil {
 		return "", errGetProcStatus
 	}
@@ -382,9 +383,9 @@ func PidCommand(pid int) (string, error) {
 }
 
 // PidCmdline gets the cmdline used to start the process specified by PID
-func PidCmdline(pid int) (string, error) {
+func PidCmdline(rootdir string, pid int) (string, error) {
 	// Get cmdline
-	cmdline, err := linuxproc.ReadProcessCmdline(fmt.Sprintf("/proc/%v/cmdline", pid))
+	cmdline, err := linuxproc.ReadProcessCmdline(fmt.Sprintf("%s/proc/%v/cmdline", rootdir, pid))
 	if err != nil {
 		return "", errGetProcCmdLine
 	}

--- a/cli/util/proc_test.go
+++ b/cli/util/proc_test.go
@@ -16,7 +16,7 @@ import (
 func TestProcessesByNameToAttach(t *testing.T) {
 	// Current process
 	name := "util.test"
-	result, err := ProcessesByNameToAttach(name)
+	result, err := ProcessesByNameToAttach("", name)
 	user, _ := user.Current()
 	exp := Processes{
 		Process{
@@ -36,9 +36,9 @@ func TestProcessesByNameToAttach(t *testing.T) {
 // - The process map with single entry is returned
 // - No error is returned
 func TestPidScopeMapByProcessName(t *testing.T) {
-	currentProcessName, err := PidCommand(os.Getpid())
+	currentProcessName, err := PidCommand("", os.Getpid())
 	assert.NoError(t, err)
-	pidMap, err := PidScopeMapByProcessName(currentProcessName)
+	pidMap, err := PidScopeMapByProcessName("", currentProcessName)
 	assert.NoError(t, err)
 	assert.Len(t, pidMap, 1)
 	assert.Contains(t, pidMap, os.Getpid())
@@ -50,11 +50,11 @@ func TestPidScopeMapByProcessName(t *testing.T) {
 // - Empty Map is returned
 // - No error is returned
 func TestPidScopeMapByProcessNameCharShorter(t *testing.T) {
-	currentProcName, err := PidCommand(os.Getpid())
+	currentProcName, err := PidCommand("", os.Getpid())
 	assert.NoError(t, err)
 	modProcName := currentProcName[:len(currentProcName)-1]
 
-	pidMap, err := PidScopeMapByProcessName(modProcName)
+	pidMap, err := PidScopeMapByProcessName("", modProcName)
 	assert.NoError(t, err)
 	assert.Len(t, pidMap, 0)
 }
@@ -64,9 +64,9 @@ func TestPidScopeMapByProcessNameCharShorter(t *testing.T) {
 // - The expected process map is returned
 // - No error is returned
 func TestPidScopeMapByCmdLine(t *testing.T) {
-	currentProcCmdLine, err := PidCmdline(os.Getpid())
+	currentProcCmdLine, err := PidCmdline("", os.Getpid())
 	assert.NoError(t, err)
-	pidMap, err := PidScopeMapByCmdLine(currentProcCmdLine)
+	pidMap, err := PidScopeMapByCmdLine("", currentProcCmdLine)
 	assert.NoError(t, err)
 	assert.Len(t, pidMap, 1)
 	assert.Contains(t, pidMap, os.Getpid())
@@ -78,11 +78,11 @@ func TestPidScopeMapByCmdLine(t *testing.T) {
 // - The expected process map is returned
 // - No error is returned
 func TestPidScopeMapByCmdLineCharShorter(t *testing.T) {
-	currentProcCmdLine, err := PidCmdline(os.Getpid())
+	currentProcCmdLine, err := PidCmdline("", os.Getpid())
 	assert.NoError(t, err)
 	modProcCmdLine := currentProcCmdLine[:len(currentProcCmdLine)-1]
 
-	pidMap, err := PidScopeMapByCmdLine(modProcCmdLine)
+	pidMap, err := PidScopeMapByCmdLine("", modProcCmdLine)
 	assert.NoError(t, err)
 	assert.Len(t, pidMap, 1)
 	assert.Contains(t, pidMap, os.Getpid())
@@ -110,7 +110,7 @@ func TestPidUser(t *testing.T) {
 	}
 	username := currentUser.Username
 	pid := os.Getpid()
-	result, err := PidUser(pid)
+	result, err := PidUser("", pid)
 	assert.Equal(t, username, result)
 	assert.NoError(t, err)
 }
@@ -122,7 +122,7 @@ func TestPidUser(t *testing.T) {
 func TestPidCommand(t *testing.T) {
 	// Current process command
 	pid := os.Getpid()
-	result, err := PidCommand(pid)
+	result, err := PidCommand("", pid)
 	assert.Equal(t, "util.test", result)
 	assert.NoError(t, err)
 }
@@ -134,7 +134,7 @@ func TestPidCommand(t *testing.T) {
 func TestPidCmdline(t *testing.T) {
 	// Current process command
 	pid := os.Getpid()
-	result, err := PidCmdline(pid)
+	result, err := PidCmdline("", pid)
 	assert.Equal(t, strings.Join(os.Args[:], " "), result)
 	assert.NoError(t, err)
 }
@@ -146,7 +146,7 @@ func TestPidCmdline(t *testing.T) {
 func TestPidThreadsPids(t *testing.T) {
 	// Current process command
 	pid := os.Getpid()
-	threadPids, err := PidThreadsPids(pid)
+	threadPids, err := PidThreadsPids("", pid)
 	assert.Contains(t, threadPids, pid)
 	assert.NoError(t, err)
 }
@@ -157,12 +157,12 @@ func TestPidThreadsPids(t *testing.T) {
 func TestPidExists(t *testing.T) {
 	// Current process PID
 	pid := os.Getpid()
-	result := PidExists(pid)
+	result := PidExists("", pid)
 	assert.Equal(t, true, result)
 
 	// PID 0
 	pid = 0
-	result = PidExists(pid)
+	result = PidExists("", pid)
 	assert.Equal(t, false, result)
 }
 
@@ -172,6 +172,6 @@ func TestPidExists(t *testing.T) {
 // - No error is returned
 func TestPidGetRefPidForMntNamespace(t *testing.T) {
 	pid := os.Getpid()
-	result := PidGetRefPidForMntNamespace(pid)
+	result := PidGetRefPidForMntNamespace("", pid)
 	assert.Equal(t, -1, result)
 }

--- a/cli/util/scopestate.go
+++ b/cli/util/scopestate.go
@@ -39,9 +39,12 @@ func (state ScopeStatus) String() string {
 var errScopeStatus = errors.New("error scope status")
 
 // getScopeStatus retreives information about Scope status using IPC
-func getScopeStatus(pid int) (ScopeStatus, error) {
+func getScopeStatus(rootdir string, pid int) (ScopeStatus, error) {
 	cmd := ipc.CmdGetScopeStatus{}
-	resp, err := cmd.Request(ipc.IpcPidCtx{Pid: pid})
+	resp, err := cmd.Request(ipc.IpcPidCtx{
+		PrefixPath: rootdir,
+		Pid:        pid,
+	})
 	if err != nil {
 		return Disable, err
 	}

--- a/test/integration/cli/test_cli.sh
+++ b/test/integration/cli/test_cli.sh
@@ -232,8 +232,8 @@ endtest
 #
 starttest "Scope detach by name"
 
-run scope detach sleep
-outputs "Detaching from pid ${sleep_pid}"
+echo "1" | scope detach sleep
+RET=$?
 returns 0
 
 endtest

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -89,7 +89,9 @@ be set to sockets with `unix:///var/run/mysock`, `tcp://hostname:port`, `udp://h
 
 ```
 scope attach 1000
-scope attach firefox
+scope attach firefox 
+scope attach --rootdir /path/to/host firefox 
+scope attach --rootdir /path/to/host/mount/proc/<hostpid>/root 1000
 scope attach --payloads 2000
 ```
 
@@ -108,6 +110,7 @@ scope attach --payloads 2000
       --metricformat string   Set format of metrics output (statsd|ndjson) (default "ndjson")
   -n, --nobreaker             Set Cribl to not break streams into events.
   -p, --payloads              Capture payloads of network transactions
+  -R, --rootdir               Path to root filesystem of target namespace
   -u, --userconfig string     Scope an application with a user specified config file; overrides all other settings.
   -v, --verbosity int         Set scope metric verbosity (default 4)
 ```
@@ -157,7 +160,7 @@ Displays an interactive dashboard with an overview of what's happening with the 
 ### detach
 ---
 
-Unscopes a currently-running process identified by PID or ProcessName.
+Unscopes a currently-running process identified by PID or process name.
 
 #### Usage
 
@@ -169,6 +172,9 @@ Unscopes a currently-running process identified by PID or ProcessName.
 scope detach 1000
 scope detach firefox
 scope detach --all
+scope detach 1000 --rootdir /path/to/host/mount
+scope detach --rootdir /path/to/host/mount
+scope detach --all --rootdir /path/to/host/mount/proc/<hostpid>/root
 ```
 
 #### Flags
@@ -176,6 +182,7 @@ scope detach --all
 ```
   -a, --all                   Detach from all processes
   -h, --help                  Help for detach
+  -R, --rootdir               Path to root filesystem of target namespace
 
 ```
 
@@ -362,7 +369,10 @@ Returns information on scoped process identified by PID.
 ```
 scope inspect
 scope inspect 1000
-scope inspect --all
+scope inspect --all --json
+scope inspect 1000 --rootdir /path/to/host/mount
+scope inspect --all --rootdir /path/to/host/mount
+scope inspect --all --rootdir /path/to/host/mount/proc/<hostpid>/root
 ```
 
 #### Flags
@@ -371,7 +381,7 @@ scope inspect --all
   -a, --all             Inspect all processes
   -h, --help            Help for inspect
   -j, --json            Output as newline delimited JSON without pretty printing
-  -p, --rootdir string  Path to root filesystem of target namespace
+  -R, --rootdir         Path to root filesystem of target namespace
 ```
 
 ### k8s
@@ -509,6 +519,22 @@ Lists all scoped processes. This means processes whose functions AppScope is int
 
 `scope ps`
 
+#### Examples
+
+```
+scope ps
+scope ps --json
+scope ps --rootdir /path/to/host/mount
+scope ps --rootdir /path/to/host/mount/proc/<hostpid>/root`,
+```
+
+#### Flags
+
+```
+  -j, --json            Output as newline delimited JSON without pretty printing
+  -R, --rootdir         Path to root filesystem of target namespace
+```
+
 ### run
 ----
 
@@ -625,10 +651,10 @@ scope start --rootdir /hostfs
 Stop scoping all processes and services on the host and in all relevant containers.
 
 `scope stop` does the following on the host and in all relevant containers:
-  - Remove filter files `/usr/lib/appscope/scope_filter` and `/tmp/appscope/scope_filter`.
-	- Detach from all existing scoped processes.
-	- Remove the `etc/profile.d/scope.sh` script.
-	- Delete any lines that `LD_PRELOAD` libscope from any relevant service configurations.
+    - Remove filter files `/usr/lib/appscope/scope_filter` and `/tmp/appscope/scope_filter`.
+    - Detach from all existing scoped processes.
+    - Remove the `etc/profile.d/scope.sh` script.
+    - Delete any lines that `LD_PRELOAD` libscope from any relevant service configurations.
 
 #### Usage
 
@@ -656,8 +682,13 @@ Updates configuration of scoped process identified by PID.
 
 #### Examples
 
-`scope update 1000 --config test_cfg.yml`
-`scope update 1000 < test_cfg.yml`
+```
+scope update 1000 --config scope_cfg.yml
+scope update 1000 < scope_cfg.yml
+scope update 1000 --json < scope_cfg.yml
+scope update 1000 --rootdir /path/to/host/mount --config scope_cfg.yml
+scope update 1000 --rootdir /path/to/host/mount/proc/<hostpid>/root < scope_cfg.yml
+```
 
 #### Flags
 
@@ -666,8 +697,8 @@ Flags:
   -f, --fetch           Inspect the process after the update is complete
   -c, --config string   Path to configuration file
   -h, --help            help for update
-  -p, --rootdir string  Prefix to /proc filesystem
   -j, --json            Output as newline delimited JSON without pretty printing
+  -R, --rootdir         Path to root filesystem of target namespace
 ```
 
 ### version


### PR DESCRIPTION
**This PR**
Extends the cli `utils` package to read the proc directory of a foreign namespace, through the use of a `rootdir` prefix passed on the command line. As a result:
- The `inspect` command now allows container to host/container inspect.
- The `ps` command now supports a `--rootdir` argument to show processes on a host, or sibling container.
- The `inspect` command and the `detach` command now show a helper menu when no argument is provided, to allow the user to choose a process. When the `--rootdir` argument is provided, the helper menu displays scoped processes in the namespace related to the rootdir.

**Testing**
The CLI `proc_utils.go` unit test was updated.
No container-to-host or container-to-container integration tests have been added as it is not yet supported in our test framework. See: https://github.com/criblio/appscope/issues/1311
In place of this, QA instructions should suffice for this change.

**Documentation**
The CLI reference page has been updated to reflect new behavior.

**QA**
- Start two containers like this:
`docker run --rm -it -v /path/to/appscope/:/opt/appscope -v /:/hostfs:ro --privileged ubuntu`
- Run 2 instances of `scope top` on the host 
- Exec into one of the containers and run 2 instances of `scope top`
- Exec into the other container and Try:
```
scope inspect --rootdir /hostfs # should reveal a helper menu with 2 procs
scope inspect --rootdir /hostfs/proc/<pid>/root # where pid is any pid in the sibling container from host perspective
scope inspect --all --rootdir /hostfs # should show output for 2 procs
scope inspect --all --rootdir /hostfs/proc/<pid>/root # where pid is any pid in the sibling container from host perspective
scope ps --rootdir /hostfs # should reveal 2 procs
scope ps --rootdir /hostfs/proc/<pid>/root # where pid is any pid in the sibling container
scope detach --rootdir /hostfs # should reveal a helper menu with 2 procs. FYI detach with rootdir doesn't work yet.
scope detach --rootdir /hostfs/proc/<pid>/root # where pid is any pid in the sibling container from host perspective
```