### PR TITLE
RFC nit: Fix Openssl compilation on machine with limited resources

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -3,7 +3,7 @@
 #
 # The `contrib/` folder contains a number of external dependencies we keep
 # locally to ensure things don't change under us. The logic here builds them.
-# 
+#
 # To support caching the results, we build most of these into subdirectories of
 # `./build/` and try not to make any changes/additions in the source folders
 # themselves. In CI, we can hash the source folder to get a key for caching the
@@ -82,7 +82,7 @@ build/openssl/libssl.a build/openssl/libcrypto.a:
 	@echo "$${CI:+::group::}Building openssl"
 	@$(RM) -r build/openssl
 	@mkdir build/openssl
-	cd build/openssl && ../../openssl/Configure no-engine no-async no-tests no-unit-test no-threads && make -j$(nproc)
+	cd build/openssl && ../../openssl/Configure no-engine no-async no-tests no-unit-test no-threads && $(MAKE)
 	# Yuck.  Avoids naming conflict between our wrap.c and libssl.a
 	objcopy --redefine-sym SSL_read=SCOPE_SSL_read build/openssl/libssl.a
 	objcopy --redefine-sym SSL_write=SCOPE_SSL_write build/openssl/libssl.a


### PR DESCRIPTION
- avoid OOM during compilation on e.g. machine with 2 CPU(s), 2GB memory and disabled swap
```
gcc  -I. -Iinclude -Iproviders/common/include -Iproviders/implementations/include
 -I../../openssl -I../../openssl/include -I../../openssl/providers/common/include
 -I../../openssl/providers/implementations/include  -DECP_NISTZ256_ASM -DKECCAK1600_ASM
 -DOPENSSL_BN_ASM_MONT -DOPENSSL_CPUID_OBJ -DPOLY1305_ASM -DSHA1_ASM -DSHA256_ASM
 -DSHA512_ASM -DVPAES_ASM -fPIC -Wa,--noexecstack -Wall -O3 -DOPENSSL_USE_NODELETE
 -DOPENSSL_PIC -DOPENSSLDIR="\"/usr/local/ssl\"" -DENGINESDIR="\"/usr/local/lib/engines-3\""
 -DMODULESDIR="\"/usr/local/lib/ossl-modules\"" -DOPENSSL_BUILDING_OPENSSL -DNDEBUG
  -MMD -MF crypto/dso/libcrypto-lib-dso_win32.d.tmp -MT crypto/dso/libcrypto-lib-dso_win32.o -c
 -o crypto/dso/libcrypto-lib-dso_win32.o ../../openssl/crypto/dso/dso_win32.c
gcc: internal compiler error: Killed (program cc1)
```
Discovered while testing #1497 