### PR TITLE
Do not expose `backtrace` as weak symbol

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -112,7 +112,7 @@ build/libunwind/src/.libs/libunwind.a:
 	@$(RM) -r build/libunwind
 	@mkdir build/libunwind
 # To enable debug please add below --enable-debug
-	cd build/libunwind && autoreconf -fvi ../../libunwind && ../../libunwind/configure --disable-pthread-api --disable-shared --disable-minidebuginfo --disable-documentation --disable-tests CFLAGS=-fPIC && $(MAKE)
+	cd build/libunwind && autoreconf -fvi ../../libunwind && ../../libunwind/configure --disable-weak-backtrace --disable-pthread-api --disable-shared --disable-minidebuginfo --disable-documentation --disable-tests CFLAGS=-fPIC && $(MAKE)
 	objcopy --redefine-syms redefine_syms.lst build/libunwind/src/.libs/libunwind.a
 	if [ "x86_64" = "$(ARCH)" ]; then \
 		objcopy --redefine-sym dl_iterate_phdr=SCOPE_DlIteratePhdr build/libunwind/src/.libs/libunwind.a; \

--- a/test/unit/verboten_sym.sh
+++ b/test/unit/verboten_sym.sh
@@ -4,6 +4,7 @@ SCOPE_LIB=./lib/linux/$(uname -m)/libscope.so
 
 # List of forbidden symbols
 declare -a verboten_syms=(
+"backtrace"
 "secure_getenv"
 "setenv"
 )


### PR DESCRIPTION
- do not interpose `backtrace` function
- we do not want for the application that calls `backtrace` call our `unw_backtrace` function

Fixes: #1499