### PR TITLE
Fix attaching container-container

### DIFF
--- a/cli/run/scopeconfig.go
+++ b/cli/run/scopeconfig.go
@@ -141,7 +141,7 @@ func (c *Config) ConfigFromStdin(cfgData []byte) error {
 func (c *Config) ConfigFromFile() error {
 	c.sc = &libscope.ScopeConfig{}
 
-	yamlFile, err := ioutil.ReadFile(c.UserConfig)
+	yamlFile, err := os.ReadFile(c.UserConfig)
 	if err != nil {
 		return err
 	}

--- a/cli/run/scopeconfig.go
+++ b/cli/run/scopeconfig.go
@@ -130,11 +130,7 @@ func (c *Config) SetDefault() error {
 func (c *Config) ConfigFromStdin(cfgData []byte) error {
 	c.sc = &libscope.ScopeConfig{}
 
-	if err := yaml.Unmarshal(cfgData, c.sc); err != nil {
-		return err
-	}
-
-	return nil
+	return yaml.Unmarshal(cfgData, c.sc)
 }
 
 // ConfigFromFile loads a configuration from a yml file

--- a/cli/run/setup.go
+++ b/cli/run/setup.go
@@ -159,26 +159,10 @@ func (rc *Config) createWorkDir(args []string, attach bool) {
 		fmt.Printf("WARNING: Session history will be stored in %s and owned by root\n", histDir)
 	}
 
-	// Create Working directory
-	if attach {
-		// Validate /tmp exists
-		if !util.CheckDirExists("/tmp") {
-			util.ErrAndExit("/tmp directory does not exist")
-		}
-		// Create working directory in /tmp (0777 permissions)
-		rc.WorkDir = filepath.Join("/tmp", tmpDirName)
-		err := os.Mkdir(rc.WorkDir, dirPerms)
-		util.CheckErrSprintf(err, "error creating workdir dir: %v", err)
-
-		// Symbolic link between /tmp/tmpDirName and /history/tmpDirName
-		rootHistDir := filepath.Join(histDir, tmpDirName)
-		os.Symlink(rc.WorkDir, rootHistDir)
-	} else {
-		// Create working directory in history/
-		rc.WorkDir = filepath.Join(HistoryDir(), tmpDirName)
-		err = os.Mkdir(rc.WorkDir, 0755)
-		util.CheckErrSprintf(err, "error creating workdir dir: %v", err)
-	}
+	// Create working directory
+	rc.WorkDir = filepath.Join(HistoryDir(), tmpDirName)
+	err = os.Mkdir(rc.WorkDir, 0755)
+	util.CheckErrSprintf(err, "error creating workdir dir: %v", err)
 
 	// Create Cmd directory
 	cmdDir := filepath.Join(rc.WorkDir, "cmd")

--- a/cli/run/setup_test.go
+++ b/cli/run/setup_test.go
@@ -3,7 +3,6 @@ package run
 import (
 	"crypto/md5"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,11 +26,11 @@ func TestCreateAll(t *testing.T) {
 		assert.Equal(t, stat.Mode(), perms[i])
 		wb, _ := Asset(fmt.Sprintf("build/%s", f))
 		hash1 := md5.Sum(wb)
-		fb, _ := ioutil.ReadFile(path)
+		fb, _ := os.ReadFile(path)
 		hash2 := md5.Sum(fb)
 		assert.Equal(t, hash1, hash2)
 
-		fb, _ = ioutil.ReadFile(fmt.Sprintf("../build/%s", f))
+		fb, _ = os.ReadFile(fmt.Sprintf("../build/%s", f))
 		hash3 := md5.Sum(fb)
 		assert.Equal(t, hash2, hash3)
 	}
@@ -197,13 +196,13 @@ func TestSetupWorkDir(t *testing.T) {
 	exists := util.CheckFileExists(wd)
 	assert.True(t, exists)
 
-	argsJSONBytes, err := ioutil.ReadFile(filepath.Join(wd, "args.json"))
+	argsJSONBytes, err := os.ReadFile(filepath.Join(wd, "args.json"))
 	assert.NoError(t, err)
 	assert.Equal(t, `["/bin/foo"]`, string(argsJSONBytes))
 
 	expectedYaml := testDefaultScopeConfigYaml(wd, 4)
 
-	scopeYAMLBytes, err := ioutil.ReadFile(filepath.Join(wd, "scope.yml"))
+	scopeYAMLBytes, err := os.ReadFile(filepath.Join(wd, "scope.yml"))
 	assert.NoError(t, err)
 	assert.Equal(t, expectedYaml, string(scopeYAMLBytes))
 
@@ -232,13 +231,13 @@ func TestSetupWorkDirAttach(t *testing.T) {
 	exists := util.CheckFileExists(wd)
 	assert.True(t, exists)
 
-	argsJSONBytes, err := ioutil.ReadFile(filepath.Join(wd, "args.json"))
+	argsJSONBytes, err := os.ReadFile(filepath.Join(wd, "args.json"))
 	assert.NoError(t, err)
 	assert.Equal(t, `["sleep","600"]`, string(argsJSONBytes))
 
 	expectedYaml := testDefaultScopeConfigYaml(wd, 4)
 
-	scopeYAMLBytes, err := ioutil.ReadFile(filepath.Join(wd, "scope.yml"))
+	scopeYAMLBytes, err := os.ReadFile(filepath.Join(wd, "scope.yml"))
 	assert.NoError(t, err)
 	assert.Equal(t, expectedYaml, string(scopeYAMLBytes))
 

--- a/src/loader/ns.c
+++ b/src/loader/ns.c
@@ -29,6 +29,31 @@ typedef enum {
     STOP = 1,
 } ns_action_t;
 
+/*
+ * Ensure that cron configuration is present in specified root path
+ */
+static bool
+isCronConfigPresent(const char *rootPath) {
+    const char* const cronFiles[] = {
+        "/etc/cron.d",
+        "/etc/crontab",
+    };
+
+    for (int i = 0; i < ARRAY_SIZE(cronFiles); ++i) {
+        char path[PATH_MAX] = {0};
+        if (snprintf(path, sizeof(path), "%s%s", rootPath, cronFiles[i]) < 0) {
+            perror("isCronConfigPresent: error: snprintf() failed\n");
+            return FALSE;
+        }
+
+        if (access(path, R_OK)) {
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+}
+
 /* Create the cron file
  *
  * When the start command is executed within a container we can't
@@ -46,19 +71,9 @@ createCron(const char *hostPrefixPath, const char *script, pid_t pid) {
     char cronjob[1024] = {0};
     char path[PATH_MAX] = {0};
 
-    // Check access to cron.d directory
-    if (snprintf(path, sizeof(path), "%s/etc/cron.d", hostPrefixPath) < 0) {
-        perror("createCron: /etc/cron.d error: snprintf() failed\n");
-        return FALSE;
-    }
-    if (access(path, R_OK)) {
-        fprintf(stderr, "createCron: error %s does not exist\n", path);
-        return FALSE;
-    }
 
     // Create the /tmp/att.sh script to be executed by cron
     // We use a script so it can delete the cron file after it's run
-    memset(path, 0, PATH_MAX);
     if (snprintf(path, sizeof(path), "%s/tmp/att%d.sh", hostPrefixPath, pid) < 0) {
         perror("createCron: /tmp/att.sh error: snprintf() failed\n");
         fprintf(stderr, "path: %s\n", path);
@@ -101,7 +116,7 @@ createCron(const char *hostPrefixPath, const char *script, pid_t pid) {
     }
     // Write cronfile contents
     if (snprintf(cronjob, sizeof(cronjob), SCOPE_CRONTAB, pid) < 0) {
-        perror("error: nsAttach: sprintf() failed\n");
+        perror("createCron: sprintf() failed\n");
         return FALSE;
     }
     if (write(outFd, cronjob, strlen(cronjob)) == -1) {
@@ -403,7 +418,7 @@ nsUnconfigure(pid_t pid) {
  * Install in the mount namespace
  * - switch the mount namespace
  * - install the library file
- * Returns status of operation 0 in case of success, other values in case of failure
+ * Returns status of operation EXIT_SUCCESS in case of success, EXIT_FAILURE in case of failure
  * TODO? switch back to origin namespace
  */
 int
@@ -445,8 +460,9 @@ out:
 // Extract a cron script into that namespace to run `scope --ldattach [pid]`
 // Optionally copy a config into the target mnt ns
 int
-nsAttach(pid_t pid, const char *rootdir)
+nsAttach(pid_t pid, const char *rootDir)
 {
+    pid_t hostPid = pid;
     int ret = EXIT_SUCCESS;
     size_t cfgSize = 0;
     char script[1024];
@@ -454,18 +470,54 @@ nsAttach(pid_t pid, const char *rootdir)
     char scopeCfgPath[PATH_MAX] = {0};
     char scopeCmd[PATH_MAX] = {0};
     char path[PATH_MAX] = {0};
-    uid_t nsUid = nsInfoTranslateUidRootDir(rootdir, pid);
-    gid_t nsGid = nsInfoTranslateGidRootDir(rootdir, pid);
+
+    snprintf(path, PATH_MAX, "%s", rootDir);
+
+    /*
+    * Check if cron configuration exists in specified root directory
+    */
+    if (isCronConfigPresent(path) == FALSE) {
+        /*
+        * Fallthrough scenario
+        * Try to modify the specified root directory to point host directory
+        * E.g. In case rootDir is equal /hostfs/proc/<pid>/root/ and it points
+        * to another container
+        */
+
+        /*
+        * TODO: make this more robust based on full path with "host pid"
+        */
+        char *pch = strstr(path, "/proc/");
+        if (!pch) {
+            fprintf(stderr, "error: nsAttach: failed to find cron configuration in %s\n", path);
+            return EXIT_FAILURE;
+        }
+        if (sscanf(pch, "/proc/%d/root", &hostPid) != 1) {
+            fprintf(stderr, "error: nsAttach: cannot find host pid in %s\n", pch);
+            return EXIT_FAILURE;
+        }
+
+        // Try to access the hostfs path
+        path[pch - path] = 0;
+
+        if (isCronConfigPresent(path) == FALSE) {
+            fprintf(stderr, "error: nsAttach: failed to find cron configuration in %s\n", path);
+            return EXIT_FAILURE;
+        }
+    }
+
+    uid_t nsUid = nsInfoTranslateUidRootDir(path, hostPid);
+    gid_t nsGid = nsInfoTranslateGidRootDir(path, hostPid);
 
     // Configuration is optionally loaded into memory from origin ns
     char *scopeCfgMem = setupLoadFileIntoMem(&cfgSize, getenv("SCOPE_CONF_PATH"));
 
-    if (nsInstall(rootdir, 1, STATIC_LOADER_FILE)) {
+    if (nsInstall(path, 1, STATIC_LOADER_FILE)) {
         fprintf(stderr, "error: nsAttach: failed to extract loader\n");
         ret = EXIT_FAILURE;
         goto out;
     }
-    
+
     // Note: After the successful call to nsInstall, we are in the target mnt ns
 
     // Create script and cron job to perform the attach 
@@ -501,7 +553,7 @@ nsAttach(pid_t pid, const char *rootdir)
     // If a config was loaded into memory, extract it into the target ns and update
     // the scope command to include the config env var
     if (scopeCfgMem) {
-        if (snprintf(scopeCfgPath, sizeof(scopeCfgPath), "%s/scope%d.yml", workdirPath, pid) < 0) {
+        if (snprintf(scopeCfgPath, sizeof(scopeCfgPath), "%s/scope%d.yml", workdirPath, hostPid) < 0) {
             perror("error: nsAttach: snprintf() failed\n");
             ret = EXIT_FAILURE;
             goto out;
@@ -518,13 +570,13 @@ nsAttach(pid_t pid, const char *rootdir)
         }
     }
 
-    if (snprintf(script, sizeof(script), SCOPE_ATTACH_SCRIPT, pid, scopeCmd, pid) < 0) {
+    if (snprintf(script, sizeof(script), SCOPE_ATTACH_SCRIPT, hostPid, scopeCmd, hostPid) < 0) {
         perror("error: nsAttach: sprintf() failed\n");
         ret = EXIT_FAILURE;
         goto out;
     }
 
-    if (createCron("", script, pid) == FALSE) {
+    if (createCron("", script, hostPid) == FALSE) {
         perror("error: nsAttach: createCronFile() failed\n");
         ret = EXIT_FAILURE;
         goto out;


### PR DESCRIPTION
- This covers the scenario when we attaching to a container-container using the direct path to container root ,e.g. /hostfs/proc/<host_target_pid>/root
- We must ensure that the cron we are going to use has an active cron process running. This is done by checking the presence of the crontab.
  * First in: /hostfs/proc/<host_target_pid>/root which is root directory of container mount namespace
  * Second in: /hostfs/ which is root directory of host
- If we will use the path in the second check, we need to translate back the "pid" argument to the host PID namespace which we can extract from the `rootDir` argument

Fixes #1508