### PR TITLE
nit: issues founded by static analyzer & failing integration node test

### DIFF
--- a/src/loader/attach.c
+++ b/src/loader/attach.c
@@ -108,8 +108,8 @@ load_and_attach(pid_t pid, char *scopeLibPath)
     }
 
     if ((ebuf = getElf(exe_path)) == NULL) {
-        free(exe_path);
         fprintf(stderr, "error: can't read the executable %s\n", exe_path);
+        free(exe_path);
         return EXIT_FAILURE;
     }
 

--- a/src/loader/ns.c
+++ b/src/loader/ns.c
@@ -791,6 +791,7 @@ nsForkAndExec(pid_t parentPid, pid_t nsPid, bool ldattach)
             snprintf(loaderInChildPath, PATH_MAX, "/tmp/appscope/%s/scope", loaderVersion);
             if (access(loaderInChildPath, R_OK)) {
                 fprintf(stderr, "error: access scope failed\n");
+                free(execArgv);
                 return EXIT_FAILURE;
             }
         }

--- a/test/integration/node/Dockerfile.glibc
+++ b/test/integration/node/Dockerfile.glibc
@@ -7,7 +7,7 @@ WORKDIR /usr/local/scope/
 
 RUN npm install hot-shots && \
     apt-get -o Acquire::Check-Valid-Until=false update && \
-    apt-get install -y vim gawk gdb emacs lsof tcpdump wget curl netcat
+    apt-get install -y vim gawk gdb emacs lsof tcpdump wget curl netcat-openbsd
 
 COPY node/scope-test /usr/local/scope/
 COPY node/hotshot.ts /usr/local/scope/


### PR DESCRIPTION
- print the `exe_path` before freeing it to avoid accessing memory after freeing
- free the `execArgv` array before returning from function