### PR TITLE
run attach as subprocess

### DIFF
--- a/cli/cmd/detach.go
+++ b/cli/cmd/detach.go
@@ -31,7 +31,6 @@ scope detach --all --rootdir /path/to/host/mount/proc/<hostpid>/root`,
 			if len(args) != 0 {
 				helpErrAndExit(cmd, "--all flag is mutual exclusive with PID or <process_name>")
 			}
-			rc.Subprocess = true
 			return rc.DetachAll(true)
 		}
 		if len(args) == 0 {

--- a/cli/run/attach.go
+++ b/cli/run/attach.go
@@ -108,11 +108,8 @@ func (rc *Config) Attach(args []string) (int, error) {
 	}
 
 	ld := loader.New()
-	if !rc.Subprocess {
-		err = ld.Attach(args, env)
-	} else {
-		_, err = ld.AttachSubProc(args, env)
-	}
+	stdoutStderr, err := ld.AttachSubProc(args, env)
+	util.Warn(stdoutStderr)
 	if err != nil {
 		return pid, err
 	}
@@ -230,13 +227,13 @@ func (rc *Config) detach(pid int) error {
 
 	env := os.Environ()
 	ld := loader.New()
-	if !rc.Subprocess {
-		return ld.Detach(args, env)
+	stdoutStderr, err := ld.DetachSubProc(args, env)
+	util.Warn(stdoutStderr)
+	if err != nil {
+		return err
 	}
-	out, err := ld.DetachSubProc(args, env)
-	util.Warn(out)
 
-	return err
+	return nil
 }
 
 // HandleInputArg handles the input argument (process id/name)


### PR DESCRIPTION
Ensure that the attach/detach command always runs as a subprocess (instead of fork/exec), so we can control what happens with stdout and stderr. In this case, we want to ensure that all messages sent to the console are sent to stderr.