### PR TITLE
Wait for detach and reattach to complete with certain flags

### DIFF
--- a/cli/filter/filter.go
+++ b/cli/filter/filter.go
@@ -158,13 +158,13 @@ func Add(filterFile libscope.Filter, addProc, procArg, sourceid, rootdir string,
 	}
 	// Note: if len(procs) == 0 do nothing
 	if len(procs) == 1 {
-		if err = rc.Attach(procs[0].Pid, false); err != nil {
+		if _, err = rc.Attach(procs[0].Pid, false); err != nil {
 			return err
 		}
 	} else if len(procs) > 1 {
 		errors := false
 		for _, proc := range procs {
-			if err = rc.Attach(proc.Pid, false); err != nil {
+			if _, err = rc.Attach(proc.Pid, false); err != nil {
 				log.Error().Err(err)
 				errors = true
 			}

--- a/website/src/pages/docs/cli-reference.md
+++ b/website/src/pages/docs/cli-reference.md
@@ -190,7 +190,7 @@ scope detach --all --rootdir /path/to/host/mount/proc/<hostpid>/root
   -a, --all                   Detach from all processes
   -h, --help                  Help for detach
   -R, --rootdir               Path to root filesystem of target namespace
-
+  -w, --wait                  Wait for detach to complete
 ```
 
 ### events


### PR DESCRIPTION
When `detach --wait` is used, wait 11 seconds for the detach to take place.
When `attach --inspect` is used, wait 10 seconds (plus 2) if we are doing a reattach.