### PR TITLE
Print cli command errors to stderr instead of stdout

### DIFF
--- a/cli/cmd/attach.go
+++ b/cli/cmd/attach.go
@@ -44,7 +44,7 @@ be set to sockets with unix:///var/run/mysock, tcp://hostname:port, udp://hostna
   scope attach --rootdir /path/to/host/root/proc/<hostpid>/root 1000
   scope attach --payloads 2000`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()
 		rc.Rootdir, _ = cmd.Flags().GetString("rootdir")
 		inspectFlag, _ := cmd.Flags().GetBool("inspect")
@@ -81,11 +81,11 @@ be set to sockets with unix:///var/run/mysock, tcp://hostname:port, udp://hostna
 
 		procs, err := util.HandleInputArg(id, "", rc.Rootdir, true, true, true, false)
 		if err != nil {
-			return err
+			util.ErrAndExit("Attach failure: %v", err)
 		}
 
 		if len(procs) == 0 {
-			return errNoScopedProcs
+			util.ErrAndExit("Attach failure: no matching processes found")
 		}
 
 		pid := procs[0].Pid // we told HandleInputArg above that we wanted to choose only one proc
@@ -137,8 +137,6 @@ be set to sockets with unix:///var/run/mysock, tcp://hostname:port, udp://hostna
 				fmt.Println(string(cfg))
 			}
 		}
-
-		return nil
 	},
 }
 

--- a/cli/cmd/detach.go
+++ b/cli/cmd/detach.go
@@ -33,7 +33,7 @@ var detachCmd = &cobra.Command{
   scope detach --rootdir /path/to/host/root
   scope detach --all --rootdir /path/to/host/root/proc/<hostpid>/root`,
 	Args: cobra.MaximumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()
 		all, _ := cmd.Flags().GetBool("all")
 		wait, _ := cmd.Flags().GetBool("wait")
@@ -50,11 +50,11 @@ var detachCmd = &cobra.Command{
 
 		procs, err := util.HandleInputArg(id, "", rc.Rootdir, !all, true, false, false)
 		if err != nil {
-			return err
+			util.ErrAndExit("Detach failure: %v", err)
 		}
 
 		if len(procs) == 0 {
-			return errNoScopedProcs
+			util.ErrAndExit("Detach failure: %v", errNoScopedProcs)
 		}
 		if len(procs) == 1 {
 			err = rc.Detach(procs[0].Pid)
@@ -63,12 +63,12 @@ var detachCmd = &cobra.Command{
 			if wait {
 				time.Sleep(11 * time.Second) // detach uses dynamic config (<10s)
 			}
-			return err
+			return
 		}
 		// len(procs) is > 1
 		if !util.Confirm(fmt.Sprintf("Are your sure you want to detach from all of these processes?")) {
 			fmt.Println("info: canceled")
-			return nil
+			return
 		}
 
 		errors := false
@@ -79,7 +79,7 @@ var detachCmd = &cobra.Command{
 			}
 		}
 		if errors {
-			return errDetachingMultiple
+			util.ErrAndExit("Detach failure: %v", errDetachingMultiple)
 		}
 
 		// Simple approach for now
@@ -87,8 +87,6 @@ var detachCmd = &cobra.Command{
 		if wait {
 			time.Sleep(11 * time.Second) // detach uses dynamic config (<10s)
 		}
-
-		return nil
 	},
 }
 

--- a/cli/cmd/detach.go
+++ b/cli/cmd/detach.go
@@ -57,7 +57,9 @@ var detachCmd = &cobra.Command{
 			util.ErrAndExit("Detach failure: %v", errNoScopedProcs)
 		}
 		if len(procs) == 1 {
-			err = rc.Detach(procs[0].Pid)
+			if err = rc.Detach(procs[0].Pid); err != nil {
+				util.ErrAndExit("Detach failure: %v", err)
+			}
 			// Simple approach for now
 			// Later: check for detach then resume
 			if wait {

--- a/cli/cmd/inspect.go
+++ b/cli/cmd/inspect.go
@@ -29,7 +29,7 @@ var inspectCmd = &cobra.Command{
   scope inspect --all --rootdir /path/to/host/root
   scope inspect --all --rootdir /path/to/host/root/proc/<hostpid>/root`,
 	Args: cobra.MaximumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, args []string) {
 		internal.InitConfig()
 		all, _ := cmd.Flags().GetBool("all")
 		rootdir, _ := cmd.Flags().GetString("rootdir")
@@ -57,17 +57,17 @@ var inspectCmd = &cobra.Command{
 
 		procs, err := util.HandleInputArg(id, "", rootdir, !all, false, false, false)
 		if err != nil {
-			return err
+			util.ErrAndExit("Inspect failure: %v", err)
 		}
 
 		if len(procs) == 0 {
-			return errNoScopedProcs
+			util.ErrAndExit("Inspect failure: %v", errNoScopedProcs)
 		}
 		if len(procs) == 1 {
 			pidCtx.Pid = procs[0].Pid
 			iout, _, err := inspect.InspectProcess(*pidCtx)
 			if err != nil {
-				return err
+				util.ErrAndExit("Inspect failure: %v", err)
 			}
 			iouts = append(iouts, iout)
 		} else { // len(procs) > 1
@@ -82,7 +82,7 @@ var inspectCmd = &cobra.Command{
 				iouts = append(iouts, iout)
 			}
 			if errors {
-				return errInspectingMultiple
+				util.ErrAndExit("Inspect failure: %v", errInspectingMultiple)
 			}
 		}
 
@@ -109,8 +109,6 @@ var inspectCmd = &cobra.Command{
 			}
 			fmt.Println(string(cfgs))
 		}
-
-		return nil
 	},
 }
 


### PR DESCRIPTION
Commands like `attach`, `detach`, `inspect`, `update`, `rules` should not emit anything other than json to stdout when the --json flag is supplied.

Some of these cobra commands were defined as functions that returned an error. That error is printed to stdout.
In some error cases those command functions would return non-nil values, and thus the error would be printed to stdout.

This PR changes those commands to not return any value. In the case when an error should be printed, the `util.ErrAndExit` function is now used, which emits errors to stderr and exits.