### PR TITLE
Set a larger (1mb) buffer size for each event in cli reader (#201)

### DIFF
--- a/cli/util/newlinereader.go
+++ b/cli/util/newlinereader.go
@@ -12,6 +12,8 @@ import (
 func NewlineReader(r io.Reader, match func(string) bool, callback func(line int, offset int64, b []byte) error) (int, error) {
 	cr := &CountingReader{Reader: r}
 	scanner := bufio.NewScanner(cr)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
 	idx := 0
 	offset := int64(0)
 	for scanner.Scan() {


### PR DESCRIPTION
When some of the CLI commands read in events, we see the error `error reading events: bufio.Scanner: token too long`. I increased the buffer size for the scanner to 1mb which seems more than appropriate for a single event. This resolves the issue in cases that I tested (events, flows).

Fixes #201 
