### PR TITLE
Bump the CLI go build version to 1.21.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,19 +193,6 @@ jobs:
           key: ${{ runner.os }}-${{ steps.env.outputs.arch }}-buildx-${{ github.sha }}
           upload-chunk-size: 1000000
 
-      # Cache downloaded Go dependencies.
-      - name: Setup Go Cache
-        uses: actions/cache@v3.3.2
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            cli/.gobin
-            cli/.gocache
-            cli/.gomod
-          key: ${{ runner.os }}-${{ steps.env.outputs.arch }}-go-${{ hashFiles('cli/go.sum') }}
-          upload-chunk-size: 1000000
-
       # Cache the cmocka build. Use a key based on a hash of all the files used
       # in the build.
       - name: Setup cmocka Cache

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -80,9 +80,9 @@ deps: goenv $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT) $(TRIVY)
 goenv:
 	( cd .. && $(GO) env )
 $(GO_BINDATA):
-	GOINSECURE=* $(GO) install github.com/go-bindata/go-bindata/...
+	( cd .. && $(GO) install github.com/go-bindata/go-bindata/...@latest )
 $(GOVVV):
-	GOINSECURE=* $(GO) install github.com/ahmetb/govvv
+	( cd .. && $(GO) install github.com/ahmetb/govvv@latest )
 $(GOLANGCI_LINT):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
 		sh -s -- -b $(GOBIN) v1.42.1

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -80,9 +80,9 @@ deps: goenv $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT) $(TRIVY)
 goenv:
 	( cd .. && $(GO) env )
 $(GO_BINDATA):
-	$(GO) install github.com/go-bindata/go-bindata/...
+	GOSUMDB=off $(GO) install github.com/go-bindata/go-bindata/...
 $(GOVVV):
-	$(GO) install github.com/ahmetb/govvv
+	GOSUMDB=off $(GO) install github.com/ahmetb/govvv
 $(GOLANGCI_LINT):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
 		sh -s -- -b $(GOBIN) v1.42.1

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -16,6 +16,7 @@ export GOCACHE := $(shell pwd)/.gocache
 # commented out the below since go 1.21.5 is broken
 export GOMODCACHE := $(shell pwd)/.gomod
 export GOFLAGS := -modcacherw
+export GOINSECURE := *
 
 BINDIR := ../bin/linux/$(ARCH)
 LIBDIR := ../lib/linux/$(ARCH)

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -77,10 +77,10 @@ clean:
 ## deps: install dependencies
 deps: $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT) $(TRIVY)
 $(GO_BINDATA):
-	$(GO) env
-	$(GO) version
+	$(GO) env 1>&2
+	$(GO) version 1>&2
 	$(GO) install github.com/go-bindata/go-bindata/...
-	$(GO) version
+	$(GO) version 1>&2
 $(GOVVV):
 	$(GO) install github.com/ahmetb/govvv
 $(GOLANGCI_LINT):

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -14,8 +14,8 @@ MIN_REQ_GO_MINOR_VERSION = 18
 export GOBIN := $(shell pwd)/.gobin/$(ARCH)
 export GOCACHE := $(shell pwd)/.gocache
 # commented out the below since go 1.21.5 is broken
-#export GOMODCACHE := $(shell pwd)/.gomod 
-#export GOFLAGS := -modcacherw
+export GOMODCACHE := $(shell pwd)/.gomod
+export GOFLAGS := -modcacherw
 
 BINDIR := ../bin/linux/$(ARCH)
 LIBDIR := ../lib/linux/$(ARCH)
@@ -77,6 +77,7 @@ clean:
 ## deps: install dependencies
 deps: $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT) $(TRIVY)
 $(GO_BINDATA):
+	chmod -f -R +w $(GOMODCACHE)/golang.org/toolchain*/* || true
 	$(GO) install github.com/go-bindata/go-bindata/...
 $(GOVVV):
 	$(GO) install github.com/ahmetb/govvv

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -78,7 +78,7 @@ clean:
 ## deps: install dependencies
 deps: goenv $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT) $(TRIVY)
 goenv:
-	$(GO) env
+	( cd .. && $(GO) env )
 $(GO_BINDATA):
 	$(GO) install github.com/go-bindata/go-bindata/...
 $(GOVVV):

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -13,8 +13,9 @@ MIN_REQ_GO_MINOR_VERSION = 18
 # cache downloaded modules and binaries locally
 export GOBIN := $(shell pwd)/.gobin/$(ARCH)
 export GOCACHE := $(shell pwd)/.gocache
-export GOMODCACHE := $(shell pwd)/.gomod
-export GOFLAGS := -modcacherw
+# commented out the below since go 1.21.5 is broken
+#export GOMODCACHE := $(shell pwd)/.gomod 
+#export GOFLAGS := -modcacherw
 
 BINDIR := ../bin/linux/$(ARCH)
 LIBDIR := ../lib/linux/$(ARCH)

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -77,7 +77,10 @@ clean:
 ## deps: install dependencies
 deps: $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT) $(TRIVY)
 $(GO_BINDATA):
+	$(GO) env
+	$(GO) version
 	$(GO) install github.com/go-bindata/go-bindata/...
+	$(GO) version
 $(GOVVV):
 	$(GO) install github.com/ahmetb/govvv
 $(GOLANGCI_LINT):

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -16,6 +16,7 @@ export GOCACHE := $(shell pwd)/.gocache
 # commented out the below since go 1.21.5 is broken
 export GOMODCACHE := $(shell pwd)/.gomod
 export GOFLAGS := -modcacherw
+export GONOSUMDB := *
 
 BINDIR := ../bin/linux/$(ARCH)
 LIBDIR := ../lib/linux/$(ARCH)
@@ -75,12 +76,11 @@ clean:
 	$(RM) -rf -- bpf/vmlinux.h
 
 ## deps: install dependencies
-deps: $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT) $(TRIVY)
+deps: goenv $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT) $(TRIVY)
+goenv:
+	$(GO) env
 $(GO_BINDATA):
-	$(GO) env 1>&2
-	$(GO) version 1>&2
 	$(GO) install github.com/go-bindata/go-bindata/...
-	$(GO) version 1>&2
 $(GOVVV):
 	$(GO) install github.com/ahmetb/govvv
 $(GOLANGCI_LINT):

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -16,7 +16,6 @@ export GOCACHE := $(shell pwd)/.gocache
 # commented out the below since go 1.21.5 is broken
 export GOMODCACHE := $(shell pwd)/.gomod
 export GOFLAGS := -modcacherw
-export GONOSUMDB := *
 
 BINDIR := ../bin/linux/$(ARCH)
 LIBDIR := ../lib/linux/$(ARCH)
@@ -80,9 +79,9 @@ deps: goenv $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT) $(TRIVY)
 goenv:
 	( cd .. && $(GO) env )
 $(GO_BINDATA):
-	GOSUMDB=off $(GO) install github.com/go-bindata/go-bindata/...
+	GOINSECURE=* $(GO) install github.com/go-bindata/go-bindata/...
 $(GOVVV):
-	GOSUMDB=off $(GO) install github.com/ahmetb/govvv
+	GOINSECURE=* $(GO) install github.com/ahmetb/govvv
 $(GOLANGCI_LINT):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
 		sh -s -- -b $(GOBIN) v1.42.1

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -77,7 +77,6 @@ clean:
 ## deps: install dependencies
 deps: $(GO_BINDATA) $(GOVVV) $(GOLANGCI_LINT) $(TRIVY)
 $(GO_BINDATA):
-	chmod -f -R +w $(GOMODCACHE)/golang.org/toolchain*/* || true
 	$(GO) install github.com/go-bindata/go-bindata/...
 $(GOVVV):
 	$(GO) install github.com/ahmetb/govvv
@@ -118,6 +117,7 @@ $(SCOPE): $(GOVVV) $(filter-out %_test.go,$(shell find . -type f -name '*.go'))
 		$(BUILD_OPTS) \
 		-o $(SCOPE)
 	$(RM) -r $(SCOPEDYN)
+	chmod -f -R +w $(GOMODCACHE)/golang.org/toolchain*/ || true
 
 ## test: run unit tests
 test:

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/criblio/scope
 
-go 1.21.4
+go 1.21.5
 
 replace github.com/olekukonko/tablewriter => github.com/cockroachdb/tablewriter v0.0.5-0.20200105123400-bd15540e8847
 

--- a/docker/builder/Dockerfile.ubuntu
+++ b/docker/builder/Dockerfile.ubuntu
@@ -38,11 +38,9 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ENV key=52B59B1571A79DBC054901C0F6BC817356A3D45E
 RUN apt-get update && \
     apt-get install -y software-properties-common gpg apt-utils libelf-dev && \
-    add-apt-repository -y ppa:longsleep/golang-backports && \
     apt-get update && \
 #    ( gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" || gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" ) && \
     apt-get install -y \
-        golang \
         autoconf \
         automake \
         curl \
@@ -60,6 +58,12 @@ RUN apt-get update && \
         && \
     dpkg-reconfigure --frontend noninteractive tzdata && \
     apt-get clean
+
+# Install Go
+RUN curl -LO https://go.dev/dl/go1.21.5.linux-amd64.tar.gz && \
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin
+RUN go version
 
 ARG UPX_VERSION=4.0.1
 ARG CMAKE_VERSION=3.24.3

--- a/docker/builder/Dockerfile.ubuntu
+++ b/docker/builder/Dockerfile.ubuntu
@@ -61,9 +61,9 @@ RUN apt-get update && \
 
 # Install Go
 RUN curl -LO https://go.dev/dl/go1.21.5.linux-amd64.tar.gz && \
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz
-ENV PATH=$PATH:/usr/local/go/bin
-RUN go version
+    rm -rf /usr/local/go && \
+    tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz
+ENV PATH="${PATH}:/usr/local/go/bin"
 
 ARG UPX_VERSION=4.0.1
 ARG CMAKE_VERSION=3.24.3

--- a/docker/builder/Dockerfile.ubuntu
+++ b/docker/builder/Dockerfile.ubuntu
@@ -63,7 +63,7 @@ RUN apt-get update && \
 RUN curl -LO https://go.dev/dl/go1.21.5.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && \
     tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz
-ENV PATH="${PATH}:/usr/local/go/bin"
+ENV PATH "$PATH:/usr/local/go/bin"
 
 ARG UPX_VERSION=4.0.1
 ARG CMAKE_VERSION=3.24.3

--- a/docker/builder/Dockerfile.ubuntu
+++ b/docker/builder/Dockerfile.ubuntu
@@ -61,8 +61,8 @@ RUN apt-get update && \
 
 # Install Go
 #RUN curl -LO https://go.dev/dl/go1.21.5.linux-amd64.tar.gz && \
-    rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz
+#    rm -rf /usr/local/go && \
+#    tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz
 #ENV PATH "$PATH:/usr/local/go/bin"
 
 ARG UPX_VERSION=4.0.1

--- a/docker/builder/Dockerfile.ubuntu
+++ b/docker/builder/Dockerfile.ubuntu
@@ -60,10 +60,10 @@ RUN apt-get update && \
     apt-get clean
 
 # Install Go
-RUN curl -LO https://go.dev/dl/go1.21.5.linux-amd64.tar.gz && \
+#RUN curl -LO https://go.dev/dl/go1.21.5.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && \
     tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz
-ENV PATH "$PATH:/usr/local/go/bin"
+#ENV PATH "$PATH:/usr/local/go/bin"
 
 ARG UPX_VERSION=4.0.1
 ARG CMAKE_VERSION=3.24.3


### PR DESCRIPTION
Note: I had to stop caching the go modules on build since there is a regression with build flags in Go 1.21.5 https://github.com/golang/go/issues/64282